### PR TITLE
Shell-and-tube: automated tube selection, expanded U-value standards, and DP/spec handling fixes

### DIFF
--- a/processpi/equipment/heatexchangers/shell_and_tube.py
+++ b/processpi/equipment/heatexchangers/shell_and_tube.py
@@ -3,19 +3,16 @@ from __future__ import annotations
 import math
 from typing import Any, Dict, List
 
-from processpi.calculations.fluids import FluidVelocity
 from processpi.calculations.heat_transfer.hx_kern import (
     ConvectiveH,
     DarcyDrop,
     DittusBoelter,
     KernShellNu,
     Reynolds,
-    ShellDiameterEstimate,
-    TubeCountFromArea,
 )
 
 from .base import HeatExchanger
-from .standards import get_u_range
+from .standards import get_u_range, select_tube_configuration
 
 
 class ShellAndTubeHX(HeatExchanger):
@@ -33,7 +30,7 @@ class ShellAndTubeHX(HeatExchanger):
 
     def _velocity_warnings(self, tube_v: float, shell_v: float, hot: Dict[str, float], cold: Dict[str, float]) -> List[str]:
         warnings: List[str] = []
-        tube_target = (1.5, 2.5) if (self.hot_in.component and getattr(self.hot_in.component, "name", "").lower() == "water") else (1.0, 2.0)
+        tube_target = (0.5, 1.0)
         if not (tube_target[0] <= tube_v <= tube_target[1]):
             warnings.append(f"Tube velocity {tube_v:.2f} m/s outside recommended {tube_target[0]}-{tube_target[1]} m/s")
 
@@ -78,10 +75,9 @@ class ShellAndTubeHX(HeatExchanger):
 
         shell_passes = int(self.specs.get("shell_passes", 1))
         tube_passes = int(self.specs.get("tube_passes", 2))
-        tube_od = float(self.specs.get("tube_od", 0.019))
-        tube_id = float(self.specs.get("tube_id", 0.016))
-        tube_length = float(self.specs.get("tube_length", 5.0))
-        tube_pitch = float(self.specs.get("tube_pitch", 1.25 * tube_od))
+        tube_od = float(self.specs.get("tube_od")) if self.specs.get("tube_od") is not None else None
+        tube_id = float(self.specs.get("tube_id")) if self.specs.get("tube_id") is not None else None
+        tube_length = float(self.specs.get("tube_length")) if self.specs.get("tube_length") is not None else None
 
         # Temperatures
         th_in = hot["t_k"]
@@ -104,64 +100,56 @@ class ShellAndTubeHX(HeatExchanger):
         cold_type = getattr(self.cold_in.component, "hx_type", "generic")
         u_range = get_u_range("shell_and_tube", self.service_type, hot_type, cold_type)
 
+        q_watts = q_w * 1000
+        area_required = q_watts / max(u_assumed * dtlm, 1e-6)
+
+        tube_selection_warning = False
+        if tube_od is None or tube_id is None or tube_length is None:
+            tube_config = select_tube_configuration(
+                area_required,
+                hot["m_dot"],
+                hot["density"],
+            )
+            if tube_config:
+                tube_od = tube_config["tube_od"]
+                tube_id = tube_config["tube_id"]
+                tube_length = tube_config["tube_length"]
+                tube_count = tube_config["tube_count"]
+                if not (0.5 <= tube_config["velocity"] <= 1.0):
+                    tube_selection_warning = True
+            else:
+                tube_selection_warning = True
+                tube_od = 0.019
+                tube_id = 0.016
+                tube_length = 5.0
+                tube_count = 50
+        else:
+            area_per_tube_surface = math.pi * tube_od * tube_length
+            tube_count = max(math.ceil(area_required / max(area_per_tube_surface, 1e-12)), 1)
+            q_vol_hot_sel = hot["m_dot"] / max(hot["density"], 1e-12)
+            flow_area_sel = tube_count * math.pi * tube_id**2 / 4.0
+            tube_velocity_selected = q_vol_hot_sel / max(flow_area_sel, 1e-12)
+            if not (0.5 <= tube_velocity_selected <= 1.0):
+                tube_selection_warning = True
+
+        tube_pitch = float(self.specs.get("tube_pitch", 1.25 * tube_od))
+        shell_diameter = (tube_count * tube_pitch**2 / 0.785) ** 0.5
+        area = tube_count * math.pi * tube_od * tube_length
+
         iterations = 0
         warnings: List[str] = []
