### PR TITLE
Shell-and-tube HX: automated tube selection, velocity standards, and improved warnings/status handling

### DIFF
--- a/processpi/equipment/heatexchangers/shell_and_tube.py
+++ b/processpi/equipment/heatexchangers/shell_and_tube.py
@@ -3,19 +3,16 @@ from __future__ import annotations
 import math
 from typing import Any, Dict, List
 
-from processpi.calculations.fluids import FluidVelocity
 from processpi.calculations.heat_transfer.hx_kern import (
     ConvectiveH,
     DarcyDrop,
     DittusBoelter,
     KernShellNu,
     Reynolds,
-    ShellDiameterEstimate,
-    TubeCountFromArea,
 )
 
 from .base import HeatExchanger
-from .standards import get_u_range
+from .standards import get_u_range, get_velocity_range, select_tube_configuration
 
 
 class ShellAndTubeHX(HeatExchanger):
@@ -33,9 +30,15 @@ class ShellAndTubeHX(HeatExchanger):
 
     def _velocity_warnings(self, tube_v: float, shell_v: float, hot: Dict[str, float], cold: Dict[str, float]) -> List[str]:
         warnings: List[str] = []
-        tube_target = (1.5, 2.5) if (self.hot_in.component and getattr(self.hot_in.component, "name", "").lower() == "water") else (1.0, 2.0)
-        if not (tube_target[0] <= tube_v <= tube_target[1]):
-            warnings.append(f"Tube velocity {tube_v:.2f} m/s outside recommended {tube_target[0]}-{tube_target[1]} m/s")
+        v_min, v_max = get_velocity_range(self.hot_in.component)
+        if tube_v > v_max * 1.5:
+            warnings.append(f"High tube velocity {tube_v:.2f} m/s → erosion risk")
+        elif tube_v > v_max:
+            warnings.append(f"Tube velocity slightly high ({v_min}-{v_max} m/s recommended)")
+        elif tube_v < v_min * 0.5:
+            warnings.append(f"Low tube velocity {tube_v:.2f} m/s → fouling risk")
+        elif tube_v < v_min:
+            warnings.append(f"Tube velocity slightly low ({v_min}-{v_max} m/s recommended)")
 
         if cold["phase"] == "vapor":
             p = cold["p_bar"]
@@ -78,10 +81,9 @@ class ShellAndTubeHX(HeatExchanger):
 
         shell_passes = int(self.specs.get("shell_passes", 1))
         tube_passes = int(self.specs.get("tube_passes", 2))
-        tube_od = float(self.specs.get("tube_od", 0.019))
-        tube_id = float(self.specs.get("tube_id", 0.016))
-        tube_length = float(self.specs.get("tube_length", 5.0))
-        tube_pitch = float(self.specs.get("tube_pitch", 1.25 * tube_od))
+        tube_od = float(self.specs.get("tube_od")) if self.specs.get("tube_od") is not None else None
+        tube_id = float(self.specs.get("tube_id")) if self.specs.get("tube_id") is not None else None
+        tube_length = float(self.specs.get("tube_length")) if self.specs.get("tube_length") is not None else None
 
         # Temperatures
         th_in = hot["t_k"]
@@ -104,64 +106,76 @@ class ShellAndTubeHX(HeatExchanger):
         cold_type = getattr(self.cold_in.component, "hx_type", "generic")
         u_range = get_u_range("shell_and_tube", self.service_type, hot_type, cold_type)
 
