### PR TITLE
Refactor double-pipe design into solver/optimizer with constraint handling and add ShellAndTube class/export

### DIFF
--- a/processpi/equipment/heatexchangers/__init__.py
+++ b/processpi/equipment/heatexchangers/__init__.py
@@ -1,7 +1,9 @@
 from .base import HeatExchanger
 from .mechanical import run_mechanical_design
+from .mechanical.shell_tube import ShellAndTubeHeatExchanger
 
 __all__ = [
     "HeatExchanger",
+    "ShellAndTubeHeatExchanger",
     "run_mechanical_design",
 ]

--- a/processpi/equipment/heatexchangers/mechanical/__init__.py
+++ b/processpi/equipment/heatexchangers/mechanical/__init__.py
@@ -1,8 +1,8 @@
 from typing import Dict, Any
 
 from .classification import HXClassification
-from .double_pipe import design_doublepipe
-from .shell_tube import design_shelltube
+from .double_pipe import design_doublepipe, HXSolver, HXOptimizer, DesignConstraints, AdaptiveHXOptimizer
+from .shell_tube import design_shelltube, ShellAndTubeHeatExchanger
 from .condenser import design_condenser
 from .reboiler import design_reboiler
 from .evaporator import design_evaporator

--- a/processpi/equipment/heatexchangers/mechanical/double_pipe.py
+++ b/processpi/equipment/heatexchangers/mechanical/double_pipe.py
@@ -15,6 +15,7 @@ Updated double-pipe heat exchanger design routine:
 
 import math
 from typing import Dict, Any, Optional, Tuple, List, Union
+from dataclasses import dataclass
 
 from processpi.calculations.heat_transfer.overall_u import OverallHeatTransferCoefficient
 from ....units import *
@@ -22,6 +23,8 @@ from ....streams.material import MaterialStream
 from ..base import HeatExchanger
 from ....pipelines import Pipe
 from ..standards import get_typical_k
+from ....pipelines.standards import get_recommended_velocity
+from ..standards import get_typical_U
 
 # ------------------------------------------------------------------
 # TUNABLE DEFAULTS
@@ -34,6 +37,318 @@ _DEFAULT_MAX_ITERS = 300
 _DEFAULT_TOL = 1e-5
 _DEFAULT_K_MINOR_TUBE = 2.5   # typical total K for bends + entrance/exit for hairpin
 _DEFAULT_K_MINOR_ANNULUS = 1.5