-        selected_geometry = None
+        if tube_selection_warning:
+            warnings.append("Tube velocity not within preferred range, adjusting tube size")
+
         while iterations < 25:
             iterations += 1
 
-            # --- STEP 1: Thermal Area Requirement ---
-            q_watts = q_w * 1000
-            print(u_assumed)
+            # --- STEP 1: Thermal Area Requirement (geometry frozen) ---
             area_required = q_watts / max(u_assumed * dtlm, 1e-6)
-
-            # --- STEP 2: Tube-side velocity design ---
-            v_target = float(self.specs.get("tube_velocity_target", 1.5))
             q_vol_hot = hot["m_dot"] / hot["density"]
             q_vol_cold = cold["m_dot"] / cold["density"]
 
-            flow_area_required = q_vol_hot / max(v_target, 1e-6)
             area_per_tube_flow = math.pi * tube_id**2 / 4.0
-
-            tube_count_velocity = int(flow_area_required / max(area_per_tube_flow, 1e-12) * tube_passes)
-
-            # --- STEP 3: Thermal tube requirement ---
-            area_per_tube_surface = math.pi * tube_od * tube_length
-            tube_count_thermal = math.ceil(area_required / max(area_per_tube_surface, 1e-12))
-
-            # --- FINAL tube count ---
-            from .standards import select_standard_exchanger
-            
-            # --- STEP 3: preliminary tube count ---
-            tube_count_calc = max(tube_count_velocity, tube_count_thermal, 10)
-            
-            # --- STEP 4: select standard exchanger ---
-            # --- FIX: Freeze geometry after first selection ---
-            if selected_geometry is None:
-                selected_geometry = select_standard_exchanger(
-                    area_required,
-                    tube_length,
-                    tube_passes,
-                    hot["m_dot"],
-                    hot["density"],
-                    cold["m_dot"],
-                    cold["density"],
-                    tube_id
-                )
-            
-            selected = selected_geometry
-            
-            if selected:
-                tube_count = selected["n"]
-                shell_diameter = selected["Da"]
-                area = selected["AS"] * tube_length
-            else:
-                # fallback (rare)
-                tube_count = tube_count_calc
-                area = tube_count * math.pi * tube_od * tube_length
-                shell_diameter = math.sqrt(4 * area_required / math.pi)
-            print("AREA REQUIRED:", area_required)
-            print("SELECTED:", selected)
             baffle_spacing = float(
                 self.specs.get(
                     "baffle_spacing",
@@ -223,8 +211,17 @@ class ShellAndTubeHX(HeatExchanger):
         ).calculate().to("Pa").value
 
         # --- Limits ---
-        tube_limit = float(self.specs.get("tube_dp", self._dp_limit(hot)).to("Pa").value)
-        shell_limit = float(self.specs.get("shell_dp", self._dp_limit(cold)).to("Pa").value)
+        tube_limit_val = self.specs.get("tube_dp", self._dp_limit(hot))
+        if hasattr(tube_limit_val, "to"):
+            tube_limit = float(tube_limit_val.to("Pa").value)
+        else:
+            tube_limit = float(tube_limit_val)
+
+        shell_limit_val = self.specs.get("shell_dp", self._dp_limit(cold))
+        if hasattr(shell_limit_val, "to"):
+            shell_limit = float(shell_limit_val.to("Pa").value)
+        else:
+            shell_limit = float(shell_limit_val)
 
         if tube_dp > tube_limit:
             warnings.append(f"Tube-side pressure drop {tube_dp:.1f} Pa exceeds limit {tube_limit:.1f} Pa")
@@ -239,7 +236,7 @@ class ShellAndTubeHX(HeatExchanger):
             warnings.append("Heat transfer area insufficient")
 
         if area < area_required:
-            warnings.append("Selected standard exchanger undersized → next size required")
+            warnings.append("Selected tube geometry undersized; increase tube count or tube length")
 
         status = "OK" if (not warnings and iterations < 25) else "VIOLATION"
 

--- a/processpi/equipment/heatexchangers/standards.py
+++ b/processpi/equipment/heatexchangers/standards.py
@@ -13,6 +13,19 @@ HX_U_STANDARDS = {
             ("gas_low_pressure", "gas_low_pressure"): (5, 35),
             ("gas_high_pressure", "gas_high_pressure"): (100, 300),
             ("water","organic"): (250,800),
+            ("water", "light_oil"): (200, 600),
+            ("water", "heavy_oil"): (100, 350),
+            ("water", "gas_low_pressure"): (100, 350),
+            ("water", "gas_high_pressure"): (200, 500),
+            ("organic", "light_oil"): (120, 350),
+            ("organic", "heavy_oil"): (80, 280),
+            ("organic", "gas_low_pressure"): (40, 180),
+            ("organic", "gas_high_pressure"): (120, 300),
+            ("light_oil", "heavy_oil"): (80, 220),
+            ("light_oil", "gas_low_pressure"): (30, 140),
+            ("light_oil", "gas_high_pressure"): (100, 250),
+            ("heavy_oil", "gas_low_pressure"): (15, 90),
+            ("heavy_oil", "gas_high_pressure"): (60, 200),
             
         },
         "cooler": {
@@ -22,19 +35,40 @@ HX_U_STANDARDS = {
             ("gas", "water"): (20, 300),
             ("gas_low_pressure", "water"): (20, 300),
             ("gas_high_pressure", "water"): (100, 300),
+            ("water", "water"): (900, 1800),
+            ("organic", "organic"): (120, 320),
+            ("light_oil", "organic"): (150, 400),
+            ("heavy_oil", "organic"): (80, 250),
+            ("gas_low_pressure", "organic"): (25, 200),
+            ("gas_high_pressure", "organic"): (120, 350),
+            ("gas_low_pressure", "light_oil"): (20, 160),
+            ("gas_high_pressure", "light_oil"): (90, 280),
         },
         "heater": {
             ("steam", "water"): (1500, 4000),
             ("steam", "organic"): (500, 1000),
             ("steam", "oil"): (300, 900),
+            ("steam", "light_oil"): (350, 950),
+            ("steam", "heavy_oil"): (220, 700),
+            ("hot_oil", "water"): (250, 650),
+            ("hot_oil", "organic"): (180, 450),
         },
         "condenser": {
             ("vapor", "water"): (700, 1500),
             ("water", "water"): (1000, 2000),
             ("water", "organic"): (600,1000),
+            ("vapor", "organic"): (350, 900),
+            ("vapor", "light_oil"): (250, 750),
+            ("vapor", "heavy_oil"): (120, 450),
+            ("steam", "water"): (1500, 3500),
+            ("steam", "organic"): (700, 1800),
         },
         "vaporizer": {
             ("steam", "liquid"): (900, 1500),
+            ("steam", "water"): (1200, 3000),
+            ("steam", "organic"): (600, 1400),
+            ("steam", "light_oil"): (500, 1100),
+            ("hot_oil", "organic"): (250, 700),
         },
     }
 }
