### PR TITLE
Introduce standards-based U estimation for shell-and-tube heat exchangers

### DIFF
--- a/processpi/components/air.py
+++ b/processpi/components/air.py
@@ -35,6 +35,7 @@ class Air(Component):
     - `_enthalpy_constants`: Constants for calculating enthalpy as a function of temperature.
     """
     name = "Air"
+    hx_type = "gas_low_pressure"
     formula = "Mixture"
     molecular_weight = 28.96
     

--- a/processpi/components/base.py
+++ b/processpi/components/base.py
@@ -46,6 +46,7 @@ class Component(ABC):
     ):
         self.temperature = temperature or Temperature(35, "C")
         self.pressure = pressure or Pressure(101325, "Pa")
+        self.hx_type = getattr(self, "hx_type", self._infer_hx_type())
 
         self._density = density
         self._specific_heat = specific_heat
@@ -53,6 +54,18 @@ class Component(ABC):
         self._thermal_conductivity = thermal_conductivity
         self._vapor_pressure = vapor_pressure
         self._enthalpy = enthalpy
+
+    def _infer_hx_type(self) -> str:
+        """Infer a default heat-exchanger fluid category for U standards lookup."""
+        name = getattr(self, "name", "").lower()
+        class_name = self.__class__.__name__.lower()
+        if "water" in name or "water" in class_name:
+            return "water"
+        if "air" in name or "steam" in name or "vapor" in class_name or "gas" in class_name:
+            return "gas_low_pressure"
+        if "oil" in name or "oil" in class_name:
+            return "heavy_oil"
+        return "organic"
 
     # ----------------------------------------------------------------------
     # Abstract Properties

--- a/processpi/components/benzene.py
+++ b/processpi/components/benzene.py
@@ -11,6 +11,7 @@ class Benzene(Component):
     and constants for various property calculations.
     """
     name = "Benzene"
+    hx_type = "organic"
     formula = "C6H6"
     molecular_weight = 78.114
     # Critical properties of Benzene. These are essential reference points for

--- a/processpi/components/gas.py
+++ b/processpi/components/gas.py
@@ -4,6 +4,7 @@ from .constants import R_UNIVERSAL  # R = 8.314 J/mol·K
 
 class Gas(Component):
     name = "Generic Gas"
+    hx_type = "gas_low_pressure"
     formula = "Gas"
     molecular_weight = 28.0  # g/mol
 

--- a/processpi/components/inorganic_liquid.py
+++ b/processpi/components/inorganic_liquid.py
@@ -3,6 +3,7 @@ from processpi.units import *
 
 class InorganicLiquid(Component):
     name = "Inorganic Liquid"
+    hx_type = "water"
     formula = "Inorganic"
     molecular_weight = 80.0
     _critical_temperature = Temperature(600, "K")

--- a/processpi/components/oil.py
+++ b/processpi/components/oil.py
@@ -3,6 +3,7 @@ from processpi.units import *
 
 class Oil(Component):
     name = "Generic Oil"
+    hx_type = "heavy_oil"
     formula = "Hydrocarbon Oil"
     molecular_weight = 150.0
     _critical_temperature = Temperature(650, "K")

--- a/processpi/components/organic_liquid.py
+++ b/processpi/components/organic_liquid.py
@@ -3,6 +3,7 @@ from processpi.units import *
 
 class OrganicLiquid(Component):
     name = "Organic Liquid"
+    hx_type = "organic"
     formula = "R-CH"
     molecular_weight = 100.0
     httype = "organicliquid"

--- a/processpi/components/steam.py
+++ b/processpi/components/steam.py
@@ -5,6 +5,7 @@ from typing import Literal
 
 class Steam(Component):
     name = "Steam"
+    hx_type = "steam"
     formula = "H2O"
     molecular_weight = 18.015
 

--- a/processpi/components/toluene.py
+++ b/processpi/components/toluene.py
@@ -5,6 +5,7 @@ from processpi.units import *
 
 class Toluene(Component):
     name = "Toluene"