+_DEFAULT_DP_LIMIT = Pressure(2.0, "bar")
+_DEFAULT_VELOCITY_LIMIT = Velocity(3.0, "m/s")
+
+
+@dataclass
+class DesignConstraints:
+    """Constraint container and validator for HXOptimizer."""
+    pressure_drop_limit: Pressure = _DEFAULT_DP_LIMIT
+    default_velocity_limit: Velocity = _DEFAULT_VELOCITY_LIMIT
+    enforce_typical_u: bool = True
+    velocity_limit_factor: float = 1.0
+    u_max_factor: float = 1.0
+
+    def _fluid_name(self, stream: MaterialStream) -> str:
+        comp = getattr(stream, "component", None)
+        name = getattr(comp, "name", None) or comp.__class__.__name__ if comp is not None else "water"
+        return str(name).strip().lower().replace(" ", "_")
+
+    def _velocity_limit_for_stream(self, stream: MaterialStream) -> float:
+        service = self._fluid_name(stream)
+        recommended = get_recommended_velocity(service)
+        if isinstance(recommended, tuple):
+            return float(recommended[1]) * self.velocity_limit_factor
+        if isinstance(recommended, (int, float)):
+            return float(recommended) * self.velocity_limit_factor
+        return self.default_velocity_limit.to("m/s").value * self.velocity_limit_factor
+
+    def _u_range_for_hx(self, hx: HeatExchanger) -> Optional[Tuple[float, float]]:
+        if not self.enforce_typical_u:
+            return None
+        try:
+            hot = self._fluid_name(hx.hot_in).replace("_", "")
+            cold = self._fluid_name(hx.cold_in).replace("_", "")
+            u_min, u_max = get_typical_U(hot, cold)
+            return u_min.to("W/m2K").value, u_max.to("W/m2K").value * self.u_max_factor
+        except Exception:
+            return None
+
+    def validate(self, hx: HeatExchanger, result: Dict[str, Any]) -> Tuple[bool, List[str]]:
+        violations: List[str] = []
+        tube_stream = hx.hot_in if result["assignment"][0] == "hot_tube" else hx.cold_in
+        annulus_stream = hx.cold_in if result["assignment"][1] == "cold_annulus" else hx.hot_in
+
+        vmax_tube = self._velocity_limit_for_stream(tube_stream)
+        vmax_ann = self._velocity_limit_for_stream(annulus_stream)
+        v_tube = result["v_tube"].to("m/s").value
+        v_ann = result["v_annulus"].to("m/s").value
+        if v_tube > vmax_tube:
+            violations.append(f"tube velocity {v_tube:.3f} m/s > vmax {vmax_tube:.3f} m/s")
+        if v_ann > vmax_ann:
+            violations.append(f"annulus velocity {v_ann:.3f} m/s > vmax {vmax_ann:.3f} m/s")
+
+        dp_limit_pa = self.pressure_drop_limit.to("Pa").value
+        if result["dp_tube"].to("Pa").value > dp_limit_pa:
+            violations.append("tube pressure drop exceeds limit")
+        if result["dp_annulus"].to("Pa").value > dp_limit_pa:
+            violations.append("annulus pressure drop exceeds limit")
+
+        typical_u_range = self._u_range_for_hx(hx)
+        if typical_u_range is not None:
+            u_min, u_max = typical_u_range
+            u_calc = result["U_ref"].to("W/m2K").value
+            if not (u_min <= u_calc <= u_max):
+                violations.append(f"U={u_calc:.1f} W/m2K outside typical range ({u_min:.1f}, {u_max:.1f})")
+
+        return len(violations) == 0, violations
+
+
+class HXSolver:
+    """Physics-only solver for one double-pipe design candidate."""
+
+    def __init__(
+        self,
+        *,
+        wall_k: Union[float, ThermalConductivity] = _DEFAULT_WALL_K,
+        roughness: float = _DEFAULT_ROUGHNESS,
+        fouling_tube: float = _DEFAULT_FOULING_TUBE,
+        fouling_shell: float = _DEFAULT_FOULING_SHELL,
+        k_minor_tube: float = _DEFAULT_K_MINOR_TUBE,
+        k_minor_annulus: float = _DEFAULT_K_MINOR_ANNULUS,
+        max_iters: int = _DEFAULT_MAX_ITERS,
+        tol: float = _DEFAULT_TOL,
+    ) -> None:
+        self.wall_k = wall_k
+        self.roughness = roughness
+        self.fouling_tube = fouling_tube
+        self.fouling_shell = fouling_shell
+        self.k_minor_tube = k_minor_tube
+        self.k_minor_annulus = k_minor_annulus
+        self.max_iters = max_iters
+        self.tol = tol
+
+    def solve_candidate(
+        self,
+        hx: HeatExchanger,
+        *,
+        Di: float,
+        Do: float,
+        assignment: Tuple[str, str],
+        inner_mode: str,
+        passes: int,
+        annulus_parallel: int,
+        arrangement: str,
+        pass_layout: Optional[str],
+    ) -> Dict[str, Any]:
+        return _solve_double_pipe_candidate(
+            hx=hx,
+            Di=Di,
+            Do=Do,
+            assignment=assignment,
+            inner_mode=inner_mode,
+            passes=passes,
+            annulus_parallel=annulus_parallel,
+            arrangement=arrangement,
+            pass_layout=pass_layout,
+            wall_k=self.wall_k,
+            roughness=self.roughness,
+            fouling_tube=self.fouling_tube,
+            fouling_shell=self.fouling_shell,
+            k_minor_tube=self.k_minor_tube,
+            k_minor_annulus=self.k_minor_annulus,
+            max_iters=self.max_iters,
+            tol=self.tol,
+        )
+
+
+class HXOptimizer:
+    """Constraint-aware optimizer for double-pipe HX design."""
+
+    def __init__(self, solver: Optional[HXSolver] = None, constraints: Optional[DesignConstraints] = None):
+        self.solver = solver or HXSolver()
+        self.constraints = constraints or DesignConstraints()
+
+    def _score(self, result: Dict[str, Any]) -> float:
+        area = result["required_area"].to("m2").value
+        pumping_power = result["pumping_power"].to("W").value
+        return area + pumping_power
+
+    def optimize(
+        self,
+        hx: HeatExchanger,
+        *,
+        pipe_pairs: List[Tuple[float, float]],
+        inner_mode: str,
+        passes: int,
+        annulus_parallel: int,
+        arrangement: str,
+        pass_layout: Optional[str],
+    ) -> Dict[str, Any]:
+        assignments = [("hot_tube", "cold_annulus"), ("cold_tube", "hot_annulus")]
+        feasible_designs: List[Dict[str, Any]] = []
+
+        for Di, Do in pipe_pairs:
+            if Do <= Di * 1.05:
+                continue
+            for assignment in assignments:
+                result = self.solver.solve_candidate(
+                    hx=hx,
+                    Di=Di,
+                    Do=Do,
+                    assignment=assignment,
+                    inner_mode=inner_mode,
+                    passes=passes,
+                    annulus_parallel=annulus_parallel,
+                    arrangement=arrangement,
+                    pass_layout=pass_layout,
+                )
+                is_valid, violations = self.constraints.validate(hx, result)
+                result["constraint_violations"] = violations
+                result["is_valid"] = is_valid
+                if is_valid:
+                    result["objective_cost"] = Variable(self._score(result), "mixed_cost")
+                    feasible_designs.append(result)
+
+        if not feasible_designs:
+            raise RuntimeError("No feasible design found. All candidates violated constraints.")
+
+        best_result = min(feasible_designs, key=lambda item: item["objective_cost"].value)
+        hx.design_results = best_result
+        return best_result
+
+
+class AdaptiveHXOptimizer:
+    """
+    Adaptive wrapper around HXOptimizer.
+
+    If no feasible design is found, constraints are relaxed stepwise:
+    1) velocity limit (+20% each step, max 2x)
+    2) pressure-drop limit (+50% each step, max 5 bar)
+    3) typical U upper bound (+30% max)
+    """
+
+    def __init__(
+        self,
+        optimizer: Optional[HXOptimizer] = None,
+        *,
+        velocity_growth: float = 1.2,
+        velocity_max_factor: float = 2.0,
+        pressure_growth: float = 1.5,
+        pressure_max: Pressure = Pressure(5.0, "bar"),
+        u_max_factor_cap: float = 1.3,
+    ) -> None:
+        self.optimizer = optimizer or HXOptimizer()
+        self.velocity_growth = velocity_growth
+        self.velocity_max_factor = velocity_max_factor
+        self.pressure_growth = pressure_growth
+        self.pressure_max = pressure_max
+        self.u_max_factor_cap = u_max_factor_cap
+
+    def _make_constraints(
+        self,
+        base: DesignConstraints,
+        *,
+        velocity_factor: float,
+        pressure_limit: Pressure,
+        u_max_factor: float,
+    ) -> DesignConstraints:
+        return DesignConstraints(
+            pressure_drop_limit=pressure_limit,
+            default_velocity_limit=base.default_velocity_limit,
+            enforce_typical_u=base.enforce_typical_u,
+            velocity_limit_factor=velocity_factor,
+            u_max_factor=u_max_factor,
+        )
+
+    def _suggestions(self) -> List[str]:
+        return [
+            "Increase pipe diameter",
+            "Use multiple passes",
+            "Reduce heat duty",
+            "Use different fluid assignment (swap tube/annulus)",
+            "Consider different heat exchanger type",
+        ]
+
+    def optimize(
+        self,
+        hx: HeatExchanger,
+        *,
+        pipe_pairs: List[Tuple[float, float]],
+        inner_mode: str,
+        passes: int,
+        annulus_parallel: int,
+        arrangement: str,
+        pass_layout: Optional[str],
+    ) -> Dict[str, Any]:
+        base = self.optimizer.constraints
+        velocity_factor = 1.0
+        pressure_limit = base.pressure_drop_limit
+        u_max_factor = 1.0
+        relaxation_steps = 0
+        history: List[Dict[str, Any]] = [{
+            "step": 0,
+            "velocity_factor": Dimensionless(velocity_factor),
+            "pressure_drop_limit": pressure_limit,
+            "u_max_factor": Dimensionless(u_max_factor),
+        }]
+        design = None
+
+        while True:
+            self.optimizer.constraints = self._make_constraints(
+                base,
+                velocity_factor=velocity_factor,
+                pressure_limit=pressure_limit,
+                u_max_factor=u_max_factor,
+            )
+            try:
+                design = self.optimizer.optimize(
+                    hx,
+                    pipe_pairs=pipe_pairs,
+                    inner_mode=inner_mode,
+                    passes=passes,
+                    annulus_parallel=annulus_parallel,
+                    arrangement=arrangement,
+                    pass_layout=pass_layout,
+                )
+                break
+            except RuntimeError:
+                can_relax_velocity = velocity_factor < self.velocity_max_factor
+                can_relax_pressure = pressure_limit.to("bar").value < self.pressure_max.to("bar").value
+                can_relax_u = u_max_factor < self.u_max_factor_cap
+                if not (can_relax_velocity or can_relax_pressure or can_relax_u):
+                    break
+
+                if can_relax_velocity:
+                    velocity_factor = min(self.velocity_max_factor, velocity_factor * self.velocity_growth)
+                elif can_relax_pressure:
+                    new_bar = min(self.pressure_max.to("bar").value, pressure_limit.to("bar").value * self.pressure_growth)
+                    pressure_limit = Pressure(new_bar, "bar")
+                elif can_relax_u:
+                    u_max_factor = self.u_max_factor_cap
+
+                relaxation_steps += 1
+                history.append({
+                    "step": relaxation_steps,
+                    "velocity_factor": Dimensionless(velocity_factor),
+                    "pressure_drop_limit": pressure_limit,
+                    "u_max_factor": Dimensionless(u_max_factor),
+                })
+
+        constraints_used = {
+            "original": history[0],
+            "relaxed": history[-1],
+            "history": history,
+        }
+        is_feasible = design is not None
+        return {
+            "design": design,
+            "is_feasible": is_feasible,
+            "relaxation_steps": relaxation_steps,
+            "constraints_used": constraints_used,
+            "suggestions": [] if is_feasible else self._suggestions(),
+        }
 
 # ------------------------------------------------------------------
 # Utilities: must match your units API (adapt if needed)
