### PR TITLE
Refactor heat exchanger mechanical modules: unified ShellAndTube, double-pipe optimizer, and compatibility wrappers

### DIFF
--- a/processpi/equipment/heatexchangers/__init__.py
+++ b/processpi/equipment/heatexchangers/__init__.py
@@ -1,7 +1,19 @@
 from .base import HeatExchanger
 from .mechanical import run_mechanical_design
+from .mechanical.shell_tube import ShellAndTube, ShellAndTubeHeatExchanger
+from .mechanical.condenser import Condenser, CondenserHeatExchanger
+from .mechanical.evaporator import Evaporator, EvaporatorHeatExchanger
+from .mechanical.reboiler import Reboiler, ReboilerHeatExchanger
 
 __all__ = [
     "HeatExchanger",
+    "ShellAndTube",
+    "ShellAndTubeHeatExchanger",
+    "Condenser",
+    "CondenserHeatExchanger",
+    "Evaporator",
+    "EvaporatorHeatExchanger",
+    "Reboiler",
+    "ReboilerHeatExchanger",
     "run_mechanical_design",
 ]

--- a/processpi/equipment/heatexchangers/mechanical/__init__.py
+++ b/processpi/equipment/heatexchangers/mechanical/__init__.py
@@ -1,11 +1,11 @@
 from typing import Dict, Any
 
 from .classification import HXClassification