+        q_watts = q_w * 1000
+        area_required = q_watts / max(u_assumed * dtlm, 1e-6)
+
+        tube_selection_warning = False
+        hot_v_min, hot_v_max = get_velocity_range(self.hot_in.component)
+        if tube_od is None or tube_id is None or tube_length is None:
+            tube_config = select_tube_configuration(
+                area_required,
+                {
+                    "m_dot": hot["m_dot"],
+                    "density": hot["density"],
+                    "component": self.hot_in.component,
+                },
+                {
+                    "m_dot": cold["m_dot"],
+                    "density": cold["density"],
+                    "component": self.cold_in.component,
+                },
+            )
+            if tube_config:
+                tube_od = tube_config["tube_od"]
+                tube_id = tube_config["tube_id"]
+                tube_length = tube_config["tube_length"]
+                tube_count = tube_config["tube_count"]
+                tube_velocity_selected = tube_config["velocity"]
+                if tube_config["velocity"] < hot_v_min or tube_config["velocity"] > hot_v_max:
+                    tube_selection_warning = True
+            else:
+                tube_selection_warning = True
+                tube_od = 0.019
+                tube_id = 0.016
+                tube_length = 5.0
+                tube_count = 50
+                q_vol_hot_sel = hot["m_dot"] / max(hot["density"], 1e-12)
+                flow_area_sel = tube_count * math.pi * tube_id**2 / 4.0
+                tube_velocity_selected = q_vol_hot_sel / max(flow_area_sel, 1e-12)
+        else:
+            area_per_tube_surface = math.pi * tube_od * tube_length
+            tube_count = max(math.ceil(area_required / max(area_per_tube_surface, 1e-12)), 1)
+            q_vol_hot_sel = hot["m_dot"] / max(hot["density"], 1e-12)
+            flow_area_sel = tube_count * math.pi * tube_id**2 / 4.0
+            tube_velocity_selected = q_vol_hot_sel / max(flow_area_sel, 1e-12)
+            if tube_velocity_selected < hot_v_min or tube_velocity_selected > hot_v_max:
+                tube_selection_warning = True
+
+        tube_pitch = float(self.specs.get("tube_pitch", 1.25 * tube_od))
+        shell_diameter = (tube_count * tube_pitch**2 / 0.785) ** 0.5
+        area = tube_count * math.pi * tube_od * tube_length
+
+        if tube_velocity_selected > hot_v_max:
+            tube_count = int(max(tube_count * 1.1, tube_count + 1))
+            shell_diameter = (tube_count * tube_pitch**2 / 0.785) ** 0.5
+            area = tube_count * math.pi * tube_od * tube_length
+
         iterations = 0
         warnings: List[str] = []
-        selected_geometry = None
+        if tube_selection_warning:
+            warnings.append(
+                f"Tube velocity slightly off recommended range ({hot_v_min}-{hot_v_max} m/s); selected best-scoring available geometry"
+            )
+
         while iterations < 25:
             iterations += 1
 
-            # --- STEP 1: Thermal Area Requirement ---
-            q_watts = q_w * 1000
-            print(u_assumed)
+            # --- STEP 1: Thermal Area Requirement (geometry frozen) ---
             area_required = q_watts / max(u_assumed * dtlm, 1e-6)
-
-            # --- STEP 2: Tube-side velocity design ---
-            v_target = float(self.specs.get("tube_velocity_target", 1.5))
             q_vol_hot = hot["m_dot"] / hot["density"]
             q_vol_cold = cold["m_dot"] / cold["density"]
 
-            flow_area_required = q_vol_hot / max(v_target, 1e-6)
             area_per_tube_flow = math.pi * tube_id**2 / 4.0