@@ -54,64 +88,47 @@ def get_u_range(hx_type: str, service_type: str, hot_type: str, cold_type: str) 
 
     return None
 
-# --- DIN 28184 STANDARD DATA ---
-DIN_SHELL_TUBE_STANDARD = [
-    {"DN": 150, "tube_passes": 2, "Da": 0.168, "n": 14, "AS": 1.1},
-    {"DN": 200, "tube_passes": 2, "Da": 0.219, "n": 26, "AS": 2.0},
-    {"DN": 250, "tube_passes": 2, "Da": 0.273, "n": 44, "AS": 3.5},
-    {"DN": 300, "tube_passes": 2, "Da": 0.324, "n": 66, "AS": 5.2},
-    {"DN": 350, "tube_passes": 2, "Da": 0.355, "n": 76, "AS": 6.0},
-    {"DN": 400, "tube_passes": 2, "Da": 0.406, "n": 106, "AS": 8.3},
-    {"DN": 500, "tube_passes": 2, "Da": 0.508, "n": 180, "AS": 14.1},
-    {"DN": 600, "tube_passes": 2, "Da": 0.600, "n": 258, "AS": 20.3},
-    {"DN": 700, "tube_passes": 2, "Da": 0.700, "n": 364, "AS": 28.6},
-    {"DN": 800, "tube_passes": 2, "Da": 0.800, "n": 484, "AS": 38.0},
-    {"DN": 900, "tube_passes": 2, "Da": 0.900, "n": 622, "AS": 48.9},
-    {"DN": 1000, "tube_passes": 2, "Da": 1.000, "n": 776, "AS": 61.0},
+TUBE_LENGTH_STANDARD = [
+    {"length": 0.5, "area": 10},
+    {"length": 1.0, "area": 20},
+    {"length": 2.5, "area": 40},
+    {"length": 3.0, "area": 60},
+    {"length": 4.0, "area": 80},
+    {"length": 5.0, "area": 100},
+    {"length": 6.0, "area": 120},
 ]
 
-def select_standard_exchanger(area_required, 
-                              hot_mdot , hot_density,
-                              cold_mdot, cold_density,
-                              tube_id = 25, tube_length = 3, tube_passes = 2 ):
+TUBE_DIAMETER_STANDARD = [
+    {"od": 0.012, "thickness": 0.001},
+    {"od": 0.016, "thickness": 0.0012},
+    {"od": 0.019, "thickness": 0.0015},
+    {"od": 0.025, "thickness": 0.002},
+    {"od": 0.032, "thickness": 0.0026},
+    {"od": 0.038, "thickness": 0.003},
+]
 
-    best = None
-    best_score = float("inf")
 
-    for item in DIN_SHELL_TUBE_STANDARD:
-        if item["tube_passes"] != tube_passes:
-            continue
+def select_tube_configuration(area_required, hot_mdot, hot_density):
+    for tube in TUBE_DIAMETER_STANDARD:
+        tube_od = tube["od"]
+        tube_id = tube_od - 2 * tube["thickness"]
 
-        tube_count = item["n"]
-        shell_diameter = item["Da"]
-        area_available = item["AS"] * tube_length
-        print("Area Avaliable :", area_available)
-        print("Area Required :", area_required)
-        # --- HARD FILTER: MUST satisfy area ---
-        if area_available > area_required:
-            break
+        for length_data in TUBE_LENGTH_STANDARD:
+            tube_length = length_data["length"]
 
-        # --- Tube velocity ---
-        area_per_tube = math.pi * tube_id**2 / 4
-        tube_flow_area = tube_count / tube_passes * area_per_tube
-        v_tube = (hot_mdot / hot_density) / max(tube_flow_area, 1e-12)
+            area_per_tube = math.pi * tube_od * tube_length
+            tube_count = math.ceil(area_required / max(area_per_tube, 1e-12))
 
-        # --- Shell velocity ---
-        shell_area = math.pi * shell_diameter**2 / 4
-        v_shell = (cold_mdot / cold_density) / max(shell_area, 1e-12)
+            flow_area = tube_count * (math.pi * tube_id**2 / 4)
+            v = (hot_mdot / hot_density) / max(flow_area, 1e-12)
 
-        # --- SCORING ---
-        velocity_penalty = (
-            abs(v_tube - 1.5) * 3 +
-            abs(v_shell - 0.5) * 2
-        )
+            if 0.5 <= v <= 1.5:
+                return {
+                    "tube_od": tube_od,
+                    "tube_id": tube_id,
+                    "tube_length": tube_length,
+                    "tube_count": tube_count,
+                    "velocity": v,
+                }
 
-        oversize_penalty = (area_available - area_required) / area_required
-
-        score = velocity_penalty + oversize_penalty
-
-        if score < best_score:
-            best_score = score
-            best = item
-        #print(best)
-    return best
+    return None


### PR DESCRIPTION
### Motivation

- Provide automatic tube geometry selection when tube dimensions are not supplied to avoid unsafe defaults and iterate fewer times. 
- Expand and refine standard overall heat transfer coefficient (`U`) ranges for more hot/cold service combinations. 
- Improve robustness of pressure-drop spec handling and velocity/warning logic to reflect more conservative tube velocities.

### Description

- Add `select_tube_configuration` and standard tables (`TUBE_DIAMETER_STANDARD`, `TUBE_LENGTH_STANDARD`) in `processpi.equipment.heatexchangers.standards` to choose tube OD, ID, length, count and estimated velocity for a required heat-transfer area. 
- Extend `HX_U_STANDARDS` entries with many additional fluid pair entries to improve `get_u_range` coverage. 
- In `processpi.equipment.heatexchangers.shell_and_tube`: compute `area_required` earlier and use `select_tube_configuration` when `tube_od`, `tube_id`, or `tube_length` are not provided, otherwise compute tube count from provided geometry; compute `tube_pitch`, `shell_diameter`, and `area` accordingly. 
- Adjust tube velocity target to a lower preferred range (`0.5–1.0` m/s) and add a warning flag when selected tube velocity is out of range; update velocity warning text and final undersized warning. 
- Make pressure-drop spec extraction robust to both numeric values and unit-wrapped objects by checking for a `.to` method before converting to Pa. 
- Remove unused imports and the old DIN `select_standard_exchanger` logic, freezing geometry after initial selection is no longer required because selection now occurs up-front.

### Testing

- Ran heat-exchanger related unit tests (`pytest tests/equipment/heatexchangers`) and targeted unit tests for `shell_and_tube` and `standards`; all tests passed. 
- Ran linters/static checks over modified modules; no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e088a7032883268b70d1f3a0604937)