-from .double_pipe import design_doublepipe
-from .shell_tube import design_shelltube
-from .condenser import design_condenser
-from .reboiler import design_reboiler
-from .evaporator import design_evaporator
+from .double_pipe import design_doublepipe, HXSolver, HXOptimizer, DesignConstraints, AdaptiveHXOptimizer
+from .shell_tube import design_shelltube, ShellAndTube, ShellAndTubeHeatExchanger
+from .condenser import design_condenser, Condenser, CondenserHeatExchanger
+from .reboiler import design_reboiler, Reboiler, ReboilerHeatExchanger
+from .evaporator import design_evaporator, Evaporator, EvaporatorHeatExchanger
 
 
 _design_type_map = {

--- a/processpi/equipment/heatexchangers/mechanical/condenser.py
+++ b/processpi/equipment/heatexchangers/mechanical/condenser.py
@@ -1,262 +1,36 @@
 """
-processpi/equipment/heatexchangers/condenser.py
+Deprecated compatibility module.
 
-Improved Condenser design module — made consistent with other ProcessPI
-heat exchanger modules (evaporator, shell_tube, double_pipe).
-
-Key changes vs. the raw snippet provided:
-- Single `hx: HeatExchanger` input (with hot_in / cold_in streams) for API
-  consistency with other modules.
-- Robust unit/property extraction via `_safe_prop_get()`.
-- Zone-wise iterative U <-> A convergence with damping and numeric guards.
-- Optional `tube_side_hot` flag to control which stream is treated as tube-side.
-- Conservative fallbacks for missing fluid property methods (latent heat, cp, etc.).
-
-This file expects your existing helper modules and preserves calls to
-`bell_delaware_pressure_drop()` and `check_flooding()` from `.bell_method`.
+Condenser behavior is now handled by unified ShellAndTube(mode="condenser").
 """
 
 from typing import Dict, Any
-import math
 
-from ....streams.material import MaterialStream
 from ..base import HeatExchanger
-from .kern_method import lmtd, overall_U, tube_htc, shell_htc, required_area, heat_duty
-from .bell_method import bell_delaware_pressure_drop, check_flooding
-
-# defaults
-DEFAULT_FOUL_HOT = 1e-4
-DEFAULT_FOUL_COLD = 2e-4
-DEFAULT_TUBE_K = 16.0
-GRAVITY = 9.81
+from .shell_tube import ShellAndTube
 
 
-def _safe_prop_get(component, fn_name: str, *args, fallback=None):
-    """Call a component property function safely and return numeric value or fallback."""
-    try:
-        fn = getattr(component, fn_name)
-        val = fn(*args)
-        # Extract numeric value from pint-like wrappers if possible
-        if hasattr(val, "to"):
-            try:
-                return float(val.value)
-            except Exception:
-                try:
-                    return float(val.to("K").value)
-                except Exception:
-                    return fallback
-        if isinstance(val, (int, float)):
-            return float(val)
-        return fallback
-    except Exception:
-        return fallback
+class Condenser(ShellAndTube):
+    def __init__(self, name: str = "Condenser", **kwargs):
+        super().__init__(name=name, mode="condenser", **kwargs)
 
 
-def design_condenser(
-    hx: HeatExchanger,
-    *,
-    orientation: str = "horizontal",
-    passes: int = 1,
-    Ft: float = 1.0,
-    fouling_hot: float = DEFAULT_FOUL_HOT,
-    fouling_cold: float = DEFAULT_FOUL_COLD,
-    layout: str = "triangular",
-    tube_OD: float = 0.0254,
-    tube_pitch_factor: float = 1.25,
-    tube_side_hot: bool = False,  # default: condenser tube-side commonly used for coolant (cold) -> set False
-    max_zone_iter: int = 30,
-    tol: float = 1e-3,
-    **kwargs
-) -> Dict[str, Any]:
-    """
-    Condenser design wrapper expecting hx (HeatExchanger) with `hot_in` and
-    `cold_in` MaterialStream attributes. Performs zone-wise design for:
-      - superheat (if any)
-      - condensation (latent)
-      - subcooling (if any)
+# Backward-compatible alias from previous refactor cycle.
+CondenserHeatExchanger = Condenser
 
-    Returns detailed sizing, U-values, LMTDs, dp estimates and a flooding flag.
-    """
-    if not isinstance(hx, HeatExchanger):
-        raise TypeError("hx must be a HeatExchanger instance")
 
-    hot = hx.hot_in
-    cold = hx.cold_in
-
-    # Extract temperatures (try Kelvin) with fallbacks
-    try:
-        T_hot_in = float(hot.temperature.to("K").value)
-    except Exception:
-        T_hot_in = float(getattr(hot, "temperature", getattr(hot, "T", 350.0)))
-    try:
-        T_cold_in = float(cold.temperature.to("K").value)
-    except Exception:
-        T_cold_in = float(getattr(cold, "temperature", getattr(cold, "T", 300.0)))
-
-    # saturation temperature for hot (condensing) stream
-    T_sat = _safe_prop_get(hot.component, "saturation_temperature", fallback=None) or _safe_prop_get(hot.component, "dew_point", fallback=None)
-    if T_sat is None:
-        T_sat = T_hot_in
-
-    # mass flows and cp
-    try:
-        m_hot = float(hot.mass_flowrate.to("kg/s").value)
-    except Exception:
-        m_hot = float(getattr(hot, "mass_flowrate", getattr(hot, "m_dot", 1.0)))
-    try:
-        m_cold = float(cold.mass_flowrate.to("kg/s").value)
-    except Exception:
-        m_cold = float(getattr(cold, "mass_flowrate", getattr(cold, "m_dot", 1.0)))
-
-    try:
-        cp_hot = float(hot.cp.to("J/kg-K").value)
-    except Exception:
-        cp_hot = _safe_prop_get(hot.component, "specific_heat", fallback=2000.0)
-    try:
-        cp_cold = float(cold.cp.to("J/kg-K").value)
-    except Exception:
-        cp_cold = _safe_prop_get(cold.component, "specific_heat", fallback=4200.0)
-
-    # Zones: superheat (hot above sat), condensation (latent), subcool (cold side)
-    deltaT_super = max(T_hot_in - T_sat, 0.0)
-    deltaT_subcool = max(T_sat - T_cold_in, 0.0)
-
-    duty_super = 0.0
-    if deltaT_super > 0:
-        duty_super = heat_duty(m_hot, cp_hot, T_hot_in, T_hot_in - deltaT_super)
-
-    h_fg = _safe_prop_get(hot.component, "latent_heat", fallback=None) or _safe_prop_get(hot.component, "latent_heat_of_vaporization", fallback=None)
-    if h_fg is None:
-        h_fg = 2.257e6
-    duty_cond = m_hot * float(h_fg)
-
-    duty_sub = 0.0
-    if deltaT_subcool > 0:
-        duty_sub = heat_duty(m_cold, cp_cold, T_cold_in, T_cold_in + deltaT_subcool)
-
-    Q_total = duty_super + duty_cond + duty_sub
-
-    # Which side is tube vs shell
-    if tube_side_hot:
-        tube_stream = hot
-        shell_stream = cold
-        m_tube_total = m_hot
-        m_shell_total = m_cold
-        cp_tube = cp_hot
-        cp_shell = cp_cold
-    else:
-        tube_stream = cold
-        shell_stream = hot
-        m_tube_total = m_cold
-        m_shell_total = m_hot
-        cp_tube = cp_cold
-        cp_shell = cp_hot
-
-    # helper: iterative zone convergence (U <-> A)
-    def zone_iter(duty: float, T_hot_start: float, T_hot_end: float, T_cold_start: float, T_cold_end: float, U_guess: float = 500.0):
-        U = max(1.0, U_guess)
-        lmtd_val = lmtd(T_hot_start, T_hot_end, T_cold_start, T_cold_end, Ft)
-        A_req = float('inf')
-        for _ in range(max_zone_iter):
-            if lmtd_val == 0 or U <= 0:
-                A_req = float('inf')
-                break
-            A_req = required_area(duty, U, lmtd_val)
-            # estimate representative geometry
-            L_guess = max(1.0, A_req / (math.pi * tube_OD * 10.0))
-            tube_count_est = max(1, int(math.ceil(A_req / (math.pi * tube_OD * L_guess))))
-
-            # film temps
-            T_f_tube = 0.5 * (T_hot_start + T_hot_end)
-            T_f_shell = 0.5 * (T_cold_start + T_cold_end)
-
-            mu_t = _safe_prop_get(tube_stream.component, "viscosity", T_f_tube, fallback=1e-3)
-            rho_t = _safe_prop_get(tube_stream.component, "density", T_f_tube, fallback=1000.0)
-            k_t = _safe_prop_get(tube_stream.component, "thermal_conductivity", T_f_tube, fallback=0.13)
-            cp_t_loc = _safe_prop_get(tube_stream.component, "specific_heat", T_f_tube, fallback=cp_tube)
-
-            mu_s = _safe_prop_get(shell_stream.component, "viscosity", T_f_shell, fallback=1e-3)
-            rho_s = _safe_prop_get(shell_stream.component, "density", T_f_shell, fallback=1000.0)
-            k_s = _safe_prop_get(shell_stream.component, "thermal_conductivity", T_f_shell, fallback=0.13)
-            cp_s_loc = _safe_prop_get(shell_stream.component, "specific_heat", T_f_shell, fallback=cp_shell)
-
-            # tube-side HTC
-            A_tube_flow = math.pi * ((tube_OD - 2e-3) ** 2) / 4.0
-            v_tube = (m_tube_total / max(1, tube_count_est)) / max(rho_t * A_tube_flow, 1e-12)
-            Re_t = rho_t * v_tube * max(tube_OD - 2e-3, 1e-6) / max(mu_t, 1e-12)
-            Pr_t = (cp_t_loc * mu_t / max(k_t, 1e-12)) if k_t>0 else 1.0
-            try:
-                h_t = tube_htc(k_t, (tube_OD - 2e-3), Re_t, Pr_t)
-            except Exception:
-                h_t = 200.0
-
-            # shell-side HTC (condensing surface) — use bell_method helper or fallback
-            try:
-                h_s = shell_htc(rho_s, mu_s, k_s, cp_s_loc, m_shell_total, Ds=0.5, pitch=tube_pitch_factor*tube_OD)
-            except Exception:
-                # conservative fallback for condensation
-                h_s = 1000.0 if duty_cond>0 else 150.0
-
-            U_new = overall_U(h_t, h_s, fouling_hot, fouling_cold, R_wall=0.001)
-            if abs(U_new - U) / max(1e-12, U) < tol:
-                U = U_new
-                break
-            U = 0.6 * U_new + 0.4 * U
-        return max(A_req, 0.0), U, lmtd_val
-
-    # Run zones
-    A_super = U_super = LMTD_super = 0.0
-    A_cond = U_cond = LMTD_cond = 0.0
-    A_sub = U_sub = LMTD_sub = 0.0
-
-    if duty_super > 0:
-        A_super, U_super, LMTD_super = zone_iter(duty_super, T_hot_in, T_sat, T_cold_in, T_cold_in + duty_super/(m_cold*cp_cold) if m_cold*cp_cold>0 else T_cold_in)
-
-    A_cond, U_cond, LMTD_cond = zone_iter(duty_cond, T_sat, T_sat, T_cold_in + duty_super/(m_cold*cp_cold) if m_cold*cp_cold>0 else T_cold_in, T_cold_in + (duty_super + duty_cond)/(m_cold*cp_cold) if m_cold*cp_cold>0 else T_cold_in)
-
-    if duty_sub > 0:
-        A_sub, U_sub, LMTD_sub = zone_iter(duty_sub, T_sat, T_sat - deltaT_subcool, T_cold_in + (duty_super + duty_cond)/(m_cold*cp_cold) if m_cold*cp_cold>0 else T_cold_in, T_cold_in + Q_total/(m_cold*cp_cold) if m_cold*cp_cold>0 else T_cold_in)
-
-    A_total = A_super + A_cond + A_sub
-
-    # bundle/tube sizing heuristics
-    pitch = tube_pitch_factor * tube_OD
-    pitch_ratio = 0.866 if layout == "triangular" else 1.0
-    bundle_diam = math.sqrt(A_total / (math.pi * tube_OD * max(1.0, passes))) if A_total>0 else 0.0
-    N_tubes = max(1, int(pitch_ratio * (bundle_diam / pitch)**2))
-    tube_length = A_total / (math.pi * tube_OD * N_tubes) if N_tubes>0 else 0.0
-    shell_ID = bundle_diam * 1.1 if bundle_diam>0 else max(0.2, tube_OD*12)
-
-    # shell-side dp and flooding
-    try:
-        rho_s_for_dp = _safe_prop_get(hot.component, "density", T_hot_in, fallback=1000.0)
-        mu_s_for_dp = _safe_prop_get(hot.component, "viscosity", T_hot_in, fallback=1e-3)
-        deltaP_shell = bell_delaware_pressure_drop(rho_s_for_dp, mu_s_for_dp, m_hot, shell_ID, tube_OD)
-    except Exception:
-        deltaP_shell = 0.0
-
-    flooded = False
-    try:
-        flooded = check_flooding(hot, math.pi*(tube_OD**2)/4.0, vertical=(orientation=="vertical"))
-    except Exception:
-        flooded = False
-
-    result = {
-        "Duty_W": Q_total,
-        "Overall_U_W_m2K": (U_super + U_cond + U_sub) / max(1, sum([1 if x>0 else 0 for x in (U_super, U_cond, U_sub)])),
-        "Area_super_m2": A_super,
-        "Area_cond_m2": A_cond,
-        "Area_sub_m2": A_sub,
-        "A_total_m2": A_total,
-        "N_tubes": N_tubes,
-        "tube_length_m": tube_length,
-        "bundle_diameter_m": bundle_diam,
-        "shell_ID_m": shell_ID,
-        "deltaP_shell_Pa": deltaP_shell,
-        "flooding_risk": flooded,
-        "LMTD_zones_K": {"superheat": LMTD_super, "condensation": LMTD_cond, "subcool": LMTD_sub},
-        "U_zones_W_m2K": {"superheat": U_super, "condensation": U_cond, "subcool": U_sub}
-    }
-
+def design_condenser(hx: HeatExchanger, **kwargs) -> Dict[str, Any]:
+    """Backward-compatible design entrypoint for condenser mode."""
+    if isinstance(hx, ShellAndTube):
+        hx.mode = "condenser"
+        return hx._design_shelltube(**kwargs)
+    # Transitional path for generic HeatExchanger instances
+    tmp = Condenser(name=getattr(hx, "name", "Condenser"))
+    tmp.inlets["hot_in"] = getattr(hx, "hot_in", None)
+    tmp.inlets["cold_in"] = getattr(hx, "cold_in", None)
+    tmp.outlets["hot_out"] = getattr(hx, "hot_out", None)
+    tmp.outlets["cold_out"] = getattr(hx, "cold_out", None)
+    tmp._collect_base_data()
+    result = tmp._design_shelltube(**kwargs)
     hx.design_results = result
     return result

--- a/processpi/equipment/heatexchangers/mechanical/double_pipe.py
+++ b/processpi/equipment/heatexchangers/mechanical/double_pipe.py
@@ -15,6 +15,7 @@ Updated double-pipe heat exchanger design routine:
 
 import math
 from typing import Dict, Any, Optional, Tuple, List, Union
+from dataclasses import dataclass
 
 from processpi.calculations.heat_transfer.overall_u import OverallHeatTransferCoefficient
 from ....units import *
@@ -22,6 +23,8 @@ from ....streams.material import MaterialStream
 from ..base import HeatExchanger
 from ....pipelines import Pipe
 from ..standards import get_typical_k
+from ....pipelines.standards import get_recommended_velocity
+from ..standards import get_typical_U
 
 # ------------------------------------------------------------------
 # TUNABLE DEFAULTS
@@ -34,6 +37,318 @@ _DEFAULT_MAX_ITERS = 300
 _DEFAULT_TOL = 1e-5
 _DEFAULT_K_MINOR_TUBE = 2.5   # typical total K for bends + entrance/exit for hairpin
 _DEFAULT_K_MINOR_ANNULUS = 1.5
+_DEFAULT_DP_LIMIT = Pressure(2.0, "bar")
+_DEFAULT_VELOCITY_LIMIT = Velocity(3.0, "m/s")
+
+
+@dataclass
+class DesignConstraints:
+    """Constraint container and validator for HXOptimizer."""
+    pressure_drop_limit: Pressure = _DEFAULT_DP_LIMIT
+    default_velocity_limit: Velocity = _DEFAULT_VELOCITY_LIMIT
+    enforce_typical_u: bool = True
+    velocity_limit_factor: float = 1.0
+    u_max_factor: float = 1.0
+
+    def _fluid_name(self, stream: MaterialStream) -> str:
+        comp = getattr(stream, "component", None)
+        name = getattr(comp, "name", None) or comp.__class__.__name__ if comp is not None else "water"
+        return str(name).strip().lower().replace(" ", "_")
+
+    def _velocity_limit_for_stream(self, stream: MaterialStream) -> float:
+        service = self._fluid_name(stream)
+        recommended = get_recommended_velocity(service)
+        if isinstance(recommended, tuple):
+            return float(recommended[1]) * self.velocity_limit_factor
+        if isinstance(recommended, (int, float)):
+            return float(recommended) * self.velocity_limit_factor
+        return self.default_velocity_limit.to("m/s").value * self.velocity_limit_factor
+
+    def _u_range_for_hx(self, hx: HeatExchanger) -> Optional[Tuple[float, float]]:
+        if not self.enforce_typical_u:
+            return None
+        try:
+            hot = self._fluid_name(hx.hot_in).replace("_", "")
+            cold = self._fluid_name(hx.cold_in).replace("_", "")
+            u_min, u_max = get_typical_U(hot, cold)
+            return u_min.to("W/m2K").value, u_max.to("W/m2K").value * self.u_max_factor
+        except Exception:
+            return None
+
+    def validate(self, hx: HeatExchanger, result: Dict[str, Any]) -> Tuple[bool, List[str]]:
+        violations: List[str] = []
+        tube_stream = hx.hot_in if result["assignment"][0] == "hot_tube" else hx.cold_in
+        annulus_stream = hx.cold_in if result["assignment"][1] == "cold_annulus" else hx.hot_in
+
+        vmax_tube = self._velocity_limit_for_stream(tube_stream)
+        vmax_ann = self._velocity_limit_for_stream(annulus_stream)
+        v_tube = result["v_tube"].to("m/s").value
+        v_ann = result["v_annulus"].to("m/s").value
+        if v_tube > vmax_tube:
+            violations.append(f"tube velocity {v_tube:.3f} m/s > vmax {vmax_tube:.3f} m/s")
+        if v_ann > vmax_ann:
+            violations.append(f"annulus velocity {v_ann:.3f} m/s > vmax {vmax_ann:.3f} m/s")
+
+        dp_limit_pa = self.pressure_drop_limit.to("Pa").value
+        if result["dp_tube"].to("Pa").value > dp_limit_pa:
+            violations.append("tube pressure drop exceeds limit")
+        if result["dp_annulus"].to("Pa").value > dp_limit_pa:
+            violations.append("annulus pressure drop exceeds limit")
+
+        typical_u_range = self._u_range_for_hx(hx)
+        if typical_u_range is not None:
+            u_min, u_max = typical_u_range
+            u_calc = result["U_ref"].to("W/m2K").value
+            if not (u_min <= u_calc <= u_max):
+                violations.append(f"U={u_calc:.1f} W/m2K outside typical range ({u_min:.1f}, {u_max:.1f})")
+
+        return len(violations) == 0, violations
+
+
+class HXSolver:
+    """Physics-only solver for one double-pipe design candidate."""
+
+    def __init__(
+        self,
+        *,
+        wall_k: Union[float, ThermalConductivity] = _DEFAULT_WALL_K,
+        roughness: float = _DEFAULT_ROUGHNESS,
+        fouling_tube: float = _DEFAULT_FOULING_TUBE,
+        fouling_shell: float = _DEFAULT_FOULING_SHELL,
+        k_minor_tube: float = _DEFAULT_K_MINOR_TUBE,
+        k_minor_annulus: float = _DEFAULT_K_MINOR_ANNULUS,
+        max_iters: int = _DEFAULT_MAX_ITERS,
+        tol: float = _DEFAULT_TOL,
+    ) -> None:
+        self.wall_k = wall_k
+        self.roughness = roughness
+        self.fouling_tube = fouling_tube
+        self.fouling_shell = fouling_shell
+        self.k_minor_tube = k_minor_tube
+        self.k_minor_annulus = k_minor_annulus
+        self.max_iters = max_iters
+        self.tol = tol
+
+    def solve_candidate(
+        self,
+        hx: HeatExchanger,
+        *,
+        Di: float,
+        Do: float,
+        assignment: Tuple[str, str],
+        inner_mode: str,
+        passes: int,
+        annulus_parallel: int,
+        arrangement: str,
+        pass_layout: Optional[str],
+    ) -> Dict[str, Any]:
+        return _solve_double_pipe_candidate(
+            hx=hx,
+            Di=Di,
+            Do=Do,
+            assignment=assignment,
+            inner_mode=inner_mode,
+            passes=passes,
+            annulus_parallel=annulus_parallel,
+            arrangement=arrangement,
+            pass_layout=pass_layout,
+            wall_k=self.wall_k,
+            roughness=self.roughness,
+            fouling_tube=self.fouling_tube,
+            fouling_shell=self.fouling_shell,
+            k_minor_tube=self.k_minor_tube,
+            k_minor_annulus=self.k_minor_annulus,
+            max_iters=self.max_iters,
+            tol=self.tol,
+        )
+
+
+class HXOptimizer:
+    """Constraint-aware optimizer for double-pipe HX design."""
+
+    def __init__(self, solver: Optional[HXSolver] = None, constraints: Optional[DesignConstraints] = None):
+        self.solver = solver or HXSolver()
+        self.constraints = constraints or DesignConstraints()
+
+    def _score(self, result: Dict[str, Any]) -> float:
+        area = result["required_area"].to("m2").value
+        pumping_power = result["pumping_power"].to("W").value
+        return area + pumping_power
+
+    def optimize(
+        self,
+        hx: HeatExchanger,
+        *,
+        pipe_pairs: List[Tuple[float, float]],
+        inner_mode: str,
+        passes: int,
+        annulus_parallel: int,
+        arrangement: str,
+        pass_layout: Optional[str],
+    ) -> Dict[str, Any]:
+        assignments = [("hot_tube", "cold_annulus"), ("cold_tube", "hot_annulus")]
+        feasible_designs: List[Dict[str, Any]] = []
+
+        for Di, Do in pipe_pairs:
+            if Do <= Di * 1.05:
+                continue
+            for assignment in assignments:
+                result = self.solver.solve_candidate(
+                    hx=hx,
+                    Di=Di,
+                    Do=Do,
+                    assignment=assignment,
+                    inner_mode=inner_mode,
+                    passes=passes,
+                    annulus_parallel=annulus_parallel,
+                    arrangement=arrangement,
+                    pass_layout=pass_layout,
+                )
+                is_valid, violations = self.constraints.validate(hx, result)
+                result["constraint_violations"] = violations
+                result["is_valid"] = is_valid
+                if is_valid:
+                    result["objective_cost"] = Variable(self._score(result), "mixed_cost")
+                    feasible_designs.append(result)
+
+        if not feasible_designs:
+            raise RuntimeError("No feasible design found. All candidates violated constraints.")
+
+        best_result = min(feasible_designs, key=lambda item: item["objective_cost"].value)
+        hx.design_results = best_result
+        return best_result
+
+
+class AdaptiveHXOptimizer:
+    """
+    Adaptive wrapper around HXOptimizer.
+
+    If no feasible design is found, constraints are relaxed stepwise:
+    1) velocity limit (+20% each step, max 2x)
+    2) pressure-drop limit (+50% each step, max 5 bar)
+    3) typical U upper bound (+30% max)
+    """
+
+    def __init__(
+        self,
+        optimizer: Optional[HXOptimizer] = None,
+        *,
+        velocity_growth: float = 1.2,
+        velocity_max_factor: float = 2.0,
+        pressure_growth: float = 1.5,
+        pressure_max: Pressure = Pressure(5.0, "bar"),
+        u_max_factor_cap: float = 1.3,
+    ) -> None:
+        self.optimizer = optimizer or HXOptimizer()
+        self.velocity_growth = velocity_growth
+        self.velocity_max_factor = velocity_max_factor
+        self.pressure_growth = pressure_growth
+        self.pressure_max = pressure_max
+        self.u_max_factor_cap = u_max_factor_cap
+
+    def _make_constraints(
+        self,
+        base: DesignConstraints,
+        *,
+        velocity_factor: float,
+        pressure_limit: Pressure,
+        u_max_factor: float,
+    ) -> DesignConstraints:
+        return DesignConstraints(
+            pressure_drop_limit=pressure_limit,
+            default_velocity_limit=base.default_velocity_limit,
+            enforce_typical_u=base.enforce_typical_u,
+            velocity_limit_factor=velocity_factor,
+            u_max_factor=u_max_factor,
+        )
+
+    def _suggestions(self) -> List[str]:
+        return [
+            "Increase pipe diameter",
+            "Use multiple passes",
+            "Reduce heat duty",
+            "Use different fluid assignment (swap tube/annulus)",
+            "Consider different heat exchanger type",
+        ]
+
+    def optimize(
+        self,
+        hx: HeatExchanger,
+        *,
+        pipe_pairs: List[Tuple[float, float]],
+        inner_mode: str,
+        passes: int,
+        annulus_parallel: int,
+        arrangement: str,
+        pass_layout: Optional[str],
+    ) -> Dict[str, Any]:
+        base = self.optimizer.constraints
+        velocity_factor = 1.0
+        pressure_limit = base.pressure_drop_limit
+        u_max_factor = 1.0
+        relaxation_steps = 0
+        history: List[Dict[str, Any]] = [{
+            "step": 0,
+            "velocity_factor": Dimensionless(velocity_factor),
+            "pressure_drop_limit": pressure_limit,
+            "u_max_factor": Dimensionless(u_max_factor),
+        }]
+        design = None
+
+        while True:
+            self.optimizer.constraints = self._make_constraints(
+                base,
+                velocity_factor=velocity_factor,
+                pressure_limit=pressure_limit,
+                u_max_factor=u_max_factor,
+            )
+            try:
+                design = self.optimizer.optimize(
+                    hx,
+                    pipe_pairs=pipe_pairs,
+                    inner_mode=inner_mode,
+                    passes=passes,
+                    annulus_parallel=annulus_parallel,
+                    arrangement=arrangement,
+                    pass_layout=pass_layout,
+                )
+                break
+            except RuntimeError:
+                can_relax_velocity = velocity_factor < self.velocity_max_factor
+                can_relax_pressure = pressure_limit.to("bar").value < self.pressure_max.to("bar").value
+                can_relax_u = u_max_factor < self.u_max_factor_cap
+                if not (can_relax_velocity or can_relax_pressure or can_relax_u):
+                    break
+
+                if can_relax_velocity:
+                    velocity_factor = min(self.velocity_max_factor, velocity_factor * self.velocity_growth)
+                elif can_relax_pressure:
+                    new_bar = min(self.pressure_max.to("bar").value, pressure_limit.to("bar").value * self.pressure_growth)
+                    pressure_limit = Pressure(new_bar, "bar")
+                elif can_relax_u:
+                    u_max_factor = self.u_max_factor_cap
+
+                relaxation_steps += 1
+                history.append({
+                    "step": relaxation_steps,
+                    "velocity_factor": Dimensionless(velocity_factor),
+                    "pressure_drop_limit": pressure_limit,
+                    "u_max_factor": Dimensionless(u_max_factor),
+                })
+
+        constraints_used = {
+            "original": history[0],
+            "relaxed": history[-1],
+            "history": history,
+        }
+        is_feasible = design is not None
+        return {
+            "design": design,
+            "is_feasible": is_feasible,
+            "relaxation_steps": relaxation_steps,
+            "constraints_used": constraints_used,
+            "suggestions": [] if is_feasible else self._suggestions(),
+        }
 
 # ------------------------------------------------------------------
 # Utilities: must match your units API (adapt if needed)
@@ -282,41 +597,9 @@ def design_doublepipe(
     """
     parms = _get_parms(hx)
 
-    # Extract required simulated params (must exist)
-    #print("Extracting parameters...")
-    Th_in = _val(parms.get("Hot in Temp"), "Hot In Temp")
-    Th_out = _val(parms.get("Hot out Temp"), "Hot Out Temp")
-    Tc_in = _val(parms.get("Cold in Temp"), "Cold In Temp")
-    Tc_out = _val(parms.get("Cold out Temp"), "Cold Out Temp")
-    m_hot = _val(parms.get("m_hot"), "m_hot")          # kg/s
-    m_cold = _val(parms.get("m_cold"), "m_cold")      # kg/s
-    cp_hot = _val(parms.get("cP_hot"), "cP_hot") * 1000      # converting kJ/kgK to J/kg-K
-    cp_cold = _val(parms.get("cP_cold"), "cP_cold") * 1000      # converting kJ/kgK to J/kg-K   # J/kg-K
-    delta_Tlm_param = parms.get("delta_Tlm")  # optional; keep unit-wrapped
-    #print("Parameters extracted.")
-
-    # energy
-    Q_hot = m_hot * cp_hot * (Th_in - Th_out)
-    Q_cold = m_cold * cp_cold * (Tc_out - Tc_in)
-    # Prefer the average of two when both exist to avoid sign issues
-    #print("Calculating heat duty...")
-    if abs(Q_hot) > 0 and abs(Q_cold) > 0:
-        Q = 0.5 * (Q_hot + Q_cold)
-    else:
-        Q = Q_hot if abs(Q_hot) > 0 else Q_cold
-
-    # convert options
-    #print("Converting options...")
     if inner_pipe is not None:
-        wall_k_val = get_typical_k(inner_pipe.material)
-    else:
-        wall_k_val = wall_k.value if hasattr(wall_k, "value") else float(wall_k)
-    dp_limit = None
-    if target_dp is not None:
-        try:
-            dp_limit = target_dp.to("Pa").value
-        except Exception:
-            dp_limit = target_dp.value if hasattr(target_dp, "value") else float(target_dp)
+        typical_k = get_typical_k(inner_pipe.material)
+        wall_k = typical_k[0] if isinstance(typical_k, tuple) else typical_k
 
     # pipe library fallback (inner ID, outer OD) pairs in meters
     #print("Selecting pipe library...")
@@ -349,285 +632,207 @@ def design_doublepipe(
     if innerpipe_dia is not None and outerpipe_dia is not None:
         pipe_pairs = [(innerpipe_dia.to("m").value, outerpipe_dia.to("m").value)]
 
-    # assignments to try
-    #print("Setting up assignments...")
-    assignments = [
-        ("hot_tube", "cold_annulus"),
-        ("cold_tube", "hot_annulus"),
-    ]
-
-    best_result = None
-    best_score = float("inf")
-    #print("Starting design iterations...")
-    for (Di, Do) in pipe_pairs:
-        if Do <= Di * 1.05:
-            continue
-        #print(f"Trying pipe pair: Inner Diameter = {Di} m, Outer Diameter = {Do} m")
-
-        for assignment in assignments:
-            # map streams
-            if assignment[0] == "hot_tube":
-                tube_stream = hx.hot_in
-                ann_stream = hx.cold_in
-                m_tube = m_hot; m_ann = m_cold
-                cp_tube_nom = cp_hot; cp_ann_nom = cp_cold
-            else:
-                tube_stream = hx.cold_in
-                ann_stream = hx.hot_in
-                m_tube = m_cold; m_ann = m_hot
-                cp_tube_nom = cp_cold; cp_ann_nom = cp_hot
-
-            # per-channel flows depend on inner_mode but mass flow remains constant across passes
-            if inner_mode == "parallel":
-                n_inner_channels = passes
-            else:
-                n_inner_channels = 1
-
-            m_tube_channel = m_tube / n_inner_channels
-            n_ann_channels = annulus_parallel
-            m_ann_channel = m_ann / n_ann_channels
-
-            # initial guesses
-            L_total = 2.0  # m
-            U_ref = 200.0
-            converged = False
-            iteration = 0
-            #print("Starting iterations...")
-            for iteration in range(max_iters):
-                # per-pass length
-                if inner_mode == "series":
-                    L_per_pass = L_total / max(passes, 1)
-                else:
-                    L_per_pass = L_total
-
-                # film temperatures (simple mean of inlet/outlet for each side depending assignment)
-                if assignment[0] == "hot_tube":
-                    T_tube_bulk = 0.5 * ((_val(parms.get("Hot in Temp"), "Hot In")) + (_val(parms.get("Hot out Temp"), "Hot Out")))
-                    T_ann_bulk = 0.5 * ((_val(parms.get("Cold in Temp"), "Cold In")) + (_val(parms.get("Cold out Temp"), "Cold Out")))
-                else:
-                    T_tube_bulk = 0.5 * ((_val(parms.get("Cold in Temp"), "Cold In")) + (_val(parms.get("Cold out Temp"), "Cold Out")))
-                    T_ann_bulk = 0.5 * ((_val(parms.get("Hot in Temp"), "Hot In")) + (_val(parms.get("Hot out Temp"), "Hot Out")))
-
-                # fetch fluid properties from stream components at film temps; fall back to cp_nom if missing
-                try:
-                    mu_t = tube_stream.component.viscosity(T_tube_bulk).to("Pa.s").value
-                    rho_t = tube_stream.component.density(T_tube_bulk).to("kg/m3").value
-                    k_t = tube_stream.component.thermal_conductivity(T_tube_bulk).to("W/mK").value
-                    cp_t = tube_stream.component.specific_heat(T_tube_bulk).to("J/kgK").value
-                except Exception:
-                    # fallback assumptions (less ideal)
-                    mu_t = 1e-3
-                    rho_t = 1000.0
-                    k_t = 0.12
-                    cp_t = cp_tube_nom
-
-                try:
-                    mu_a = ann_stream.component.viscosity(T_ann_bulk).to("Pa.s").value
-                    rho_a = ann_stream.component.density(T_ann_bulk).to("kg/m3").value
-                    k_a = ann_stream.component.thermal_conductivity(T_ann_bulk).to("W/mK").value
-                    cp_a = ann_stream.component.specific_heat(T_ann_bulk).to("J/kgK").value
-                except Exception:
-                    mu_a = 1e-3
-                    rho_a = 1000.0
-                    k_a = 0.12
-                    cp_a = cp_ann_nom
-
-                # Cross-sectional areas (single inner tube and single annulus)
-                A_tube_single = math.pi * (Di ** 2) / 4.0
-                A_annulus_single = math.pi * (Do ** 2 - Di ** 2) / 4.0
-
-                # velocities (per channel)
-                v_tube = m_tube_channel / (rho_t * A_tube_single)
-                v_ann = m_ann_channel / (rho_a * A_annulus_single)
-
-                # Reynolds and Prandtl
-                Re_t = rho_t * v_tube * Di / max(mu_t, 1e-12)
-                Re_a = rho_a * v_ann * max((Do - Di), 1e-6) / max(mu_a, 1e-12)  # Dh ≈ Do - Di
-                Pr_t = _prandtl(cp_t, mu_t, k_t)
-                Pr_a = _prandtl(cp_a, mu_a, k_a)
-
-                # friction factors
-                eps_rel_t = roughness / Di
-                eps_rel_a = roughness / max((Do - Di), Di * 1e-6)
-                f_t = _colebrook_f(max(Re_t, 1e-6), eps_rel_t)
-                f_a = _colebrook_f(max(Re_a, 1e-6), eps_rel_a)
-
-                # Nusselt numbers
-                Nu_t = _nusselt_gnielinski(max(Re_t, 1e-6), max(Pr_t, 1e-6), f_t)
-                Nu_a = _nusselt_annulus(max(Re_a, 1e-6), max(Pr_a, 1e-6), Do, Di, f_a)
-
-                # film coefficients
-                h_t = Nu_t * k_t / Di
-                h_a = Nu_a * k_a / max((Do - Di), Di * 1e-6)
-
-                # ------------------------------------------------------------------
-                # Step 10: Clean Uc (area refs to inner area)
-                # Resistances referenced to inner-surface area (m2 K/W)
-                R_conv_i = 1.0 / max(h_t, 1e-12)
-                # wall resistance per inner-area reference: (Di * ln(Do/Di)) / (2 * k_wall)
-                R_wall = (Di * math.log(Do / Di)) / (2.0 * wall_k_val)
-                R_conv_o = (Di / Do) * (1.0 / max(h_a, 1e-12))
-                R_foul_i = fouling_tube
-                R_foul_o = fouling_shell * (Di / Do)
-                R_total_area = R_conv_i + R_wall + R_conv_o + R_foul_i + R_foul_o
-                U_new = 1.0 / max(R_total_area, 1e-12)  # W/m2K (inner area reference)
-                # ------------------------------------------------------------------
-
-                # --------------------------
-                # NTU -> epsilon -> Ft block
-                # --------------------------
-                Ch = m_tube * cp_t
-                Cc = m_ann * cp_a
-                Cmin = min(Ch, Cc)
-                Cmax = max(Ch, Cc)
-                C_ratio = (Cmin / Cmax) if Cmax > 0 else 0.0
-
-                # compute total inner area available for heat transfer:
-                # as requested => effective area = inner_perimeter * L_per_pass * passes * n_inner_channels
-                # Note: the user's choice was **mass flow constant** and **effective area × passes** in NTU.
-                inner_perimeter = math.pi * Di
-                effective_inner_area = inner_perimeter * L_per_pass * passes * n_inner_channels
-
-                UA = U_new * effective_inner_area
-                NTU_raw = UA / Cmin if Cmin > 0 else 0.0
-
-                ntu_scale = _ntuscaling_for_passes(inner_mode, passes)
-                NTU_effective = NTU_raw * ntu_scale
-
-                eps = _epsilon_from_arrangement(arrangement, NTU_effective, C_ratio)
-
-                # delta_T_lm
-                dT1 = Th_in - Tc_out
-                dT2 = Th_out - Tc_in
-                if dT1 * dT2 <= 0:
-                    delta_T_lm = max(abs(dT1), abs(dT2), 1e-6)
-                else:
-                    delta_T_lm = (dT1 - dT2) / math.log(dT1 / dT2)
-
-                # compute Ft either from chart or NTU-derived
-                Ft = 1.0
-                if pass_layout and pass_layout in _CHART_FT_MAP:
-                    Ft = _CHART_FT_MAP[pass_layout](NTU_raw, C_ratio)
-                else:
-                    if NTU_raw <= 1e-12 or delta_T_lm == 0:
-                        Ft = 1.0
-                    else:
-                        Ft_calc = (eps * (Th_in - Tc_in)) / (NTU_raw * delta_T_lm)
-                        Ft = max(1e-6, min(1.0, Ft_calc))
-
-                # required total inner area (based on current U_new and Ft)
-                denom = U_new * delta_T_lm * Ft
-                if denom <= 0:
-                    A_required = float("inf")
-                else:
-                    A_required = abs(Q) / denom
-
-                L_required = A_required / (math.pi * Di * passes * n_inner_channels)  # distribute area over passes & channels
-
-                # damping for stable convergence
-                U_ref = 0.6 * U_new + 0.4 * U_ref
-                L_total_new = 0.6 * L_required + 0.4 * L_total
-
-                # stopping criteria: relative change in L and U
-                if abs(L_total_new - L_total) / max(1e-9, L_total_new) < tol and abs(U_new - U_ref) / max(1e-9, U_ref) < tol:
-                    L_total = L_total_new
-                    U_ref = U_new
-                    converged = True
-                    break
-
-                L_total = L_total_new
-                U_ref = U_new
-                #print(f"Iteration {iteration+1}: L_total = {L_total}, U_ref = {U_ref}")
-            # end iterative loop
-            #print("Design iterations completed.")
-            # Final recomputation after converge/exit for dp calculations
-            #print("Recomputing pressure drops and final parameters...")
-            if inner_mode == "parallel":
-                n_inner_channels = passes
-            else:
-                n_inner_channels = 1
-            m_tube_channel = m_tube / n_inner_channels
-            m_ann_channel = m_ann / n_ann_channels
-
-            A_tube_single = math.pi * (Di ** 2) / 4.0
-            A_annulus_single = math.pi * (Do ** 2 - Di ** 2) / 4.0
-
-            v_tube = m_tube_channel / (rho_t * A_tube_single)
-            v_ann = m_ann_channel / (rho_a * A_annulus_single)
-
-            Re_t_final = rho_t * v_tube * Di / max(mu_t, 1e-12)
-            Re_a_final = rho_a * v_ann * max((Do - Di), 1e-6) / max(mu_a, 1e-12)
-
-            f_t_final = _colebrook_f(max(Re_t_final, 1e-6), roughness / Di)
-            f_a_final = _colebrook_f(max(Re_a_final, 1e-6), roughness / max((Do - Di), 1e-6))
-
-            dp_tube_fric = _deltaP_darcy(f_t_final, L_per_pass, Di, rho_t, v_tube)
-            dp_tube_system = dp_tube_fric * (passes if inner_mode == "series" else 1)
-            dp_tube_minor = k_minor_tube * 0.5 * rho_t * v_tube * v_tube
-            dp_tube_total = dp_tube_system + dp_tube_minor
-
-            dp_ann_fric = _deltaP_darcy(f_a_final, L_per_pass, (Do - Di), rho_a, v_ann)
-            dp_ann_system = dp_ann_fric  # annulus typically single pass length
-            dp_ann_minor = k_minor_annulus * 0.5 * rho_a * v_ann * v_ann
-            dp_ann_total = dp_ann_system + dp_ann_minor
-
-            total_dp = dp_tube_total + dp_ann_total
-
-            penalty = 0.0
-            if dp_limit is not None:
-                if dp_tube_total > dp_limit or dp_ann_total > dp_limit:
-                    penalty = 1e6 + (dp_tube_total + dp_ann_total - dp_limit)
-
-            # scoring metric: minimize total length + dp penalty
-            score = L_total + penalty
-
-            # hairpin counting if requested (hairpin_length provided)
-            hairpin_info = {}
-            if hairpin_length and hairpin_pipe_inner_id and hairpin_pipe_outer_od:
-                # area per hairpin (single hairpin has inner_perimeter * length * passes_per_hairpin)
-                # hairpin is typically one U-turn: treat each hairpin as a single inner tube of length hairpin_length
-                hairpin_area_per = math.pi * hairpin_pipe_inner_id * hairpin_length
-                hairpins_required = math.ceil((A_required) / hairpin_area_per) if A_required != float("inf") else None
-                hairpin_info = {
-                    "hairpin_length_m": hairpin_length,
-                    "hairpin_area_m2": hairpin_area_per,
-                    "hairpins_required": hairpins_required
-                }
-
-            result = {
-                "innerpipe_dia": Diameter(Di,"m"),
-                "outerpipe_dia": Diameter(Do,"m"), 
-                "assignment": assignment,
-                "inner_mode": inner_mode,
-                "passes": passes,
-                "annulus_parallel": annulus_parallel,
-                "total_length": Length(L_total,"m"),
-                "length_per_pass": Length(L_per_pass,"m"),
-                "U_ref": HeatTransferCoefficient(U_ref,"W/m2K"),
-                "U_max": HeatTransferCoefficient(U_new,"W/m2K"),
-                "Ft": Ft,
-                "required_area": Area(A_required,"m2"),
-                "effective_area": Area(effective_inner_area,"m2"),
-                "Q": HeatFlow(Q,"W"),
-                "Re_tube": Dimensionless(Re_t_final),
-                "Re_annulus": Dimensionless(Re_a_final),
-                "Nu_tube": Dimensionless(Nu_t),
-                "Nu_annulus": Dimensionless(Nu_a),
-                "dp_tube": Pressure(dp_tube_total,"Pa"),
-                "dp_annulus": Pressure(dp_ann_total,"Pa"),
-                "total_dp": Pressure(total_dp,"Pa"),
-                "converged": converged,
-                "iterations": iteration + 1,
-                "hairpin_info": hairpin_info,
-            }
-
-            if score < best_score:
-                best_score = score
-                best_result = result
-
-    if best_result is None:
-        raise RuntimeError("No feasible design found with given options / pipe library.")
-
-    # attach design to hx for downstream use
-    hx.design_results = best_result
+    solver = HXSolver(
+        wall_k=wall_k,
+        roughness=roughness,
+        fouling_tube=fouling_tube,
+        fouling_shell=fouling_shell,
+        k_minor_tube=k_minor_tube,
+        k_minor_annulus=k_minor_annulus,
+        max_iters=max_iters,
+        tol=tol,
+    )
+    constraints = DesignConstraints(pressure_drop_limit=target_dp or _DEFAULT_DP_LIMIT)
+    optimizer = HXOptimizer(solver=solver, constraints=constraints)
+    try:
+        best_result = optimizer.optimize(
+            hx,
+            pipe_pairs=pipe_pairs,
+            inner_mode=inner_mode,
+            passes=passes,
+            annulus_parallel=annulus_parallel,
+            arrangement=arrangement,
+            pass_layout=pass_layout,
+        )
+    except RuntimeError:
+        adaptive = AdaptiveHXOptimizer(optimizer=optimizer)
+        adaptive_result = adaptive.optimize(
+            hx,
+            pipe_pairs=pipe_pairs,
+            inner_mode=inner_mode,
+            passes=passes,
+            annulus_parallel=annulus_parallel,
+            arrangement=arrangement,
+            pass_layout=pass_layout,
+        )
+        if not adaptive_result["is_feasible"]:
+            return adaptive_result
+        best_result = adaptive_result["design"]
+    if hairpin_length and hairpin_pipe_inner_id and hairpin_pipe_outer_od:
+        area_required = best_result["required_area"].to("m2").value
+        hairpin_area_per = math.pi * hairpin_pipe_inner_id * hairpin_length
+        best_result["hairpin_info"] = {
+            "hairpin_length_m": hairpin_length,
+            "hairpin_area_m2": hairpin_area_per,
+            "hairpins_required": math.ceil(area_required / hairpin_area_per),
+        }
+    else:
+        best_result["hairpin_info"] = {}
     return best_result
+
+
+def _solve_double_pipe_candidate(
+    hx: HeatExchanger,
+    *,
+    Di: float,
+    Do: float,
+    assignment: Tuple[str, str],
+    inner_mode: str,
+    passes: int,
+    annulus_parallel: int,
+    arrangement: str,
+    pass_layout: Optional[str],
+    wall_k: Union[float, ThermalConductivity],
+    roughness: float,
+    fouling_tube: float,
+    fouling_shell: float,
+    k_minor_tube: float,
+    k_minor_annulus: float,
+    max_iters: int,
+    tol: float,
+) -> Dict[str, Any]:
+    parms = _get_parms(hx)
+    Th_in = _val(parms.get("Hot in Temp"), "Hot In Temp")
+    Th_out = _val(parms.get("Hot out Temp"), "Hot Out Temp")
+    Tc_in = _val(parms.get("Cold in Temp"), "Cold In Temp")
+    Tc_out = _val(parms.get("Cold out Temp"), "Cold Out Temp")
+    m_hot = _val(parms.get("m_hot"), "m_hot")
+    m_cold = _val(parms.get("m_cold"), "m_cold")
+    cp_hot = _val(parms.get("cP_hot"), "cP_hot") * 1000
+    cp_cold = _val(parms.get("cP_cold"), "cP_cold") * 1000
+    Q_hot = m_hot * cp_hot * (Th_in - Th_out)
+    Q_cold = m_cold * cp_cold * (Tc_out - Tc_in)
+    Q = 0.5 * (Q_hot + Q_cold) if abs(Q_hot) > 0 and abs(Q_cold) > 0 else (Q_hot if abs(Q_hot) > 0 else Q_cold)
+    wall_k_val = wall_k.value if hasattr(wall_k, "value") else float(wall_k)
+
+    if assignment[0] == "hot_tube":
+        tube_stream, ann_stream = hx.hot_in, hx.cold_in
+        m_tube, m_ann = m_hot, m_cold
+        cp_tube_nom, cp_ann_nom = cp_hot, cp_cold
+    else:
+        tube_stream, ann_stream = hx.cold_in, hx.hot_in
+        m_tube, m_ann = m_cold, m_hot
+        cp_tube_nom, cp_ann_nom = cp_cold, cp_hot
+
+    n_inner_channels = passes if inner_mode == "parallel" else 1
+    n_ann_channels = annulus_parallel
+    m_tube_channel = m_tube / n_inner_channels
+    m_ann_channel = m_ann / n_ann_channels
+    L_total = 2.0
+    U_ref = 200.0
+    converged = False
+
+    for iteration in range(max_iters):
+        L_per_pass = L_total / max(passes, 1) if inner_mode == "series" else L_total
+        if assignment[0] == "hot_tube":
+            T_tube_bulk = 0.5 * (_val(parms.get("Hot in Temp"), "Hot In") + _val(parms.get("Hot out Temp"), "Hot Out"))
+            T_ann_bulk = 0.5 * (_val(parms.get("Cold in Temp"), "Cold In") + _val(parms.get("Cold out Temp"), "Cold Out"))
+        else:
+            T_tube_bulk = 0.5 * (_val(parms.get("Cold in Temp"), "Cold In") + _val(parms.get("Cold out Temp"), "Cold Out"))
+            T_ann_bulk = 0.5 * (_val(parms.get("Hot in Temp"), "Hot In") + _val(parms.get("Hot out Temp"), "Hot Out"))
+
+        try:
+            mu_t = tube_stream.component.viscosity(T_tube_bulk).to("Pa.s").value
+            rho_t = tube_stream.component.density(T_tube_bulk).to("kg/m3").value
+            k_t = tube_stream.component.thermal_conductivity(T_tube_bulk).to("W/mK").value
+            cp_t = tube_stream.component.specific_heat(T_tube_bulk).to("J/kgK").value
+        except Exception:
+            mu_t, rho_t, k_t, cp_t = 1e-3, 1000.0, 0.12, cp_tube_nom
+
+        try:
+            mu_a = ann_stream.component.viscosity(T_ann_bulk).to("Pa.s").value
+            rho_a = ann_stream.component.density(T_ann_bulk).to("kg/m3").value
+            k_a = ann_stream.component.thermal_conductivity(T_ann_bulk).to("W/mK").value
+            cp_a = ann_stream.component.specific_heat(T_ann_bulk).to("J/kgK").value
+        except Exception:
+            mu_a, rho_a, k_a, cp_a = 1e-3, 1000.0, 0.12, cp_ann_nom
+
+        A_tube_single = math.pi * (Di ** 2) / 4.0
+        A_annulus_single = math.pi * (Do ** 2 - Di ** 2) / 4.0
+        v_tube = m_tube_channel / (rho_t * A_tube_single)
+        v_ann = m_ann_channel / (rho_a * A_annulus_single)
+        Re_t = rho_t * v_tube * Di / max(mu_t, 1e-12)
+        Re_a = rho_a * v_ann * max((Do - Di), 1e-6) / max(mu_a, 1e-12)
+        Pr_t = _prandtl(cp_t, mu_t, k_t)
+        Pr_a = _prandtl(cp_a, mu_a, k_a)
+        f_t = _colebrook_f(max(Re_t, 1e-6), roughness / Di)
+        f_a = _colebrook_f(max(Re_a, 1e-6), roughness / max((Do - Di), Di * 1e-6))
+        Nu_t = _nusselt_gnielinski(max(Re_t, 1e-6), max(Pr_t, 1e-6), f_t)
+        Nu_a = _nusselt_annulus(max(Re_a, 1e-6), max(Pr_a, 1e-6), Do, Di, f_a)
+        h_t = Nu_t * k_t / Di
+        h_a = Nu_a * k_a / max((Do - Di), Di * 1e-6)
+
+        R_total_area = (1.0 / max(h_t, 1e-12)) + ((Di * math.log(Do / Di)) / (2.0 * wall_k_val)) + ((Di / Do) * (1.0 / max(h_a, 1e-12))) + fouling_tube + (fouling_shell * (Di / Do))
+        U_new = 1.0 / max(R_total_area, 1e-12)
+        Cmin = min(m_tube * cp_t, m_ann * cp_a)
+        Cmax = max(m_tube * cp_t, m_ann * cp_a)
+        C_ratio = (Cmin / Cmax) if Cmax > 0 else 0.0
+        effective_inner_area = math.pi * Di * L_per_pass * passes * n_inner_channels
+        NTU_raw = (U_new * effective_inner_area / Cmin) if Cmin > 0 else 0.0
+        NTU_effective = NTU_raw * _ntuscaling_for_passes(inner_mode, passes)
+        eps = _epsilon_from_arrangement(arrangement, NTU_effective, C_ratio)
+        dT1 = Th_in - Tc_out
+        dT2 = Th_out - Tc_in
+        delta_T_lm = max(abs(dT1), abs(dT2), 1e-6) if dT1 * dT2 <= 0 else (dT1 - dT2) / math.log(dT1 / dT2)
+        if pass_layout and pass_layout in _CHART_FT_MAP:
+            Ft = _CHART_FT_MAP[pass_layout](NTU_raw, C_ratio)
+        else:
+            Ft = 1.0 if (NTU_raw <= 1e-12 or delta_T_lm == 0) else max(1e-6, min(1.0, (eps * (Th_in - Tc_in)) / (NTU_raw * delta_T_lm)))
+        denom = U_new * delta_T_lm * Ft
+        A_required = float("inf") if denom <= 0 else abs(Q) / denom
+        L_required = A_required / (math.pi * Di * passes * n_inner_channels)
+        U_ref = 0.6 * U_new + 0.4 * U_ref
+        L_total_new = 0.6 * L_required + 0.4 * L_total
+        if abs(L_total_new - L_total) / max(1e-9, L_total_new) < tol and abs(U_new - U_ref) / max(1e-9, U_ref) < tol:
+            L_total = L_total_new
+            U_ref = U_new
+            converged = True
+            break
+        L_total = L_total_new
+        U_ref = U_new
+
+    L_per_pass = L_total / max(passes, 1) if inner_mode == "series" else L_total
+    Re_t_final = rho_t * v_tube * Di / max(mu_t, 1e-12)
+    Re_a_final = rho_a * v_ann * max((Do - Di), 1e-6) / max(mu_a, 1e-12)
+    dp_tube_total = (_deltaP_darcy(_colebrook_f(max(Re_t_final, 1e-6), roughness / Di), L_per_pass, Di, rho_t, v_tube) * (passes if inner_mode == "series" else 1)) + (k_minor_tube * 0.5 * rho_t * v_tube * v_tube)
+    dp_ann_total = _deltaP_darcy(_colebrook_f(max(Re_a_final, 1e-6), roughness / max((Do - Di), 1e-6)), L_per_pass, (Do - Di), rho_a, v_ann) + (k_minor_annulus * 0.5 * rho_a * v_ann * v_ann)
+    total_dp = dp_tube_total + dp_ann_total
+    pumping_power_w = (dp_tube_total * (m_tube / max(rho_t, 1e-12))) + (dp_ann_total * (m_ann / max(rho_a, 1e-12)))
+    return {
+        "innerpipe_dia": Diameter(Di, "m"),
+        "outerpipe_dia": Diameter(Do, "m"),
+        "assignment": assignment,
+        "inner_mode": inner_mode,
+        "passes": passes,
+        "annulus_parallel": annulus_parallel,
+        "total_length": Length(L_total, "m"),
+        "length_per_pass": Length(L_per_pass, "m"),
+        "U_ref": HeatTransferCoefficient(U_ref, "W/m2K"),
+        "U_max": HeatTransferCoefficient(U_new, "W/m2K"),
+        "Ft": Ft,
+        "required_area": Area(A_required, "m2"),
+        "effective_area": Area(effective_inner_area, "m2"),
+        "Q": HeatFlow(Q, "W"),
+        "Re_tube": Dimensionless(Re_t_final),
+        "Re_annulus": Dimensionless(Re_a_final),
+        "Nu_tube": Dimensionless(Nu_t),
+        "Nu_annulus": Dimensionless(Nu_a),
+        "v_tube": Velocity(v_tube, "m/s"),
+        "v_annulus": Velocity(v_ann, "m/s"),
+        "dp_tube": Pressure(dp_tube_total, "Pa"),
+        "dp_annulus": Pressure(dp_ann_total, "Pa"),
+        "total_dp": Pressure(total_dp, "Pa"),
+        "pumping_power": Power(pumping_power_w, "W"),
+        "converged": converged,
+        "iterations": iteration + 1,
+    }

--- a/processpi/equipment/heatexchangers/mechanical/evaporator.py
+++ b/processpi/equipment/heatexchangers/mechanical/evaporator.py
@@ -1,263 +1,35 @@
 """
-processpi/equipment/heatexchangers/evaporator.py
+Deprecated compatibility module.
 
-Improved Evaporator design module — kept your original structure but
-made the routine more robust and consistent with the ProcessPI
-units/stream patterns used in other exchanger modules.
-
-Key improvements:
-- Accepts a single HeatExchanger-like object `hx` (keeps API consistent).
-- Robust unit handling and safe fallbacks when component property calls fail.
-- Clear zone-wise iterative U ↔ A convergence, with safe numerical guards.
-- Uses ASCII unit strings (e.g. "kg/m3") when converting units.
-- Clean, well-documented return dict.
-
-This file assumes the existence of the helper modules you referenced:
-- .kern_method: providing lmtd(), overall_U(), tube_htc(), shell_htc(), required_area(), heat_duty()
-- .bell_method: providing bell_delaware_pressure_drop(), check_flooding()
-
-If those functions have different names/signatures, you'll need to adapt the imports.
+Evaporator behavior is now handled by unified ShellAndTube(mode="evaporator").
 """
 
 from typing import Dict, Any
-import math
 
-from ....streams.material import MaterialStream
 from ..base import HeatExchanger
-from .kern_method import lmtd, overall_U, tube_htc, shell_htc, required_area, heat_duty
-from .bell_method import bell_delaware_pressure_drop, check_flooding
-
-# defaults
-DEFAULT_FOUL_HOT = 1e-4
-DEFAULT_FOUL_COLD = 2e-4
-DEFAULT_TUBE_K = 16.0
-GRAVITY = 9.81
+from .shell_tube import ShellAndTube
 
 
-def _safe_prop_get(component, fn_name: str, *args, fallback=None):
-    """Call a component property function safely and return numeric value or fallback."""
-    try:
-        fn = getattr(component, fn_name)
-        val = fn(*args)
-        # if the returned object has .to(unit).value pattern, try to extract
-        if hasattr(val, "to"):
-            # user code often expects Kelvin for temperature, J/kg for latent, etc.
-            try:
-                # Try to return SI scalar when possible
-                return float(val.to("K").value) if "temp" in fn_name.lower() or "temperature" in fn_name.lower() else float(val.value)
-            except Exception:
-                try:
-                    return float(val.value)
-                except Exception:
-                    return fallback
-        # numbers
-        if isinstance(val, (int, float)):
-            return float(val)
-        return fallback
-    except Exception:
-        return fallback
+class Evaporator(ShellAndTube):
+    def __init__(self, name: str = "Evaporator", **kwargs):
+        super().__init__(name=name, mode="evaporator", **kwargs)
 
 
-def design_evaporator(
-    hx: HeatExchanger,
-    *,
-    orientation: str = "horizontal",
-    passes: int = 1,
-    Ft: float = 1.0,
-    fouling_hot: float = DEFAULT_FOUL_HOT,
-    fouling_cold: float = DEFAULT_FOUL_COLD,
-    layout: str = "triangular",
-    tube_OD: float = 0.0254,
-    tube_pitch_factor: float = 1.25,
-    max_zone_iter: int = 30,
-    tol: float = 1e-3,
-    **kwargs
-) -> Dict[str, Any]:
-    """
-    Evaporator design wrapper that expects the HeatExchanger `hx` object to
-    have `hot_in`, `cold_in` MaterialStream attributes and `simulated_params` as
-    used elsewhere in ProcessPI.
+# Backward-compatible alias from previous refactor cycle.
+EvaporatorHeatExchanger = Evaporator
 
-    The routine calculates separate zones: superheat, boiling, subcool (if any),
-    and performs iterative convergence for U and area in each zone.
 
-    Returns a dictionary with zone areas, U-values, LMTDs, hydraulic info and
-    flags like flooding risk.
-    """
-    if not isinstance(hx, HeatExchanger):
-        raise TypeError("hx must be a HeatExchanger instance")
-
-    hot = hx.hot_in
-    cold = hx.cold_in
-
-    # temperatures (try Kelvin first, fall back to raw numeric)
-    try:
-        T_hot_in_K = float(hot.temperature.to("K").value)
-    except Exception:
-        T_hot_in_K = float(getattr(hot, "temperature", getattr(hot, "T", 300.0)))
-    try:
-        T_cold_in_K = float(cold.temperature.to("K").value)
-    except Exception:
-        T_cold_in_K = float(getattr(cold, "temperature", getattr(cold, "T", 280.0)))
-
-    # saturation temperature of cold (assume component method exists)
-    T_sat_K = _safe_prop_get(cold.component, "saturation_temperature", fallback=None) or _safe_prop_get(cold.component, "boiling_point", fallback=None)
-    if T_sat_K is None:
-        # fallback: assume slightly below cold inlet
-        T_sat_K = T_cold_in_K
-
-    # mass flows and cp (attempt robust extraction)
-    try:
-        m_dot_hot = float(hot.mass_flowrate.to("kg/s").value)
-    except Exception:
-        m_dot_hot = float(getattr(hot, "mass_flowrate", getattr(hot, "m_dot", 1.0)))
-    try:
-        m_dot_cold = float(cold.mass_flowrate.to("kg/s").value)
-    except Exception:
-        m_dot_cold = float(getattr(cold, "mass_flowrate", getattr(cold, "m_dot", 1.0)))
-
-    try:
-        cp_hot = float(hot.cp.to("J/kg-K").value)
-    except Exception:
-        cp_hot = _safe_prop_get(hot.component, "specific_heat", fallback=4200.0)
-    try:
-        cp_cold = float(cold.cp.to("J/kg-K").value)
-    except Exception:
-        cp_cold = _safe_prop_get(cold.component, "specific_heat", fallback=4200.0)
-
-    # zone duties
-    # superheat: bring cold from its inlet to saturation, if inlet > sat then no superheat
-    deltaT_super = max(T_cold_in_K - T_sat_K, 0.0)
-    duty_super = 0.0
-    if deltaT_super > 0:
-        duty_super = heat_duty(m_dot_cold, cp_cold, T_cold_in_K, T_sat_K)
-
-    # boiling duty (latent)
-    h_fg = _safe_prop_get(cold.component, "latent_heat", fallback=None) or _safe_prop_get(cold.component, "latent_heat_of_vaporization", fallback=None)
-    if h_fg is None:
-        # best-effort fallback (water at 1 atm ~ 2257000 J/kg)
-        h_fg = 2.257e6
-    duty_boil = m_dot_cold * float(h_fg)
-
-    # subcooling duty: if hot inlet hotter than saturation
-    deltaT_sub = max(T_hot_in_K - T_sat_K, 0.0)
-    duty_sub = 0.0
-    if deltaT_sub > 0:
-        duty_sub = heat_duty(m_dot_hot, cp_hot, T_hot_in_K, T_sat_K)
-
-    Q_total = duty_super + duty_boil + duty_sub
-
-    # helper: zone iterative convergence (U ↔ A)
-    def zone_iter(duty: float, T_hot_start: float, T_hot_end: float, T_cold_start: float, T_cold_end: float, U_guess: float = 500.0):
-        U = max(1.0, U_guess)
-        A_req = float('inf')
-        lmtd_val = lmtd(T_hot_start, T_hot_end, T_cold_start, T_cold_end, Ft)
-        for _ in range(max_zone_iter):
-            if lmtd_val == 0 or U <= 0:
-                A_req = float('inf')
-                break
-            A_req = required_area(duty, U, lmtd_val)
-            # compute representative hydraulic geometry: use total area to estimate flow velocities
-            # assume tube area is A_req distributed over tube outer perimeter * length default
-            # we pick a default tube length guess and refine by area
-            L_guess = max(1.0, A_req / (math.pi * tube_OD * 10.0))
-            # use representative area per tube (assume 10 tubes as placeholder) -> compute velocities
-            tube_count_est = max(1, int(math.ceil(A_req / (math.pi * tube_OD * L_guess))))
-
-            # fluid properties for heat transfer coefficients (try to pull at film temps)
-            T_f_hot = 0.5 * (T_hot_start + T_hot_end)
-            T_f_cold = 0.5 * (T_cold_start + T_cold_end)
-
-            mu_hot = _safe_prop_get(hot.component, "viscosity", T_f_hot, fallback=1e-3)
-            rho_hot = _safe_prop_get(hot.component, "density", T_f_hot, fallback=1000.0)
-            k_hot = _safe_prop_get(hot.component, "thermal_conductivity", T_f_hot, fallback=0.13)
-            cp_hot_loc = _safe_prop_get(hot.component, "specific_heat", T_f_hot, fallback=cp_hot)
-
-            mu_cold = _safe_prop_get(cold.component, "viscosity", T_f_cold, fallback=1e-3)
-            rho_cold = _safe_prop_get(cold.component, "density", T_f_cold, fallback=1000.0)
-            k_cold = _safe_prop_get(cold.component, "thermal_conductivity", T_f_cold, fallback=0.13)
-            cp_cold_loc = _safe_prop_get(cold.component, "specific_heat", T_f_cold, fallback=cp_cold)
-
-            # estimate velocities (tube-side assumed hot by default as in other modules)
-            v_tube = (m_dot_hot / tube_count_est) / max(rho_hot * (math.pi * ( (tube_OD - 2e-3)**2)/4.0), 1e-12)
-            Re_t = rho_hot * v_tube * (tube_OD - 2e-3) / max(mu_hot, 1e-12)
-            Pr_t = _prandtl = (cp_hot_loc * mu_hot / max(k_hot, 1e-12)) if k_hot>0 else 1.0
-            h_t = tube_htc(k_hot, (tube_OD - 2e-3), Re_t, Pr_t)
-
-            # shell-side HTC using bell-method helper (fallback to simple correlation)
-            try:
-                h_s = shell_htc(rho_hot, mu_hot, k_hot, cp_hot_loc, m_dot_hot, Ds=0.5, pitch=1.25*tube_OD)
-            except Exception:
-                # conservative fallback
-                h_s = 100.0
-
-            U_new = overall_U(h_t, h_s, fouling_hot, fouling_cold, R_wall=0.001)
-
-            if abs(U_new - U) / max(1e-12, U) < tol:
-                U = U_new
-                break
-            U = 0.6 * U_new + 0.4 * U
-        return max(A_req, 0.0), U, lmtd_val
-
-    # run zones
-    A_super, U_super, LMTD_super = (0.0, 0.0, 0.0)
-    A_boil, U_boil, LMTD_boil = (0.0, 0.0, 0.0)
-    A_sub, U_sub, LMTD_sub = (0.0, 0.0, 0.0)
-
-    # superheat zone (if any)
-    if duty_super > 0:
-        A_super, U_super, LMTD_super = zone_iter(duty_super, T_hot_in_K, T_hot_in_K - max(1.0, duty_super/(m_dot_hot*cp_hot) ), T_cold_in_K, T_sat_K)
-
-    # boiling zone
-    A_boil, U_boil, LMTD_boil = zone_iter(duty_boil, T_hot_in_K - max(0.0, duty_super/(m_dot_hot*cp_hot)), T_hot_in_K - max(0.0, duty_super/(m_dot_hot*cp_hot)), T_sat_K, T_sat_K)
-
-    # subcool zone (if any)
-    if duty_sub > 0:
-        A_sub, U_sub, LMTD_sub = zone_iter(duty_sub, T_hot_in_K - max(0.0, (duty_super + duty_boil)/(m_dot_hot*cp_hot)), T_hot_in_K - max(0.0, (duty_super + duty_boil + duty_sub)/(m_dot_hot*cp_hot)), T_sat_K, T_cold_in_K)
-
-    A_total = A_super + A_boil + A_sub
-
-    # bundle/tube counts (simple heuristic)
-    pitch = tube_pitch_factor * tube_OD
-    pitch_ratio = 0.866 if layout == "triangular" else 1.0
-    # choose a nominal bundle diameter from area
-    bundle_diam = math.sqrt(A_total / (math.pi * tube_OD * max(1.0, passes))) if A_total>0 else 0.0
-    N_tubes = max(1, int(pitch_ratio * (bundle_diam / pitch)**2))
-    tube_length = A_total / (math.pi * tube_OD * N_tubes) if N_tubes>0 else 0.0
-    shell_ID = bundle_diam * 1.1 if bundle_diam>0 else max(0.2, tube_OD*12)
-
-    # shell-side pressure drop using Bell-Delaware helper (use last h_s estimates if available)
-    try:
-        rho_s = _safe_prop_get(hot.component, "density", T_hot_in_K, fallback=1000.0)
-        mu_s = _safe_prop_get(hot.component, "viscosity", T_hot_in_K, fallback=1e-3)
-        deltaP_shell = bell_delaware_pressure_drop(rho_s, mu_s, m_dot_hot, shell_ID, tube_OD)
-    except Exception:
-        deltaP_shell = 0.0
-
-    # flooding check
-    flooded = False
-    try:
-        flooded = check_flooding(cold, math.pi*(tube_OD**2)/4.0, vertical=(orientation=="vertical"))
-    except Exception:
-        flooded = False
-
-    result = {
-        "Duty_W": Q_total,
-        "Overall_U_W_m2K": (U_super + U_boil + U_sub) / max(1, sum([1 if x>0 else 0 for x in (U_super, U_boil, U_sub)])),
-        "Area_super_m2": A_super,
-        "Area_boil_m2": A_boil,
-        "Area_sub_m2": A_sub,
-        "A_total_m2": A_total,
-        "N_tubes": N_tubes,
-        "tube_length_m": tube_length,
-        "bundle_diameter_m": bundle_diam,
-        "shell_ID_m": shell_ID,
-        "deltaP_shell_Pa": deltaP_shell,
-        "flooding_risk": flooded,
-        "LMTD_zones_K": {"superheat": LMTD_super, "boiling": LMTD_boil, "subcool": LMTD_sub},
-        "U_zones_W_m2K": {"superheat": U_super, "boiling": U_boil, "subcool": U_sub}
-    }
-
-    # attach to hx
+def design_evaporator(hx: HeatExchanger, **kwargs) -> Dict[str, Any]:
+    """Backward-compatible design entrypoint for evaporator mode."""
+    if isinstance(hx, ShellAndTube):
+        hx.mode = "evaporator"
+        return hx._design_shelltube(**kwargs)
+    tmp = Evaporator(name=getattr(hx, "name", "Evaporator"))
+    tmp.inlets["hot_in"] = getattr(hx, "hot_in", None)
+    tmp.inlets["cold_in"] = getattr(hx, "cold_in", None)
+    tmp.outlets["hot_out"] = getattr(hx, "hot_out", None)
+    tmp.outlets["cold_out"] = getattr(hx, "cold_out", None)
+    tmp._collect_base_data()
+    result = tmp._design_shelltube(**kwargs)
     hx.design_results = result
     return result

--- a/processpi/equipment/heatexchangers/mechanical/reboiler.py
+++ b/processpi/equipment/heatexchangers/mechanical/reboiler.py
@@ -1,288 +1,35 @@
 """
-processpi/equipment/heatexchangers/reboiler.py
+Deprecated compatibility module.
 
-Improved Reboiler design module — aligned with other exchanger modules
-(evaporator, condenser, shell_tube, double_pipe).
-
-Key improvements that this implementation provides:
-- Single `hx: HeatExchanger` input (uses hx.hot_in / hx.cold_in streams)
-- Robust unit/property extraction via `_safe_prop_get()`
-- Zone-wise iterative U <-> A convergence with damping and numeric guards
-- Uses packing routine (if available) for bundle sizing
-- Conservatively falls back to heuristics when component methods are missing
-- Attaches result to `hx.design_results`
-
-This module expects your existing helper modules: `.kern_method` and
-`.bell_method` (same names as in your repo). Adapt imports if your helpers
-have different names/signatures.
+Reboiler behavior is now handled by unified ShellAndTube(mode="reboiler").
 """
 
 from typing import Dict, Any
-import math
 
-from ....streams.material import MaterialStream
 from ..base import HeatExchanger
-from .kern_method import lmtd, overall_U, tube_htc, shell_htc, required_area, heat_duty
-from .bell_method import bell_delaware_pressure_drop, check_flooding
-
-# try to reuse packing routine from shell_tube if available
-try:
-    from .shell_tube import pack_tubes_in_shell
-except Exception:
-    def pack_tubes_in_shell(D_shell: float, D_tube: float, pitch: float, layout: str = "triangular"):
-        # simple fallback: estimate tube count from area
-        return [], max(1, int(max(6, math.floor((D_shell/D_tube)**2))))
-
-# defaults
-DEFAULT_FOUL_HOT = 1e-4
-DEFAULT_FOUL_COLD = 2e-4
-DEFAULT_TUBE_K = 16.0
-GRAVITY = 9.81
+from .shell_tube import ShellAndTube
 
 
-def _safe_prop_get(component, fn_name: str, *args, fallback=None):
-    """Call component property safely and extract numeric value or fallback."""
-    try:
-        fn = getattr(component, fn_name)
-        val = fn(*args)
-        if hasattr(val, "to"):
-            try:
-                return float(val.value)
-            except Exception:
-                try:
-                    return float(val.to("K").value)
-                except Exception:
-                    return fallback
-        if isinstance(val, (int, float)):
-            return float(val)
-        return fallback
-    except Exception:
-        return fallback
+class Reboiler(ShellAndTube):
+    def __init__(self, name: str = "Reboiler", **kwargs):
+        super().__init__(name=name, mode="reboiler", **kwargs)
 
 
-def design_reboiler(
-    hx: HeatExchanger,
-    *,
-    orientation: str = "horizontal",
-    passes: int = 1,
-    Ft: float = 1.0,
-    fouling_hot: float = DEFAULT_FOUL_HOT,
-    fouling_cold: float = DEFAULT_FOUL_COLD,
-    layout: str = "triangular",
-    tube_OD: float = 0.0254,
-    tube_pitch_factor: float = 1.25,
-    tube_side_hot: bool = True,  # tube-side hot by default for reboilers
-    max_zone_iter: int = 30,
-    tol: float = 1e-3,
-    **kwargs
-) -> Dict[str, Any]:
-    """
-    Reboiler design wrapper expecting hx (HeatExchanger) with `hot_in` and
-    `cold_in` MaterialStream attributes. Calculates heating, boiling and
-    optional superheat zones with iterative U <-> A convergence.
-    """
-    if not isinstance(hx, HeatExchanger):
-        raise TypeError("hx must be a HeatExchanger instance")
+# Backward-compatible alias from previous refactor cycle.
+ReboilerHeatExchanger = Reboiler
 
-    hot = hx.hot_in
-    cold = hx.cold_in
 
-    # temperatures (Kelvin preferred)
-    try:
-        T_hot_in = float(hot.temperature.to("K").value)
-    except Exception:
-        T_hot_in = float(getattr(hot, "temperature", getattr(hot, "T", 350.0)))
-    try:
-        T_cold_in = float(cold.temperature.to("K").value)
-    except Exception:
-        T_cold_in = float(getattr(cold, "temperature", getattr(cold, "T", 300.0)))
-
-    # saturation temperature of the cold (boiling) stream
-    T_sat = _safe_prop_get(cold.component, "saturation_temperature", fallback=None) or _safe_prop_get(cold.component, "boiling_point", fallback=None)
-    if T_sat is None:
-        # fallback assume cold is the boiling stream; if unknown use inlet
-        T_sat = T_cold_in
-
-    # mass flows and heat capacities
-    try:
-        m_hot = float(hot.mass_flowrate.to("kg/s").value)
-    except Exception:
-        m_hot = float(getattr(hot, "mass_flowrate", getattr(hot, "m_dot", 1.0)))
-    try:
-        m_cold = float(cold.mass_flowrate.to("kg/s").value)
-    except Exception:
-        m_cold = float(getattr(cold, "mass_flowrate", getattr(cold, "m_dot", 1.0)))
-
-    try:
-        cp_hot = float(hot.cp.to("J/kg-K").value)
-    except Exception:
-        cp_hot = _safe_prop_get(hot.component, "specific_heat", fallback=2000.0)
-    try:
-        cp_cold = float(cold.cp.to("J/kg-K").value)
-    except Exception:
-        cp_cold = _safe_prop_get(cold.component, "specific_heat", fallback=4200.0)
-
-    # Zone duties
-    # heating: bring hot from inlet down (or cold up) — user semantics vary; we mimic textbook reboiler
-    deltaT_heat = max(T_hot_in - T_sat, 0.0)
-    deltaT_super = max(T_sat - T_hot_in, 0.0)  # if hot inlet hotter than sat
-
-    duty_heat = 0.0
-    if deltaT_heat > 0:
-        # heat required to raise cold to near saturation using hot energy
-        duty_heat = heat_duty(m_cold, cp_cold, T_cold_in, T_sat)
-
-    # boiling duty (latent on cold side)
-    h_fg = _safe_prop_get(cold.component, "latent_heat", fallback=None) or _safe_prop_get(cold.component, "latent_heat_of_vaporization", fallback=None)
-    if h_fg is None:
-        # fallback water-like
-        h_fg = 2.257e6
-    duty_boil = m_cold * float(h_fg)
-
-    # optional superheat of vapor leaving reboiler (usually small)
-    duty_super = 0.0
-    if T_hot_in > T_sat:
-        duty_super = heat_duty(m_hot, cp_hot, T_hot_in, T_sat)
-
-    Q_total = duty_heat + duty_boil + duty_super
-
-    # which side is tube vs shell
-    if tube_side_hot:
-        tube_stream = hot
-        shell_stream = cold
-        m_tube_total = m_hot
-        m_shell_total = m_cold
-        cp_tube = cp_hot
-        cp_shell = cp_cold
-    else:
-        tube_stream = cold
-        shell_stream = hot
-        m_tube_total = m_cold
-        m_shell_total = m_hot
-        cp_tube = cp_cold
-        cp_shell = cp_hot
-
-    # iterative zone solver
-    def zone_iter(duty: float, T_hot_start: float, T_hot_end: float, T_cold_start: float, T_cold_end: float, U_guess: float = 500.0):
-        U = max(1.0, U_guess)
-        lmtd_val = lmtd(T_hot_start, T_hot_end, T_cold_start, T_cold_end, Ft)
-        A_req = float('inf')
-        for _ in range(max_zone_iter):
-            if lmtd_val == 0 or U <= 0:
-                A_req = float('inf')
-                break
-            A_req = required_area(duty, U, lmtd_val)
-
-            # estimate flow geometry
-            L_guess = max(1.0, A_req / (math.pi * tube_OD * 10.0))
-            tube_count_est = max(1, int(math.ceil(A_req / (math.pi * tube_OD * L_guess))))
-
-            # film temps
-            T_f_tube = 0.5 * (T_hot_start + T_hot_end)
-            T_f_shell = 0.5 * (T_cold_start + T_cold_end)
-
-            mu_t = _safe_prop_get(tube_stream.component, "viscosity", T_f_tube, fallback=1e-3)
-            rho_t = _safe_prop_get(tube_stream.component, "density", T_f_tube, fallback=1000.0)
-            k_t = _safe_prop_get(tube_stream.component, "thermal_conductivity", T_f_tube, fallback=0.13)
-            cp_t_loc = _safe_prop_get(tube_stream.component, "specific_heat", T_f_tube, fallback=cp_tube)
-
-            mu_s = _safe_prop_get(shell_stream.component, "viscosity", T_f_shell, fallback=1e-3)
-            rho_s = _safe_prop_get(shell_stream.component, "density", T_f_shell, fallback=1000.0)
-            k_s = _safe_prop_get(shell_stream.component, "thermal_conductivity", T_f_shell, fallback=0.13)
-            cp_s_loc = _safe_prop_get(shell_stream.component, "specific_heat", T_f_shell, fallback=cp_shell)
-
-            # tube-side heat transfer
-            A_tube_flow = math.pi * ((tube_OD - 2e-3) ** 2) / 4.0
-            v_tube = (m_tube_total / max(1, tube_count_est)) / max(rho_t * A_tube_flow, 1e-12)
-            Re_t = rho_t * v_tube * max(tube_OD - 2e-3, 1e-6) / max(mu_t, 1e-12)
-            Pr_t = (cp_t_loc * mu_t / max(k_t, 1e-12)) if k_t>0 else 1.0
-            try:
-                h_t = tube_htc(k_t, (tube_OD - 2e-3), Re_t, Pr_t)
-            except Exception:
-                h_t = 200.0
-
-            # shell-side (boiling) — boiling HTC guess or shell_htc helper
-            try:
-                h_s = shell_htc(rho_s, mu_s, k_s, cp_s_loc, m_shell_total, Ds=0.5, pitch=tube_pitch_factor*tube_OD)
-            except Exception:
-                # conservative boiling film fallback
-                h_s = 500.0
-
-            U_new = overall_U(h_t, h_s, fouling_hot, fouling_cold, R_wall=0.001)
-            if abs(U_new - U) / max(1e-12, U) < tol:
-                U = U_new
-                break
-            U = 0.6 * U_new + 0.4 * U
-        return max(A_req, 0.0), U, lmtd_val
-
-    # run zones
-    A_heat = U_heat = LMTD_heat = 0.0
-    A_boil = U_boil = LMTD_boil = 0.0
-    A_super = U_super = LMTD_super = 0.0
-
-    if duty_heat > 0:
-        A_heat, U_heat, LMTD_heat = zone_iter(duty_heat, T_hot_in, T_sat, T_cold_in, T_sat)
-
-    A_boil, U_boil, LMTD_boil = zone_iter(duty_boil, T_sat, T_sat, T_cold_in, T_sat)
-
-    if duty_super > 0:
-        A_super, U_super, LMTD_super = zone_iter(duty_super, T_hot_in, T_hot_in - 1.0, T_sat, T_sat + 1.0)
-
-    A_total = A_heat + A_boil + A_super
-
-    # bundle sizing using packing routine when available
-    pitch = tube_pitch_factor * tube_OD
-    bundle_diam_guess = math.sqrt(A_total / (math.pi * tube_OD * max(1.0, passes))) if A_total>0 else 0.0
-    Ds = max(0.1, bundle_diam_guess)
-    centers, N_packed = pack_tubes_in_shell(Ds, tube_OD, pitch, layout=layout)
-    attempts = 0
-    while (not centers or len(centers) < 4) and attempts < 5:
-        Ds *= 1.25
-        centers, N_packed = pack_tubes_in_shell(Ds, tube_OD, pitch, layout=layout)
-        attempts += 1
-
-    if centers and len(centers) > 0:
-        max_r = max(math.hypot(x, y) for x, y in centers)
-        bundle_diam = max(2.0 * max_r, Ds)
-        N_tubes = len(centers)
-    else:
-        pitch_ratio = 0.866 if layout == "triangular" else 1.0
-        N_tubes = max(1, int(pitch_ratio * (bundle_diam_guess / pitch)**2))
-        bundle_diam = bundle_diam_guess
-
-    tube_length = A_total / (math.pi * tube_OD * N_tubes) if N_tubes>0 else 0.0
-    shell_ID = bundle_diam * 1.1 if bundle_diam>0 else max(0.2, tube_OD*12)
-
-    # shell-side dp and flooding
-    try:
-        rho_s_for_dp = _safe_prop_get(shell_stream.component, "density", T_cold_in, fallback=1000.0)
-        mu_s_for_dp = _safe_prop_get(shell_stream.component, "viscosity", T_cold_in, fallback=1e-3)
-        deltaP_shell = bell_delaware_pressure_drop(rho_s_for_dp, mu_s_for_dp, m_shell_total, shell_ID, tube_OD)
-    except Exception:
-        deltaP_shell = 0.0
-
-    flooded = False
-    try:
-        flooded = check_flooding(cold, math.pi*(tube_OD**2)/4.0, vertical=(orientation=="vertical"))
-    except Exception:
-        flooded = False
-
-    result = {
-        "Duty_W": Q_total,
-        "Overall_U_W_m2K": (U_heat + U_boil + U_super) / max(1, sum([1 if x>0 else 0 for x in (U_heat, U_boil, U_super)])),
-        "Area_heat_m2": A_heat,
-        "Area_boil_m2": A_boil,
-        "Area_super_m2": A_super,
-        "A_total_m2": A_total,
-        "N_tubes": N_tubes,
-        "tube_length_m": tube_length,
-        "bundle_diameter_m": bundle_diam,
-        "shell_ID_m": shell_ID,
-        "deltaP_shell_Pa": deltaP_shell,
-        "flooding_risk": flooded,
-        "LMTD_zones_K": {"heating": LMTD_heat, "boiling": LMTD_boil, "superheat": LMTD_super},
-        "U_zones_W_m2K": {"heating": U_heat, "boiling": U_boil, "superheat": U_super}
-    }
-
+def design_reboiler(hx: HeatExchanger, **kwargs) -> Dict[str, Any]:
+    """Backward-compatible design entrypoint for reboiler mode."""
+    if isinstance(hx, ShellAndTube):
+        hx.mode = "reboiler"
+        return hx._design_shelltube(**kwargs)
+    tmp = Reboiler(name=getattr(hx, "name", "Reboiler"))
+    tmp.inlets["hot_in"] = getattr(hx, "hot_in", None)
+    tmp.inlets["cold_in"] = getattr(hx, "cold_in", None)
+    tmp.outlets["hot_out"] = getattr(hx, "hot_out", None)
+    tmp.outlets["cold_out"] = getattr(hx, "cold_out", None)
+    tmp._collect_base_data()
+    result = tmp._design_shelltube(**kwargs)
     hx.design_results = result
     return result

--- a/processpi/equipment/heatexchangers/mechanical/shell_tube.py
+++ b/processpi/equipment/heatexchangers/mechanical/shell_tube.py
@@ -18,7 +18,7 @@ Notes:
 
 import math
 from typing import Dict, Any, Optional, Tuple, List, Union
-from ....units import Diameter, Length, Pressure, ThermalConductivity, Variable
+from ....units import Diameter, Length, Pressure, ThermalConductivity, Variable, Temperature
 from ....streams.material import MaterialStream
 from ..base import HeatExchanger
 
@@ -50,6 +50,155 @@ _HEADER_KS = {
     "entrance": 0.5,
     "exit": 1.0
 }
+
+
+class ShellAndTube(HeatExchanger):
+    """Unified shell-and-tube exchanger with mode-based operation."""
+
+    _ALLOWED_MODES = {"sensible", "condenser", "reboiler", "evaporator"}
+
+    def __init__(self, name: str = "ShellAndTube", mode: str = "sensible", **kwargs):
+        super().__init__(name=name, **kwargs)
+        mode_norm = (mode or "sensible").lower().strip()
+        if mode_norm not in self._ALLOWED_MODES:
+            raise ValueError(f"Unsupported mode '{mode}'. Allowed: {sorted(self._ALLOWED_MODES)}")
+        self.mode = mode_norm
+        self.inlets = {"hot_in": None, "cold_in": None}
+        self.outlets = {"hot_out": None, "cold_out": None}
+        self.results: Dict[str, Any] = {}
+        self._design_kwargs: Dict[str, Any] = {}
+
+    @property
+    def hot_in(self) -> Optional[MaterialStream]:
+        return self.inlets["hot_in"]
+
+    @hot_in.setter
+    def hot_in(self, stream: MaterialStream):
+        self.inlets["hot_in"] = stream
+
+    @property
+    def cold_in(self) -> Optional[MaterialStream]:
+        return self.inlets["cold_in"]
+
+    @cold_in.setter
+    def cold_in(self, stream: MaterialStream):
+        self.inlets["cold_in"] = stream
+
+    @property
+    def hot_out(self) -> Optional[MaterialStream]:
+        return self.outlets["hot_out"]
+
+    @hot_out.setter
+    def hot_out(self, stream: MaterialStream):
+        self.outlets["hot_out"] = stream
+
+    @property
+    def cold_out(self) -> Optional[MaterialStream]:
+        return self.outlets["cold_out"]
+
+    @cold_out.setter
+    def cold_out(self, stream: MaterialStream):
+        self.outlets["cold_out"] = stream
+
+    def connect_inlet(self, port: str, stream: MaterialStream) -> None:
+        if port not in self.inlets:
+            raise ValueError(f"Invalid inlet port '{port}'. Expected one of: {list(self.inlets.keys())}")
+        self.inlets[port] = stream
+
+    def connect_outlet(self, port: str, stream: MaterialStream) -> None:
+        if port not in self.outlets:
+            raise ValueError(f"Invalid outlet port '{port}'. Expected one of: {list(self.outlets.keys())}")
+        self.outlets[port] = stream
+
+    def _design_shelltube(self, **kwargs) -> Dict[str, Any]:
+        return _design_shelltube_impl(self, **kwargs)
+
+    def _safe_enthalpy(self, component, temperature_k: float, fallback: float) -> float:
+        try:
+            val = component.enthalpy(Temperature(temperature_k, "K"))
+        except Exception:
+            try:
+                val = component.enthalpy(temperature_k)
+            except Exception:
+                return fallback
+        if hasattr(val, "to"):
+            try:
+                return float(val.to("J/kg").value)
+            except Exception:
+                return float(getattr(val, "value", fallback))
+        return float(val) if isinstance(val, (int, float)) else fallback
+
+    def _collect_base_data(self) -> None:
+        hot_in = self.inlets["hot_in"]
+        cold_in = self.inlets["cold_in"]
+        hot_out = self.outlets["hot_out"]
+        cold_out = self.outlets["cold_out"]
+
+        if any(s is None for s in [hot_in, cold_in, hot_out, cold_out]):
+            raise ValueError("All inlet and outlet streams must be connected before simulation.")
+
+        Th_in = hot_in.temperature.to("K").value if hasattr(hot_in.temperature, "to") else float(hot_in.temperature)
+        Th_out = hot_out.temperature.to("K").value if hasattr(hot_out.temperature, "to") else float(hot_out.temperature)
+        Tc_in = cold_in.temperature.to("K").value if hasattr(cold_in.temperature, "to") else float(cold_in.temperature)
+        Tc_out = cold_out.temperature.to("K").value if hasattr(cold_out.temperature, "to") else float(cold_out.temperature)
+
+        hot_mdot = hot_in.mass_flow() if callable(getattr(hot_in, "mass_flow", None)) else hot_in.mass_flow
+        cold_mdot = cold_in.mass_flow() if callable(getattr(cold_in, "mass_flow", None)) else cold_in.mass_flow
+        m_hot = hot_mdot.to("kg/s").value if hasattr(hot_mdot, "to") else float(hot_mdot)
+        m_cold = cold_mdot.to("kg/s").value if hasattr(cold_mdot, "to") else float(cold_mdot)
+
+        T_hot_mean = 0.5 * (Th_in + Th_out)
+        T_cold_mean = 0.5 * (Tc_in + Tc_out)
+
+        try:
+            cp_hot_obj = hot_in.component.specific_heat(Temperature(T_hot_mean, "K"))
+        except TypeError:
+            cp_hot_obj = hot_in.component.specific_heat()
+        try:
+            cp_cold_obj = cold_in.component.specific_heat(Temperature(T_cold_mean, "K"))
+        except TypeError:
+            cp_cold_obj = cold_in.component.specific_heat()
+        cp_hot = cp_hot_obj.to("J/kgK").value if hasattr(cp_hot_obj, "to") else float(cp_hot_obj)
+        cp_cold = cp_cold_obj.to("J/kgK").value if hasattr(cp_cold_obj, "to") else float(cp_cold_obj)
+
+        self.simulated_params = {
+            "Hot in Temp": Th_in,
+            "Hot out Temp": Th_out,
+            "Cold in Temp": Tc_in,
+            "Cold out Temp": Tc_out,
+            "m_hot": m_hot,
+            "m_cold": m_cold,
+            "cP_hot": cp_hot,
+            "cP_cold": cp_cold,
+            "mode": self.mode,
+        }
+
+        if self.mode in {"condenser", "reboiler", "evaporator"}:
+            if self.mode == "condenser":
+                h_in = self._safe_enthalpy(hot_in.component, Th_in, fallback=cp_hot * Th_in)
+                h_out = self._safe_enthalpy(hot_out.component, Th_out, fallback=cp_hot * Th_out)
+                q_duty = abs(m_hot * (h_in - h_out))
+            else:
+                h_in = self._safe_enthalpy(cold_in.component, Tc_in, fallback=cp_cold * Tc_in)
+                h_out = self._safe_enthalpy(cold_out.component, Tc_out, fallback=cp_cold * Tc_out)
+                q_duty = abs(m_cold * (h_out - h_in))
+            self.simulated_params["Q_duty"] = q_duty
+
+        for key, val in self.simulated_params.items():
+            if val is None:
+                raise ValueError(f"Missing parameter: {key}")
+
+    def simulate(self, **kwargs) -> Dict[str, Any]:
+        self._collect_base_data()
+        if kwargs:
+            self._design_kwargs.update(kwargs)
+        self.results = self._design_shelltube(**self._design_kwargs)
+        self.design_results = self.results
+        return self.results
+
+
+# backward-compatible alias
+ShellAndTubeHeatExchanger = ShellAndTube
 
 # -------------------------------------------------------------------------
 # Small utilities
@@ -376,7 +525,7 @@ def _epsilon_from_arrangement(arr: str, NTU: float, C: float) -> float:
 # -------------------------------------------------------------------------
 # Top-level design function using Bell-Delaware, packing, header design, mechanical summary
 # -------------------------------------------------------------------------
-def design_shelltube(
+def _design_shelltube_impl(
     hx: HeatExchanger,
     *,
     tube_nominal: Optional[Diameter] = None,
@@ -415,7 +564,11 @@ def design_shelltube(
 
     Q_hot = m_hot * cp_hot * (Th_in - Th_out)
     Q_cold = m_cold * cp_cold * (Tc_out - Tc_in)
-    Q = 0.5 * (Q_hot + Q_cold) if abs(Q_hot)>0 and abs(Q_cold)>0 else (Q_hot if abs(Q_hot)>0 else Q_cold)
+    Q_override = parms.get("Q_duty")
+    if Q_override is not None:
+        Q = abs(_val(Q_override, "Q_duty"))
+    else:
+        Q = 0.5 * (Q_hot + Q_cold) if abs(Q_hot)>0 and abs(Q_cold)>0 else (Q_hot if abs(Q_hot)>0 else Q_cold)
 
     wall_k_val = wall_k.value if hasattr(wall_k, "value") else float(wall_k)
     target_dp_t_val = target_dp_tube.to("Pa").value if target_dp_tube else None
@@ -684,3 +837,16 @@ def design_shelltube(
 
     hx.design_results = best
     return best
+
+
+def design_shelltube(
+    hx: HeatExchanger,
+    **kwargs
+) -> Dict[str, Any]:
+    """
+    Backward-compatible functional API.
+    Delegates to class method when available.
+    """
+    if hasattr(hx, "_design_shelltube"):
+        return hx._design_shelltube(**kwargs)
+    return _design_shelltube_impl(hx, **kwargs)


### PR DESCRIPTION
### Motivation
- Unify and modernize the mechanical heat-exchanger design code to a consistent object-oriented API and reduce duplicated compatibility logic across condenser/evaporator/reboiler modules.
- Provide a constraint-aware optimizer for double-pipe designs and make design entrypoints backward-compatible with existing functional APIs.
- Improve robustness of parameter extraction, unit handling and simulation interfaces for downstream tooling.

### Description
- Introduces `ShellAndTube` class (and aliases `ShellAndTubeHeatExchanger`) that centralizes shell-and-tube behavior, adds `simulate()` and `_collect_base_data()` to populate `simulated_params`, and exposes `hot_in`/`cold_in`/`hot_out`/`cold_out` ports.
- Replaces large procedural condenser/evaporator/reboiler modules with lightweight compatibility modules that instantiate `ShellAndTube` in the appropriate `mode` and expose `design_condenser`, `design_evaporator`, and `design_reboiler` wrappers; also adds `Condenser`, `Evaporator`, `Reboiler` classes and backward-compatible aliases.
- Reworks double-pipe design into `HXSolver`, `HXOptimizer`, and `AdaptiveHXOptimizer` with `DesignConstraints` for constraint validation and stepwise relaxation, and exposes these from the mechanical package.
- Refactors `shell_tube` implementation into `_design_shelltube_impl` (detailed Bell-Delaware-based design) and provides `design_shelltube` wrapper to call the instance method when present; adds improved unit extraction, enthalpy handling, and Q duty support.
- Updates package exports in `__init__.py` so the new classes and optimizer components are available at `processpi.equipment.heatexchangers` and `processpi.equipment.heatexchangers.mechanical`.

### Testing
- Ran import and smoke tests for the heat exchanger package and the mechanical design modules using `pytest -q processpi/equipment/heatexchangers`; the test run completed successfully with all tests passing.
- Performed basic simulation-style checks by instantiating `ShellAndTube`, connecting streams, calling `simulate()` and calling the backward-compatible `design_*` wrappers; these checks returned design dictionaries and attached `design_results` to the HX instances.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d769de3b348326b2042ffde9ab1ac3)