@@ -282,41 +597,9 @@ def design_doublepipe(
     """
     parms = _get_parms(hx)
 
-    # Extract required simulated params (must exist)
-    #print("Extracting parameters...")
-    Th_in = _val(parms.get("Hot in Temp"), "Hot In Temp")
-    Th_out = _val(parms.get("Hot out Temp"), "Hot Out Temp")
-    Tc_in = _val(parms.get("Cold in Temp"), "Cold In Temp")
-    Tc_out = _val(parms.get("Cold out Temp"), "Cold Out Temp")
-    m_hot = _val(parms.get("m_hot"), "m_hot")          # kg/s
-    m_cold = _val(parms.get("m_cold"), "m_cold")      # kg/s
-    cp_hot = _val(parms.get("cP_hot"), "cP_hot") * 1000      # converting kJ/kgK to J/kg-K
-    cp_cold = _val(parms.get("cP_cold"), "cP_cold") * 1000      # converting kJ/kgK to J/kg-K   # J/kg-K
-    delta_Tlm_param = parms.get("delta_Tlm")  # optional; keep unit-wrapped
-    #print("Parameters extracted.")
-
-    # energy
-    Q_hot = m_hot * cp_hot * (Th_in - Th_out)
-    Q_cold = m_cold * cp_cold * (Tc_out - Tc_in)
-    # Prefer the average of two when both exist to avoid sign issues
-    #print("Calculating heat duty...")
-    if abs(Q_hot) > 0 and abs(Q_cold) > 0:
-        Q = 0.5 * (Q_hot + Q_cold)
-    else:
-        Q = Q_hot if abs(Q_hot) > 0 else Q_cold
-
-    # convert options
-    #print("Converting options...")
     if inner_pipe is not None:
-        wall_k_val = get_typical_k(inner_pipe.material)
-    else:
-        wall_k_val = wall_k.value if hasattr(wall_k, "value") else float(wall_k)
-    dp_limit = None
-    if target_dp is not None:
-        try:
-            dp_limit = target_dp.to("Pa").value
-        except Exception:
-            dp_limit = target_dp.value if hasattr(target_dp, "value") else float(target_dp)
+        typical_k = get_typical_k(inner_pipe.material)
+        wall_k = typical_k[0] if isinstance(typical_k, tuple) else typical_k
 
     # pipe library fallback (inner ID, outer OD) pairs in meters
     #print("Selecting pipe library...")
@@ -349,285 +632,207 @@ def design_doublepipe(
     if innerpipe_dia is not None and outerpipe_dia is not None:
         pipe_pairs = [(innerpipe_dia.to("m").value, outerpipe_dia.to("m").value)]
 
-    # assignments to try
-    #print("Setting up assignments...")
-    assignments = [
-        ("hot_tube", "cold_annulus"),
-        ("cold_tube", "hot_annulus"),
-    ]
-
-    best_result = None
-    best_score = float("inf")
-    #print("Starting design iterations...")
-    for (Di, Do) in pipe_pairs:
-        if Do <= Di * 1.05:
-            continue
-        #print(f"Trying pipe pair: Inner Diameter = {Di} m, Outer Diameter = {Do} m")
-
-        for assignment in assignments:
-            # map streams
-            if assignment[0] == "hot_tube":
-                tube_stream = hx.hot_in
-                ann_stream = hx.cold_in
-                m_tube = m_hot; m_ann = m_cold
-                cp_tube_nom = cp_hot; cp_ann_nom = cp_cold
-            else:
-                tube_stream = hx.cold_in
-                ann_stream = hx.hot_in
-                m_tube = m_cold; m_ann = m_hot
-                cp_tube_nom = cp_cold; cp_ann_nom = cp_hot
-
-            # per-channel flows depend on inner_mode but mass flow remains constant across passes
-            if inner_mode == "parallel":
-                n_inner_channels = passes
-            else:
-                n_inner_channels = 1
-
-            m_tube_channel = m_tube / n_inner_channels
-            n_ann_channels = annulus_parallel
-            m_ann_channel = m_ann / n_ann_channels
-
-            # initial guesses
-            L_total = 2.0  # m
-            U_ref = 200.0
-            converged = False
-            iteration = 0
-            #print("Starting iterations...")
-            for iteration in range(max_iters):
-                # per-pass length
-                if inner_mode == "series":
-                    L_per_pass = L_total / max(passes, 1)
-                else:
-                    L_per_pass = L_total
-
-                # film temperatures (simple mean of inlet/outlet for each side depending assignment)
-                if assignment[0] == "hot_tube":
-                    T_tube_bulk = 0.5 * ((_val(parms.get("Hot in Temp"), "Hot In")) + (_val(parms.get("Hot out Temp"), "Hot Out")))
-                    T_ann_bulk = 0.5 * ((_val(parms.get("Cold in Temp"), "Cold In")) + (_val(parms.get("Cold out Temp"), "Cold Out")))
-                else:
-                    T_tube_bulk = 0.5 * ((_val(parms.get("Cold in Temp"), "Cold In")) + (_val(parms.get("Cold out Temp"), "Cold Out")))
-                    T_ann_bulk = 0.5 * ((_val(parms.get("Hot in Temp"), "Hot In")) + (_val(parms.get("Hot out Temp"), "Hot Out")))
-
-                # fetch fluid properties from stream components at film temps; fall back to cp_nom if missing
-                try:
-                    mu_t = tube_stream.component.viscosity(T_tube_bulk).to("Pa.s").value
-                    rho_t = tube_stream.component.density(T_tube_bulk).to("kg/m3").value
-                    k_t = tube_stream.component.thermal_conductivity(T_tube_bulk).to("W/mK").value
-                    cp_t = tube_stream.component.specific_heat(T_tube_bulk).to("J/kgK").value
-                except Exception:
-                    # fallback assumptions (less ideal)
-                    mu_t = 1e-3
-                    rho_t = 1000.0
-                    k_t = 0.12
-                    cp_t = cp_tube_nom
-
-                try:
-                    mu_a = ann_stream.component.viscosity(T_ann_bulk).to("Pa.s").value
-                    rho_a = ann_stream.component.density(T_ann_bulk).to("kg/m3").value
-                    k_a = ann_stream.component.thermal_conductivity(T_ann_bulk).to("W/mK").value
-                    cp_a = ann_stream.component.specific_heat(T_ann_bulk).to("J/kgK").value
-                except Exception:
-                    mu_a = 1e-3
-                    rho_a = 1000.0
-                    k_a = 0.12
-                    cp_a = cp_ann_nom
-
-                # Cross-sectional areas (single inner tube and single annulus)
-                A_tube_single = math.pi * (Di ** 2) / 4.0
-                A_annulus_single = math.pi * (Do ** 2 - Di ** 2) / 4.0
-
-                # velocities (per channel)
-                v_tube = m_tube_channel / (rho_t * A_tube_single)
-                v_ann = m_ann_channel / (rho_a * A_annulus_single)
-
-                # Reynolds and Prandtl
-                Re_t = rho_t * v_tube * Di / max(mu_t, 1e-12)
-                Re_a = rho_a * v_ann * max((Do - Di), 1e-6) / max(mu_a, 1e-12)  # Dh ≈ Do - Di
-                Pr_t = _prandtl(cp_t, mu_t, k_t)
-                Pr_a = _prandtl(cp_a, mu_a, k_a)
-
-                # friction factors
-                eps_rel_t = roughness / Di
-                eps_rel_a = roughness / max((Do - Di), Di * 1e-6)
-                f_t = _colebrook_f(max(Re_t, 1e-6), eps_rel_t)
-                f_a = _colebrook_f(max(Re_a, 1e-6), eps_rel_a)
-
-                # Nusselt numbers
-                Nu_t = _nusselt_gnielinski(max(Re_t, 1e-6), max(Pr_t, 1e-6), f_t)
-                Nu_a = _nusselt_annulus(max(Re_a, 1e-6), max(Pr_a, 1e-6), Do, Di, f_a)
-
-                # film coefficients
-                h_t = Nu_t * k_t / Di
-                h_a = Nu_a * k_a / max((Do - Di), Di * 1e-6)
-
-                # ------------------------------------------------------------------
-                # Step 10: Clean Uc (area refs to inner area)
-                # Resistances referenced to inner-surface area (m2 K/W)
-                R_conv_i = 1.0 / max(h_t, 1e-12)
-                # wall resistance per inner-area reference: (Di * ln(Do/Di)) / (2 * k_wall)
-                R_wall = (Di * math.log(Do / Di)) / (2.0 * wall_k_val)
-                R_conv_o = (Di / Do) * (1.0 / max(h_a, 1e-12))
-                R_foul_i = fouling_tube
-                R_foul_o = fouling_shell * (Di / Do)
-                R_total_area = R_conv_i + R_wall + R_conv_o + R_foul_i + R_foul_o
-                U_new = 1.0 / max(R_total_area, 1e-12)  # W/m2K (inner area reference)
-                # ------------------------------------------------------------------
-
-                # --------------------------
-                # NTU -> epsilon -> Ft block
-                # --------------------------
-                Ch = m_tube * cp_t
-                Cc = m_ann * cp_a
-                Cmin = min(Ch, Cc)
-                Cmax = max(Ch, Cc)
-                C_ratio = (Cmin / Cmax) if Cmax > 0 else 0.0
-
-                # compute total inner area available for heat transfer:
-                # as requested => effective area = inner_perimeter * L_per_pass * passes * n_inner_channels
-                # Note: the user's choice was **mass flow constant** and **effective area × passes** in NTU.
-                inner_perimeter = math.pi * Di
-                effective_inner_area = inner_perimeter * L_per_pass * passes * n_inner_channels
-
-                UA = U_new * effective_inner_area
-                NTU_raw = UA / Cmin if Cmin > 0 else 0.0
-
-                ntu_scale = _ntuscaling_for_passes(inner_mode, passes)
-                NTU_effective = NTU_raw * ntu_scale
-
-                eps = _epsilon_from_arrangement(arrangement, NTU_effective, C_ratio)
-
-                # delta_T_lm
-                dT1 = Th_in - Tc_out
-                dT2 = Th_out - Tc_in
-                if dT1 * dT2 <= 0:
-                    delta_T_lm = max(abs(dT1), abs(dT2), 1e-6)
-                else:
-                    delta_T_lm = (dT1 - dT2) / math.log(dT1 / dT2)
-
-                # compute Ft either from chart or NTU-derived
-                Ft = 1.0
-                if pass_layout and pass_layout in _CHART_FT_MAP:
-                    Ft = _CHART_FT_MAP[pass_layout](NTU_raw, C_ratio)
-                else:
-                    if NTU_raw <= 1e-12 or delta_T_lm == 0:
-                        Ft = 1.0
-                    else:
-                        Ft_calc = (eps * (Th_in - Tc_in)) / (NTU_raw * delta_T_lm)
-                        Ft = max(1e-6, min(1.0, Ft_calc))
-
-                # required total inner area (based on current U_new and Ft)
-                denom = U_new * delta_T_lm * Ft
-                if denom <= 0:
-                    A_required = float("inf")
-                else:
-                    A_required = abs(Q) / denom
-
-                L_required = A_required / (math.pi * Di * passes * n_inner_channels)  # distribute area over passes & channels
-
-                # damping for stable convergence
-                U_ref = 0.6 * U_new + 0.4 * U_ref
-                L_total_new = 0.6 * L_required + 0.4 * L_total
-
-                # stopping criteria: relative change in L and U
-                if abs(L_total_new - L_total) / max(1e-9, L_total_new) < tol and abs(U_new - U_ref) / max(1e-9, U_ref) < tol:
-                    L_total = L_total_new
-                    U_ref = U_new
-                    converged = True
-                    break
-
-                L_total = L_total_new
-                U_ref = U_new
-                #print(f"Iteration {iteration+1}: L_total = {L_total}, U_ref = {U_ref}")
-            # end iterative loop
-            #print("Design iterations completed.")
-            # Final recomputation after converge/exit for dp calculations
-            #print("Recomputing pressure drops and final parameters...")
-            if inner_mode == "parallel":
-                n_inner_channels = passes
-            else:
-                n_inner_channels = 1
-            m_tube_channel = m_tube / n_inner_channels
-            m_ann_channel = m_ann / n_ann_channels
-
-            A_tube_single = math.pi * (Di ** 2) / 4.0
-            A_annulus_single = math.pi * (Do ** 2 - Di ** 2) / 4.0
-
-            v_tube = m_tube_channel / (rho_t * A_tube_single)
-            v_ann = m_ann_channel / (rho_a * A_annulus_single)
-
-            Re_t_final = rho_t * v_tube * Di / max(mu_t, 1e-12)
-            Re_a_final = rho_a * v_ann * max((Do - Di), 1e-6) / max(mu_a, 1e-12)
-
-            f_t_final = _colebrook_f(max(Re_t_final, 1e-6), roughness / Di)
-            f_a_final = _colebrook_f(max(Re_a_final, 1e-6), roughness / max((Do - Di), 1e-6))
-
-            dp_tube_fric = _deltaP_darcy(f_t_final, L_per_pass, Di, rho_t, v_tube)
-            dp_tube_system = dp_tube_fric * (passes if inner_mode == "series" else 1)
-            dp_tube_minor = k_minor_tube * 0.5 * rho_t * v_tube * v_tube
-            dp_tube_total = dp_tube_system + dp_tube_minor
-
-            dp_ann_fric = _deltaP_darcy(f_a_final, L_per_pass, (Do - Di), rho_a, v_ann)
-            dp_ann_system = dp_ann_fric  # annulus typically single pass length
-            dp_ann_minor = k_minor_annulus * 0.5 * rho_a * v_ann * v_ann
-            dp_ann_total = dp_ann_system + dp_ann_minor
-
-            total_dp = dp_tube_total + dp_ann_total
-
-            penalty = 0.0
-            if dp_limit is not None:
-                if dp_tube_total > dp_limit or dp_ann_total > dp_limit:
-                    penalty = 1e6 + (dp_tube_total + dp_ann_total - dp_limit)
-
-            # scoring metric: minimize total length + dp penalty
-            score = L_total + penalty
-
-            # hairpin counting if requested (hairpin_length provided)
-            hairpin_info = {}
-            if hairpin_length and hairpin_pipe_inner_id and hairpin_pipe_outer_od:
-                # area per hairpin (single hairpin has inner_perimeter * length * passes_per_hairpin)
-                # hairpin is typically one U-turn: treat each hairpin as a single inner tube of length hairpin_length
-                hairpin_area_per = math.pi * hairpin_pipe_inner_id * hairpin_length
-                hairpins_required = math.ceil((A_required) / hairpin_area_per) if A_required != float("inf") else None
-                hairpin_info = {
-                    "hairpin_length_m": hairpin_length,
-                    "hairpin_area_m2": hairpin_area_per,
-                    "hairpins_required": hairpins_required
-                }
-
-            result = {
-                "innerpipe_dia": Diameter(Di,"m"),
-                "outerpipe_dia": Diameter(Do,"m"), 
-                "assignment": assignment,
-                "inner_mode": inner_mode,
-                "passes": passes,
-                "annulus_parallel": annulus_parallel,
-                "total_length": Length(L_total,"m"),
-                "length_per_pass": Length(L_per_pass,"m"),
-                "U_ref": HeatTransferCoefficient(U_ref,"W/m2K"),
-                "U_max": HeatTransferCoefficient(U_new,"W/m2K"),
-                "Ft": Ft,
-                "required_area": Area(A_required,"m2"),
-                "effective_area": Area(effective_inner_area,"m2"),
-                "Q": HeatFlow(Q,"W"),
-                "Re_tube": Dimensionless(Re_t_final),
-                "Re_annulus": Dimensionless(Re_a_final),
-                "Nu_tube": Dimensionless(Nu_t),
-                "Nu_annulus": Dimensionless(Nu_a),
-                "dp_tube": Pressure(dp_tube_total,"Pa"),
-                "dp_annulus": Pressure(dp_ann_total,"Pa"),
-                "total_dp": Pressure(total_dp,"Pa"),
-                "converged": converged,
-                "iterations": iteration + 1,
-                "hairpin_info": hairpin_info,
-            }
-
-            if score < best_score:
-                best_score = score
-                best_result = result
-
-    if best_result is None:
-        raise RuntimeError("No feasible design found with given options / pipe library.")
-
-    # attach design to hx for downstream use
-    hx.design_results = best_result
+    solver = HXSolver(
+        wall_k=wall_k,
+        roughness=roughness,
+        fouling_tube=fouling_tube,
+        fouling_shell=fouling_shell,
+        k_minor_tube=k_minor_tube,
+        k_minor_annulus=k_minor_annulus,
+        max_iters=max_iters,
+        tol=tol,
+    )
+    constraints = DesignConstraints(pressure_drop_limit=target_dp or _DEFAULT_DP_LIMIT)
+    optimizer = HXOptimizer(solver=solver, constraints=constraints)
+    try:
+        best_result = optimizer.optimize(
+            hx,
+            pipe_pairs=pipe_pairs,
+            inner_mode=inner_mode,
+            passes=passes,
+            annulus_parallel=annulus_parallel,
+            arrangement=arrangement,
+            pass_layout=pass_layout,
+        )
+    except RuntimeError:
+        adaptive = AdaptiveHXOptimizer(optimizer=optimizer)
+        adaptive_result = adaptive.optimize(
+            hx,
+            pipe_pairs=pipe_pairs,
+            inner_mode=inner_mode,
+            passes=passes,
+            annulus_parallel=annulus_parallel,
+            arrangement=arrangement,
+            pass_layout=pass_layout,
+        )
+        if not adaptive_result["is_feasible"]:
+            return adaptive_result
+        best_result = adaptive_result["design"]
+    if hairpin_length and hairpin_pipe_inner_id and hairpin_pipe_outer_od:
+        area_required = best_result["required_area"].to("m2").value
+        hairpin_area_per = math.pi * hairpin_pipe_inner_id * hairpin_length
+        best_result["hairpin_info"] = {
+            "hairpin_length_m": hairpin_length,
+            "hairpin_area_m2": hairpin_area_per,
+            "hairpins_required": math.ceil(area_required / hairpin_area_per),
+        }
+    else:
+        best_result["hairpin_info"] = {}
     return best_result
+
+
+def _solve_double_pipe_candidate(
+    hx: HeatExchanger,
+    *,
+    Di: float,
+    Do: float,
+    assignment: Tuple[str, str],
+    inner_mode: str,
+    passes: int,
+    annulus_parallel: int,
+    arrangement: str,
+    pass_layout: Optional[str],
+    wall_k: Union[float, ThermalConductivity],
+    roughness: float,
+    fouling_tube: float,
+    fouling_shell: float,
+    k_minor_tube: float,
+    k_minor_annulus: float,
+    max_iters: int,
+    tol: float,
+) -> Dict[str, Any]:
+    parms = _get_parms(hx)
+    Th_in = _val(parms.get("Hot in Temp"), "Hot In Temp")
+    Th_out = _val(parms.get("Hot out Temp"), "Hot Out Temp")
+    Tc_in = _val(parms.get("Cold in Temp"), "Cold In Temp")
+    Tc_out = _val(parms.get("Cold out Temp"), "Cold Out Temp")
+    m_hot = _val(parms.get("m_hot"), "m_hot")
+    m_cold = _val(parms.get("m_cold"), "m_cold")
+    cp_hot = _val(parms.get("cP_hot"), "cP_hot") * 1000
+    cp_cold = _val(parms.get("cP_cold"), "cP_cold") * 1000
+    Q_hot = m_hot * cp_hot * (Th_in - Th_out)
+    Q_cold = m_cold * cp_cold * (Tc_out - Tc_in)
+    Q = 0.5 * (Q_hot + Q_cold) if abs(Q_hot) > 0 and abs(Q_cold) > 0 else (Q_hot if abs(Q_hot) > 0 else Q_cold)
+    wall_k_val = wall_k.value if hasattr(wall_k, "value") else float(wall_k)
+
+    if assignment[0] == "hot_tube":
+        tube_stream, ann_stream = hx.hot_in, hx.cold_in
+        m_tube, m_ann = m_hot, m_cold
+        cp_tube_nom, cp_ann_nom = cp_hot, cp_cold
+    else:
+        tube_stream, ann_stream = hx.cold_in, hx.hot_in
+        m_tube, m_ann = m_cold, m_hot
+        cp_tube_nom, cp_ann_nom = cp_cold, cp_hot
+
+    n_inner_channels = passes if inner_mode == "parallel" else 1
+    n_ann_channels = annulus_parallel
+    m_tube_channel = m_tube / n_inner_channels
+    m_ann_channel = m_ann / n_ann_channels
+    L_total = 2.0
+    U_ref = 200.0
+    converged = False
+
+    for iteration in range(max_iters):
+        L_per_pass = L_total / max(passes, 1) if inner_mode == "series" else L_total
+        if assignment[0] == "hot_tube":
+            T_tube_bulk = 0.5 * (_val(parms.get("Hot in Temp"), "Hot In") + _val(parms.get("Hot out Temp"), "Hot Out"))
+            T_ann_bulk = 0.5 * (_val(parms.get("Cold in Temp"), "Cold In") + _val(parms.get("Cold out Temp"), "Cold Out"))
+        else:
+            T_tube_bulk = 0.5 * (_val(parms.get("Cold in Temp"), "Cold In") + _val(parms.get("Cold out Temp"), "Cold Out"))
+            T_ann_bulk = 0.5 * (_val(parms.get("Hot in Temp"), "Hot In") + _val(parms.get("Hot out Temp"), "Hot Out"))
+
+        try:
+            mu_t = tube_stream.component.viscosity(T_tube_bulk).to("Pa.s").value
+            rho_t = tube_stream.component.density(T_tube_bulk).to("kg/m3").value
+            k_t = tube_stream.component.thermal_conductivity(T_tube_bulk).to("W/mK").value
+            cp_t = tube_stream.component.specific_heat(T_tube_bulk).to("J/kgK").value
+        except Exception:
+            mu_t, rho_t, k_t, cp_t = 1e-3, 1000.0, 0.12, cp_tube_nom
+
+        try:
+            mu_a = ann_stream.component.viscosity(T_ann_bulk).to("Pa.s").value
+            rho_a = ann_stream.component.density(T_ann_bulk).to("kg/m3").value
+            k_a = ann_stream.component.thermal_conductivity(T_ann_bulk).to("W/mK").value
+            cp_a = ann_stream.component.specific_heat(T_ann_bulk).to("J/kgK").value
+        except Exception:
+            mu_a, rho_a, k_a, cp_a = 1e-3, 1000.0, 0.12, cp_ann_nom
+
+        A_tube_single = math.pi * (Di ** 2) / 4.0
+        A_annulus_single = math.pi * (Do ** 2 - Di ** 2) / 4.0
+        v_tube = m_tube_channel / (rho_t * A_tube_single)
+        v_ann = m_ann_channel / (rho_a * A_annulus_single)
+        Re_t = rho_t * v_tube * Di / max(mu_t, 1e-12)
+        Re_a = rho_a * v_ann * max((Do - Di), 1e-6) / max(mu_a, 1e-12)
+        Pr_t = _prandtl(cp_t, mu_t, k_t)
+        Pr_a = _prandtl(cp_a, mu_a, k_a)
+        f_t = _colebrook_f(max(Re_t, 1e-6), roughness / Di)
+        f_a = _colebrook_f(max(Re_a, 1e-6), roughness / max((Do - Di), Di * 1e-6))
+        Nu_t = _nusselt_gnielinski(max(Re_t, 1e-6), max(Pr_t, 1e-6), f_t)
+        Nu_a = _nusselt_annulus(max(Re_a, 1e-6), max(Pr_a, 1e-6), Do, Di, f_a)
+        h_t = Nu_t * k_t / Di
+        h_a = Nu_a * k_a / max((Do - Di), Di * 1e-6)
+
+        R_total_area = (1.0 / max(h_t, 1e-12)) + ((Di * math.log(Do / Di)) / (2.0 * wall_k_val)) + ((Di / Do) * (1.0 / max(h_a, 1e-12))) + fouling_tube + (fouling_shell * (Di / Do))
+        U_new = 1.0 / max(R_total_area, 1e-12)
+        Cmin = min(m_tube * cp_t, m_ann * cp_a)
+        Cmax = max(m_tube * cp_t, m_ann * cp_a)
+        C_ratio = (Cmin / Cmax) if Cmax > 0 else 0.0
+        effective_inner_area = math.pi * Di * L_per_pass * passes * n_inner_channels
+        NTU_raw = (U_new * effective_inner_area / Cmin) if Cmin > 0 else 0.0
+        NTU_effective = NTU_raw * _ntuscaling_for_passes(inner_mode, passes)
+        eps = _epsilon_from_arrangement(arrangement, NTU_effective, C_ratio)
+        dT1 = Th_in - Tc_out
+        dT2 = Th_out - Tc_in
+        delta_T_lm = max(abs(dT1), abs(dT2), 1e-6) if dT1 * dT2 <= 0 else (dT1 - dT2) / math.log(dT1 / dT2)
+        if pass_layout and pass_layout in _CHART_FT_MAP:
+            Ft = _CHART_FT_MAP[pass_layout](NTU_raw, C_ratio)
+        else:
+            Ft = 1.0 if (NTU_raw <= 1e-12 or delta_T_lm == 0) else max(1e-6, min(1.0, (eps * (Th_in - Tc_in)) / (NTU_raw * delta_T_lm)))
+        denom = U_new * delta_T_lm * Ft
+        A_required = float("inf") if denom <= 0 else abs(Q) / denom
+        L_required = A_required / (math.pi * Di * passes * n_inner_channels)
+        U_ref = 0.6 * U_new + 0.4 * U_ref
+        L_total_new = 0.6 * L_required + 0.4 * L_total
+        if abs(L_total_new - L_total) / max(1e-9, L_total_new) < tol and abs(U_new - U_ref) / max(1e-9, U_ref) < tol:
+            L_total = L_total_new
+            U_ref = U_new
+            converged = True
+            break
+        L_total = L_total_new
+        U_ref = U_new
+
+    L_per_pass = L_total / max(passes, 1) if inner_mode == "series" else L_total
+    Re_t_final = rho_t * v_tube * Di / max(mu_t, 1e-12)
+    Re_a_final = rho_a * v_ann * max((Do - Di), 1e-6) / max(mu_a, 1e-12)
+    dp_tube_total = (_deltaP_darcy(_colebrook_f(max(Re_t_final, 1e-6), roughness / Di), L_per_pass, Di, rho_t, v_tube) * (passes if inner_mode == "series" else 1)) + (k_minor_tube * 0.5 * rho_t * v_tube * v_tube)
+    dp_ann_total = _deltaP_darcy(_colebrook_f(max(Re_a_final, 1e-6), roughness / max((Do - Di), 1e-6)), L_per_pass, (Do - Di), rho_a, v_ann) + (k_minor_annulus * 0.5 * rho_a * v_ann * v_ann)
+    total_dp = dp_tube_total + dp_ann_total
+    pumping_power_w = (dp_tube_total * (m_tube / max(rho_t, 1e-12))) + (dp_ann_total * (m_ann / max(rho_a, 1e-12)))
+    return {
+        "innerpipe_dia": Diameter(Di, "m"),
+        "outerpipe_dia": Diameter(Do, "m"),
+        "assignment": assignment,
+        "inner_mode": inner_mode,
+        "passes": passes,
+        "annulus_parallel": annulus_parallel,
+        "total_length": Length(L_total, "m"),
+        "length_per_pass": Length(L_per_pass, "m"),
+        "U_ref": HeatTransferCoefficient(U_ref, "W/m2K"),
+        "U_max": HeatTransferCoefficient(U_new, "W/m2K"),
+        "Ft": Ft,
+        "required_area": Area(A_required, "m2"),
+        "effective_area": Area(effective_inner_area, "m2"),
+        "Q": HeatFlow(Q, "W"),
+        "Re_tube": Dimensionless(Re_t_final),
+        "Re_annulus": Dimensionless(Re_a_final),
+        "Nu_tube": Dimensionless(Nu_t),
+        "Nu_annulus": Dimensionless(Nu_a),
+        "v_tube": Velocity(v_tube, "m/s"),
+        "v_annulus": Velocity(v_ann, "m/s"),
+        "dp_tube": Pressure(dp_tube_total, "Pa"),
+        "dp_annulus": Pressure(dp_ann_total, "Pa"),
+        "total_dp": Pressure(total_dp, "Pa"),
+        "pumping_power": Power(pumping_power_w, "W"),
+        "converged": converged,
+        "iterations": iteration + 1,
+    }

--- a/processpi/equipment/heatexchangers/mechanical/shell_tube.py
+++ b/processpi/equipment/heatexchangers/mechanical/shell_tube.py
@@ -51,6 +51,75 @@ _HEADER_KS = {
     "exit": 1.0
 }
 
+
+class ShellAndTubeHeatExchanger(HeatExchanger):
+    """
+    Class-based shell-and-tube exchanger aligned with flowsheet-style named ports.
+    """
+
+    def __init__(self, name: str = "ShellAndTubeHeatExchanger", **kwargs):
+        super().__init__(name=name, **kwargs)
+        self.inlets = {"hot_in": None, "cold_in": None}
+        self.outlets = {"hot_out": None, "cold_out": None}
+        self.results: Dict[str, Any] = {}
+        self._design_kwargs: Dict[str, Any] = {}
+
+    @property
+    def hot_in(self) -> Optional[MaterialStream]:
+        return self.inlets["hot_in"]
+
+    @hot_in.setter
+    def hot_in(self, stream: MaterialStream):
+        self.inlets["hot_in"] = stream
+
+    @property
+    def cold_in(self) -> Optional[MaterialStream]:
+        return self.inlets["cold_in"]
+
+    @cold_in.setter
+    def cold_in(self, stream: MaterialStream):
+        self.inlets["cold_in"] = stream
+
+    @property
+    def hot_out(self) -> Optional[MaterialStream]:
+        return self.outlets["hot_out"]
+
+    @hot_out.setter
+    def hot_out(self, stream: MaterialStream):
+        self.outlets["hot_out"] = stream
+
+    @property
+    def cold_out(self) -> Optional[MaterialStream]:
+        return self.outlets["cold_out"]
+
+    @cold_out.setter
+    def cold_out(self, stream: MaterialStream):
+        self.outlets["cold_out"] = stream
+
+    def connect_inlet(self, port: str, stream: MaterialStream) -> None:
+        if port not in self.inlets:
+            raise ValueError(f"Invalid inlet port '{port}'. Expected one of: {list(self.inlets.keys())}")
+        self.inlets[port] = stream
+
+    def connect_outlet(self, port: str, stream: MaterialStream) -> None:
+        if port not in self.outlets:
+            raise ValueError(f"Invalid outlet port '{port}'. Expected one of: {list(self.outlets.keys())}")
+        self.outlets[port] = stream
+
+    def _design_shelltube(self, **kwargs) -> Dict[str, Any]:
+        return _design_shelltube_impl(self, **kwargs)
+
+    def simulate(self, **kwargs) -> Dict[str, Any]:
+        hot_stream = self.inlets["hot_in"]
+        cold_stream = self.inlets["cold_in"]
+        if hot_stream is None or cold_stream is None:
+            raise ValueError("Both 'hot_in' and 'cold_in' must be connected before simulate().")
+        if kwargs:
+            self._design_kwargs.update(kwargs)
+        self.results = self._design_shelltube(**self._design_kwargs)
+        self.design_results = self.results
+        return self.results
+
 # -------------------------------------------------------------------------
 # Small utilities
 # -------------------------------------------------------------------------
@@ -376,7 +445,7 @@ def _epsilon_from_arrangement(arr: str, NTU: float, C: float) -> float:
 # -------------------------------------------------------------------------
 # Top-level design function using Bell-Delaware, packing, header design, mechanical summary
 # -------------------------------------------------------------------------
-def design_shelltube(
+def _design_shelltube_impl(
     hx: HeatExchanger,
     *,
     tube_nominal: Optional[Diameter] = None,
@@ -684,3 +753,16 @@ def design_shelltube(
 
     hx.design_results = best
     return best
+
+
+def design_shelltube(
+    hx: HeatExchanger,
+    **kwargs
+) -> Dict[str, Any]:
+    """
+    Backward-compatible functional API.
+    Delegates to class method when available.
+    """
+    if hasattr(hx, "_design_shelltube"):
+        return hx._design_shelltube(**kwargs)
+    return _design_shelltube_impl(hx, **kwargs)


### PR DESCRIPTION
### Motivation

- Make the double-pipe design engine modular and constraint-aware so candidate designs can be scored and validated against engineering limits.
- Provide adaptive constraint relaxation to recover feasible designs when strict constraints block all candidates.
- Add a flowsheet-friendly `ShellAndTubeHeatExchanger` class to simplify connection/simulation in code that uses named ports.
- Export the new class and reusable optimizer types from the package API for downstream usage.

### Description

- Introduced `DesignConstraints`, `HXSolver`, `HXOptimizer`, and `AdaptiveHXOptimizer` to `double_pipe.py` to separate physics solve from search/constraint logic and to support adaptive relaxation of constraints.
- Refactored the old `design_doublepipe` implementation to use the new solver/optimizer pipeline and added `_solve_double_pipe_candidate` as the physics-only candidate evaluator; the public `design_doublepipe` now delegates to the optimizer and adaptive wrapper when needed.
- Added velocity, pumping power, constraint validation, and objective scoring into double-pipe results, and preserved hairpin counting support while moving post-processing to the optimizer path.
- Added `ShellAndTubeHeatExchanger` class in `shell_tube.py` with named inlet/outlet ports, `connect_*` helpers, `simulate()` and an internal `_design_shelltube` method, and provided a backward-compatible `design_shelltube` functional wrapper that delegates to either the instance method or the original implementation.
- Updated package exports by adding `ShellAndTubeHeatExchanger` to `processpi.equipment.heatexchangers.__init__` and re-exporting optimizer types in `mechanical.__init__`.

### Testing

- Ran the heat exchanger unit tests with `pytest tests/equipment/heatexchangers` (existing test suite covering double-pipe and shell-and-tube behavior) and observed all tests passed.
- Executed the package integration smoke tests for mechanical design dispatch via `run_mechanical_design` and confirmed successful delegation to the updated implementations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d769de3b348326b2042ffde9ab1ac3)