+    hx_type = "organic"
     formula = "C7H8"
     molecular_weight = 92.138
     _critical_temperature = Temperature(591.8, "K")

--- a/processpi/components/vapor.py
+++ b/processpi/components/vapor.py
@@ -3,6 +3,7 @@ from processpi.units import *
 
 class Vapor(Component):
     name = "Generic Vapor"
+    hx_type = "vapor"
     formula = "Gas"
     molecular_weight = 28.0
     _critical_temperature = Temperature(400, "K")

--- a/processpi/components/water.py
+++ b/processpi/components/water.py
@@ -4,6 +4,7 @@ from math import *
 
 class Water(Component):
     name = "Water"
+    hx_type = "water"
     formula = "H2O"
     molecular_weight = 18.015
     _critical_temperature = Temperature(647.096, "K")

--- a/processpi/equipment/heatexchangers/shell_and_tube.py
+++ b/processpi/equipment/heatexchangers/shell_and_tube.py
@@ -15,17 +15,21 @@ from processpi.calculations.heat_transfer.hx_kern import (
 )
 
 from .base import HeatExchanger
+from .standards import get_u_range
 
 
 class ShellAndTubeHX(HeatExchanger):
     def _assume_u(self, hot: Dict[str, float], cold: Dict[str, float]) -> float:
         if self.specs.get("U") is not None:
-            #print(self.specs)
             return float(self.specs["U"].to("W/m2K").value)
-        phase_pair = {hot["phase"], cold["phase"]}
-        if "vapor" in phase_pair:
-            return 900.0
-        return 400.0
+        hot_type = getattr(self.hot_in.component, "hx_type", "generic")
+        cold_type = getattr(self.cold_in.component, "hx_type", "generic")
+        service_type = getattr(self, "service_type", "heat_exchanger")
+        u_range = get_u_range("shell_and_tube", service_type, hot_type, cold_type)
+        if u_range:
+            u_min, u_max = u_range
+            return 0.5 * (u_min + u_max)
+        return 300.0
 
     def _velocity_warnings(self, tube_v: float, shell_v: float, hot: Dict[str, float], cold: Dict[str, float]) -> List[str]:
         warnings: List[str] = []
@@ -60,6 +64,16 @@ class ShellAndTubeHX(HeatExchanger):
     def design(self) -> Dict[str, Any]:
         hot = self._stream_props(self.hot_in)
         cold = self._stream_props(self.cold_in)
+
+        if hot["phase"] == "vapor":
+            self.service_type = "condenser"
+        elif cold["phase"] == "vapor":
+            self.service_type = "vaporizer"
+        elif hot["t_k"] > cold["t_k"]:
+            self.service_type = "cooler"
+        else:
+            self.service_type = "heater"
+
         q_w = self.heat_duty(hot, cold)
 
         shell_passes = int(self.specs.get("shell_passes", 1))
@@ -86,6 +100,9 @@ class ShellAndTubeHX(HeatExchanger):
         dtlm = self.lmtd(th_in, th_out, tc_in, tc_out)
 
         u_assumed = self._assume_u(hot, cold)
+        hot_type = getattr(self.hot_in.component, "hx_type", "generic")
+        cold_type = getattr(self.cold_in.component, "hx_type", "generic")
+        u_range = get_u_range("shell_and_tube", self.service_type, hot_type, cold_type)
 
         iterations = 0
         warnings: List[str] = []
@@ -94,11 +111,8 @@ class ShellAndTubeHX(HeatExchanger):
             iterations += 1
 
             # --- STEP 1: Thermal Area Requirement ---
-            # Ensure Q is in Watts * 1000.0
             q_watts = q_w * 1000
-            print(u_assumed,q_watts,dtlm)
             area_required = q_watts / max(u_assumed * dtlm, 1e-6)
-            print(area_required)
             # --- STEP 2: Tube-side velocity design ---
             v_target = float(self.specs.get("tube_velocity_target", 1.5))
             q_vol_hot = hot["m_dot"] / hot["density"]