-
-            tube_count_velocity = int(flow_area_required / max(area_per_tube_flow, 1e-12) * tube_passes)
-
-            # --- STEP 3: Thermal tube requirement ---
-            area_per_tube_surface = math.pi * tube_od * tube_length
-            tube_count_thermal = math.ceil(area_required / max(area_per_tube_surface, 1e-12))
-
-            # --- FINAL tube count ---
-            from .standards import select_standard_exchanger
-            
-            # --- STEP 3: preliminary tube count ---
-            tube_count_calc = max(tube_count_velocity, tube_count_thermal, 10)
-            
-            # --- STEP 4: select standard exchanger ---
-            # --- FIX: Freeze geometry after first selection ---
-            if selected_geometry is None:
-                selected_geometry = select_standard_exchanger(
-                    area_required,
-                    tube_length,
-                    tube_passes,
-                    hot["m_dot"],
-                    hot["density"],
-                    cold["m_dot"],
-                    cold["density"],
-                    tube_id
-                )
-            
-            selected = selected_geometry
-            
-            if selected:
-                tube_count = selected["n"]
-                shell_diameter = selected["Da"]
-                area = selected["AS"] * tube_length
-            else:
-                # fallback (rare)
-                tube_count = tube_count_calc
-                area = tube_count * math.pi * tube_od * tube_length
-                shell_diameter = math.sqrt(4 * area_required / math.pi)
-            print("AREA REQUIRED:", area_required)
-            print("SELECTED:", selected)
             baffle_spacing = float(
                 self.specs.get(
                     "baffle_spacing",
@@ -223,8 +237,17 @@ class ShellAndTubeHX(HeatExchanger):
         ).calculate().to("Pa").value
 
         # --- Limits ---
-        tube_limit = float(self.specs.get("tube_dp", self._dp_limit(hot)).to("Pa").value)
-        shell_limit = float(self.specs.get("shell_dp", self._dp_limit(cold)).to("Pa").value)
+        tube_limit_val = self.specs.get("tube_dp", self._dp_limit(hot))
+        if hasattr(tube_limit_val, "to"):
+            tube_limit = float(tube_limit_val.to("Pa").value)
+        else:
+            tube_limit = float(tube_limit_val)
+
+        shell_limit_val = self.specs.get("shell_dp", self._dp_limit(cold))
+        if hasattr(shell_limit_val, "to"):
+            shell_limit = float(shell_limit_val.to("Pa").value)
+        else:
+            shell_limit = float(shell_limit_val)
 
         if tube_dp > tube_limit:
             warnings.append(f"Tube-side pressure drop {tube_dp:.1f} Pa exceeds limit {tube_limit:.1f} Pa")
@@ -234,14 +257,35 @@ class ShellAndTubeHX(HeatExchanger):
         # --- Velocity warnings ---
         warnings.extend(self._velocity_warnings(v_tube, v_shell, hot, cold))
 
-        # --- Thermal safety ---
-        if area < area_required:
-            warnings.append("Heat transfer area insufficient")
+        # --- Thermal safety and auto-improvement ---
+        if 0.9 * area_required <= area < area_required:
+            tube_length = min(tube_length * 1.25, 6.0)
+            area = tube_count * math.pi * tube_od * tube_length
 
-        if area < area_required:
-            warnings.append("Selected standard exchanger undersized → next size required")
+        if area < 0.9 * area_required:
+            warnings.append("Area significantly undersized — redesign required")
+        elif area < area_required:
+            warnings.append("Area slightly undersized — acceptable with margin")
 
-        status = "OK" if (not warnings and iterations < 25) else "VIOLATION"
+        critical: List[str] = []
+        advisory: List[str] = []
+        for w in warnings:
+            wl = w.lower()
+            if "pressure drop" in wl:
+                critical.append(w)
+            elif "significantly undersized" in wl:
+                critical.append(w)
+            elif "erosion risk" in wl:
+                critical.append(w)
+            else:
+                advisory.append(w)
+
+        if critical:
+            status = "VIOLATION"
+        elif advisory:
+            status = "WARNING"
+        else:
+            status = "OK"
 
         return {
             "hx_type": "shell_and_tube",

--- a/processpi/equipment/heatexchangers/standards.py
+++ b/processpi/equipment/heatexchangers/standards.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional, Tuple
 import math
+from processpi.pipelines.standards import RECOMMENDED_VELOCITIES
 
 HX_U_STANDARDS = {
     "shell_and_tube": {
@@ -13,6 +14,19 @@ HX_U_STANDARDS = {
             ("gas_low_pressure", "gas_low_pressure"): (5, 35),
             ("gas_high_pressure", "gas_high_pressure"): (100, 300),
             ("water","organic"): (250,800),
+            ("water", "light_oil"): (200, 600),
+            ("water", "heavy_oil"): (100, 350),
+            ("water", "gas_low_pressure"): (100, 350),
+            ("water", "gas_high_pressure"): (200, 500),
+            ("organic", "light_oil"): (120, 350),
+            ("organic", "heavy_oil"): (80, 280),
+            ("organic", "gas_low_pressure"): (40, 180),
+            ("organic", "gas_high_pressure"): (120, 300),
+            ("light_oil", "heavy_oil"): (80, 220),
+            ("light_oil", "gas_low_pressure"): (30, 140),
+            ("light_oil", "gas_high_pressure"): (100, 250),
+            ("heavy_oil", "gas_low_pressure"): (15, 90),
+            ("heavy_oil", "gas_high_pressure"): (60, 200),
             
         },
         "cooler": {
@@ -22,19 +36,40 @@ HX_U_STANDARDS = {
             ("gas", "water"): (20, 300),
             ("gas_low_pressure", "water"): (20, 300),
             ("gas_high_pressure", "water"): (100, 300),
+            ("water", "water"): (900, 1800),
+            ("organic", "organic"): (120, 320),
+            ("light_oil", "organic"): (150, 400),
+            ("heavy_oil", "organic"): (80, 250),
+            ("gas_low_pressure", "organic"): (25, 200),
+            ("gas_high_pressure", "organic"): (120, 350),
+            ("gas_low_pressure", "light_oil"): (20, 160),
+            ("gas_high_pressure", "light_oil"): (90, 280),
         },
         "heater": {
             ("steam", "water"): (1500, 4000),
             ("steam", "organic"): (500, 1000),
             ("steam", "oil"): (300, 900),
+            ("steam", "light_oil"): (350, 950),
+            ("steam", "heavy_oil"): (220, 700),
+            ("hot_oil", "water"): (250, 650),
+            ("hot_oil", "organic"): (180, 450),
         },
         "condenser": {
             ("vapor", "water"): (700, 1500),
             ("water", "water"): (1000, 2000),
             ("water", "organic"): (600,1000),
+            ("vapor", "organic"): (350, 900),
+            ("vapor", "light_oil"): (250, 750),
+            ("vapor", "heavy_oil"): (120, 450),
+            ("steam", "water"): (1500, 3500),
+            ("steam", "organic"): (700, 1800),
         },
         "vaporizer": {
             ("steam", "liquid"): (900, 1500),
+            ("steam", "water"): (1200, 3000),
+            ("steam", "organic"): (600, 1400),
+            ("steam", "light_oil"): (500, 1100),
+            ("hot_oil", "organic"): (250, 700),
         },
     }
 }
@@ -54,64 +89,75 @@ def get_u_range(hx_type: str, service_type: str, hot_type: str, cold_type: str) 
 
     return None
 
-# --- DIN 28184 STANDARD DATA ---
-DIN_SHELL_TUBE_STANDARD = [
-    {"DN": 150, "tube_passes": 2, "Da": 0.168, "n": 14, "AS": 1.1},
-    {"DN": 200, "tube_passes": 2, "Da": 0.219, "n": 26, "AS": 2.0},
-    {"DN": 250, "tube_passes": 2, "Da": 0.273, "n": 44, "AS": 3.5},
-    {"DN": 300, "tube_passes": 2, "Da": 0.324, "n": 66, "AS": 5.2},
-    {"DN": 350, "tube_passes": 2, "Da": 0.355, "n": 76, "AS": 6.0},
-    {"DN": 400, "tube_passes": 2, "Da": 0.406, "n": 106, "AS": 8.3},
-    {"DN": 500, "tube_passes": 2, "Da": 0.508, "n": 180, "AS": 14.1},
-    {"DN": 600, "tube_passes": 2, "Da": 0.600, "n": 258, "AS": 20.3},
-    {"DN": 700, "tube_passes": 2, "Da": 0.700, "n": 364, "AS": 28.6},
-    {"DN": 800, "tube_passes": 2, "Da": 0.800, "n": 484, "AS": 38.0},
-    {"DN": 900, "tube_passes": 2, "Da": 0.900, "n": 622, "AS": 48.9},
-    {"DN": 1000, "tube_passes": 2, "Da": 1.000, "n": 776, "AS": 61.0},
+
+def get_velocity_range(component):
+    hx_type = getattr(component, "hx_type", None)
+
+    if hx_type and hx_type in RECOMMENDED_VELOCITIES:
+        return RECOMMENDED_VELOCITIES[hx_type]
+
+    name = getattr(component, "name", "").lower()
+    if name in RECOMMENDED_VELOCITIES:
+        return RECOMMENDED_VELOCITIES[name]
+
+    return (0.8, 2.5)
+
+TUBE_LENGTH_STANDARD = [
+    {"length": 0.5, "area": 10},
+    {"length": 1.0, "area": 20},
+    {"length": 2.5, "area": 40},
+    {"length": 3.0, "area": 60},
+    {"length": 4.0, "area": 80},
+    {"length": 5.0, "area": 100},
+    {"length": 6.0, "area": 120},
 ]
 
-def select_standard_exchanger(area_required, 
-                              hot_mdot , hot_density,
-                              cold_mdot, cold_density,
-                              tube_id = 25, tube_length = 3, tube_passes = 2 ):
+TUBE_DIAMETER_STANDARD = [
+    {"od": 0.012, "thickness": 0.001},
+    {"od": 0.016, "thickness": 0.0012},
+    {"od": 0.019, "thickness": 0.0015},
+    {"od": 0.025, "thickness": 0.002},
+    {"od": 0.032, "thickness": 0.0026},
+    {"od": 0.038, "thickness": 0.003},
+]
 
+
+def select_tube_configuration(area_required, hot, cold):
     best = None
     best_score = float("inf")
 
-    for item in DIN_SHELL_TUBE_STANDARD:
-        if item["tube_passes"] != tube_passes:
-            continue
+    hot_v_min, hot_v_max = get_velocity_range(hot["component"])
+    target_velocity = 0.5 * (hot_v_min + hot_v_max)
 
-        tube_count = item["n"]
-        shell_diameter = item["Da"]
-        area_available = item["AS"] * tube_length
-        print("Area Avaliable :", area_available)
-        print("Area Required :", area_required)
-        # --- HARD FILTER: MUST satisfy area ---
-        if area_available > area_required:
-            break
+    for tube in TUBE_DIAMETER_STANDARD:
+        tube_od = tube["od"]
+        tube_id = tube_od - 2 * tube["thickness"]
 
-        # --- Tube velocity ---
-        area_per_tube = math.pi * tube_id**2 / 4
-        tube_flow_area = tube_count / tube_passes * area_per_tube
-        v_tube = (hot_mdot / hot_density) / max(tube_flow_area, 1e-12)
+        for length_data in TUBE_LENGTH_STANDARD:
+            tube_length = length_data["length"]
 
-        # --- Shell velocity ---
-        shell_area = math.pi * shell_diameter**2 / 4
-        v_shell = (cold_mdot / cold_density) / max(shell_area, 1e-12)
+            area_per_tube = math.pi * tube_od * tube_length
+            tube_count = math.ceil(area_required / max(area_per_tube, 1e-12))
 
-        # --- SCORING ---
-        velocity_penalty = (
-            abs(v_tube - 1.5) * 3 +
-            abs(v_shell - 0.5) * 2
-        )
+            flow_area = tube_count * (math.pi * tube_id**2 / 4)
+            velocity = (hot["m_dot"] / hot["density"]) / max(flow_area, 1e-12)
+            total_area = tube_count * area_per_tube
 
-        oversize_penalty = (area_available - area_required) / area_required
+            area_penalty = abs((total_area - area_required) / max(area_required, 1e-12))
+            velocity_penalty = abs(velocity - target_velocity)
+            score = area_penalty * 2 + velocity_penalty
 
-        score = velocity_penalty + oversize_penalty
+            if score < best_score:
+                best_score = score
+                best = {
+                    "tube_od": tube_od,
+                    "tube_id": tube_id,
+                    "tube_length": tube_length,
+                    "tube_count": tube_count,
+                    "velocity": velocity,
+                    "area": total_area,
+                    "velocity_range": (hot_v_min, hot_v_max),
+                    "score": score,
+                }
 
-        if score < best_score:
-            best_score = score
-            best = item
-        #print(best)
     return best


### PR DESCRIPTION
### Motivation
- Provide automatic tube geometry selection when tube dimensions are not specified and base recommended velocity ranges on standardized recommendations. 
- Make velocity warnings and status detection more robust and actionable by distinguishing critical vs advisory items. 
- Handle pressure-drop spec values that may be unit-aware objects and add more realistic U-value and tube-sizing standards. 

### Description
- Enhanced `ShellAndTubeHX.design` to compute required area up-front, call `select_tube_configuration` when tube geometry is missing, and compute tube count/velocities from that selection while auto-adjusting if the selected tube velocity is high. 
- Reworked tube velocity warning logic to use `get_velocity_range` and produce graded messages (slightly low/high, low/high with risk language), and classify warnings into `critical` and `advisory` to determine `status` (`OK`, `WARNING`, `VIOLATION`). 
- Improved pressure-drop handling to accept either plain numeric values or unit-aware objects by checking for a `to` method before converting to Pa. 
- Extended `standards.py` with many new `HX_U_STANDARDS` entries, added `get_velocity_range`, `TUBE_LENGTH_STANDARD`, `TUBE_DIAMETER_STANDARD`, and a new `select_tube_configuration` routine that scores candidate geometries by area match and target velocity using `RECOMMENDED_VELOCITIES`. 

### Testing
- Ran the heat exchanger unit tests with `pytest processpi/equipment/heatexchangers -q` and the tests passed. 
- Ran the module-level lint and import checks and they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e088a7032883268b70d1f3a0604937)