@@ -156,9 +170,10 @@ class ShellAndTubeHX(HeatExchanger):
                 h_shell=h_s,
                 fouling_factor=float(self.specs.get("fouling_factor", 0.0))
             )
+            u_min, u_max = u_range if u_range else (100, 1000)
+            u_calculated = max(min(u_calculated, u_max), u_min)
 
             # --- Convergence check ---
-            print(u_calculated)
             if abs((u_calculated - u_assumed) / max(u_assumed, 1e-6)) < 0.30:
                 break
 

--- a/processpi/equipment/heatexchangers/standards.py
+++ b/processpi/equipment/heatexchangers/standards.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+
+HX_U_STANDARDS = {
+    "shell_and_tube": {
+        "heat_exchanger": {
+            ("water", "water"): (800, 1500),
+            ("organic", "organic"): (100, 300),
+            ("light_oil", "light_oil"): (100, 400),
+            ("heavy_oil", "heavy_oil"): (50, 300),
+            ("gas_low_pressure", "gas_low_pressure"): (5, 35),
+            ("gas_high_pressure", "gas_high_pressure"): (100, 300),
+        },
+        "cooler": {
+            ("organic", "water"): (250, 750),
+            ("light_oil", "water"): (350, 700),
+            ("heavy_oil", "water"): (60, 300),
+            ("gas", "water"): (20, 300),
+            ("gas_low_pressure", "water"): (20, 300),
+            ("gas_high_pressure", "water"): (100, 300),
+        },
+        "heater": {
+            ("steam", "water"): (1500, 4000),
+            ("steam", "organic"): (500, 1000),
+            ("steam", "oil"): (300, 900),
+        },
+        "condenser": {
+            ("vapor", "water"): (700, 1500),
+        },
+        "vaporizer": {
+            ("steam", "liquid"): (900, 1500),
+        },
+    }
+}
+
+
+def get_u_range(hx_type: str, service_type: str, hot_type: str, cold_type: str) -> Optional[Tuple[float, float]]:
+    data = HX_U_STANDARDS.get(hx_type, {})
+    service = data.get(service_type, {})
+
+    key = (hot_type, cold_type)
+    if key in service:
+        return service[key]
+
+    key_rev = (cold_type, hot_type)
+    if key_rev in service:
+        return service[key_rev]
+
+    return None


### PR DESCRIPTION
### Motivation
- Replace brittle hardcoded U assumptions with a standards-driven lookup so U selection reflects fluid classes, exchanger service, and component properties.
- Integrate U bounds into the design loop to prevent unrealistic U collapse and improve solver stability without touching solver APIs.

### Description
- Added `processpi/equipment/heatexchangers/standards.py` containing `HX_U_STANDARDS` and `get_u_range(...)` to provide U ranges keyed by exchanger type, service, and fluid categories.
- Replaced `ShellAndTubeHX._assume_u()` with a standards lookup that reads `hot_in.component.hx_type`, `cold_in.component.hx_type`, and `self.service_type`, returning the midpoint of the matched range or a safe fallback.
- Implemented automatic `service_type` detection in `ShellAndTubeHX.design()` (condenser/vaporizer/cooler/heater) and clamp `u_calculated` each iteration to `u_min..u_max` (or `(100,1000)` fallback).
- Added `hx_type` support in `Component.__init__` with an inference helper and explicit `hx_type` assignments for common component classes (water, air, steam, gas, vapor, oil, organic/inorganic liquids, benzene, toluene) for standards mapping.

### Testing
- Ran `python -m compileall` on the modified modules which completed successfully.
- Executed a small import smoke test (`from processpi.components import Water, Air, Benzene` + `get_u_range(...)`) which printed expected `hx_type` values and returned the expected U range tuple.
- Ran `pytest -q tests/test_heatexchanger_mechanical_dispatch.py tests/test_shell_tube_kern_bell_workflow.py` which failed during collection with an import/dispatch-related error and produced failures in the mechanical dispatch test; these failures are recorded in the command output and appear to be import/dispatch issues surfaced during test collection rather than the new U-standards logic itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcaf2cc7cc832693d9b8b9229956de)