### PR TITLE
Refactor shell-and-tube HX design: modularize calculations, improve geometry selection and standards

### DIFF
--- a/processpi/equipment/heatexchangers/shell_and_tube.py
+++ b/processpi/equipment/heatexchangers/shell_and_tube.py
@@ -1,21 +1,18 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
-from processpi.calculations.fluids import FluidVelocity
 from processpi.calculations.heat_transfer.hx_kern import (
     ConvectiveH,
     DarcyDrop,
     DittusBoelter,
     KernShellNu,
     Reynolds,
-    ShellDiameterEstimate,
-    TubeCountFromArea,
 )
 
 from .base import HeatExchanger
-from .standards import get_u_range
+from .standards import get_u_range, get_velocity_range, select_tube_configuration
 
 
 class ShellAndTubeHX(HeatExchanger):
@@ -31,20 +28,259 @@ class ShellAndTubeHX(HeatExchanger):
             return 0.5 * (u_min + u_max)
         return 300.0
 
-    def _velocity_warnings(self, tube_v: float, shell_v: float, hot: Dict[str, float], cold: Dict[str, float]) -> List[str]:
-        warnings: List[str] = []
-        tube_target = (1.5, 2.5) if (self.hot_in.component and getattr(self.hot_in.component, "name", "").lower() == "water") else (1.0, 2.0)
-        if not (tube_target[0] <= tube_v <= tube_target[1]):
-            warnings.append(f"Tube velocity {tube_v:.2f} m/s outside recommended {tube_target[0]}-{tube_target[1]} m/s")
+    def _validate_inputs(self, hot: Dict[str, float], cold: Dict[str, float]) -> None:
+        required = ["cp", "density", "viscosity", "k", "m_dot", "t_k"]
+        missing: List[str] = []
+        for side_name, props in (("hot", hot), ("cold", cold)):
+            for key in required:
+                val = props.get(key)
+                if val is None or val <= 0:
+                    missing.append(f"{side_name}.{key}")
+        if missing:
+            raise ValueError(f"Missing or invalid stream properties for shell-and-tube design: {', '.join(missing)}")
 
-        if cold["phase"] == "vapor":
-            p = cold["p_bar"]
-            target = (50, 70) if p < 1 else ((10, 30) if p <= 2 else (5, 10))
+    def _calculate_heat_duty(self, hot: Dict[str, float], cold: Dict[str, float]) -> Tuple[float, float, float]:
+        q_kw = self.heat_duty(hot, cold)
+        th_in = hot["t_k"]
+        tc_in = cold["t_k"]
+
+        if self.hot_out and self.hot_out.temperature:
+            th_out = self.hot_out.temperature.to("K").value
         else:
-            target = (0.3, 1.0)
-        if not (target[0] <= shell_v <= target[1]):
-            warnings.append(f"Shell velocity {shell_v:.2f} m/s outside recommended {target[0]}-{target[1]} m/s")
-        return warnings
+            th_out = th_in - q_kw / max(hot["m_dot"] * hot["cp"], 1e-9)
+
+        if self.cold_out and self.cold_out.temperature:
+            tc_out = self.cold_out.temperature.to("K").value
+        else:
+            tc_out = tc_in + q_kw / max(cold["m_dot"] * cold["cp"], 1e-9)
+
+        return q_kw * 1000.0, th_out, tc_out
+
+    def _calculate_lmtd(self, hot: Dict[str, float], cold: Dict[str, float], th_out: float, tc_out: float) -> float:
+        return self.lmtd(hot["t_k"], th_out, cold["t_k"], tc_out)
+
+    def _calculate_ft(self, hot: Dict[str, float], cold: Dict[str, float], th_out: float, tc_out: float,
+                      shell_passes: int, tube_passes: int) -> float:
+        dt1 = max(hot["t_k"] - tc_out, 1e-9)
+        dt2 = max(th_out - cold["t_k"], 1e-9)
+        r = max((hot["t_k"] - th_out) / max(tc_out - cold["t_k"], 1e-9), 1e-9)
+        p = (tc_out - cold["t_k"]) / max(hot["t_k"] - cold["t_k"], 1e-9)
+
+        # practical deterministic approximation for 1-2 and multi-pass correction behavior
+        pass_factor = 1.0 / max((shell_passes * tube_passes) ** 0.08, 1.0)
+        shape_factor = max(0.70, min(1.0, 1.0 - 0.08 * abs(r - 1.0) - 0.12 * max(p - 0.7, 0.0)))
+        dt_ratio_factor = max(0.75, min(1.0, min(dt1, dt2) / max(dt1, dt2)))
+        return max(0.65, min(1.0, pass_factor * shape_factor * dt_ratio_factor))
+
+    def _adjust_passes(self, hot: Dict[str, float], cold: Dict[str, float], th_out: float, tc_out: float) -> Tuple[int, int, float]:
+        candidates = [(1, 2), (1, 4), (2, 4), (2, 6)]
+        if self.specs.get("shell_passes") is not None or self.specs.get("tube_passes") is not None:
+            candidates = [(int(self.specs.get("shell_passes", 1)), int(self.specs.get("tube_passes", 2)))] + candidates
+
+        best = (1, 2, 0.0)
+        for shell_passes, tube_passes in candidates:
+            ft = self._calculate_ft(hot, cold, th_out, tc_out, shell_passes, tube_passes)
+            if ft > best[2]:
+                best = (shell_passes, tube_passes, ft)
+            if ft > 0.78:
+                return shell_passes, tube_passes, ft
+        return best
+
+    def _calculate_area(self, q_watts: float, u_assumed: float, cltd: float) -> float:
+        return q_watts / max(u_assumed * cltd, 1e-9)
+
+    def _round_tube_count_to_passes(self, tube_count: int, tube_passes: int) -> int:
+        return max(tube_passes, int(math.ceil(tube_count / max(tube_passes, 1)) * max(tube_passes, 1)))
+
+    def _select_tube_geometry(self, area_required: float, hot: Dict[str, float], cold: Dict[str, float],
+                              tube_passes: int) -> Dict[str, float]:
+        tube_od = float(self.specs.get("tube_od")) if self.specs.get("tube_od") is not None else None
+        tube_id = float(self.specs.get("tube_id")) if self.specs.get("tube_id") is not None else None
+        tube_length = float(self.specs.get("tube_length")) if self.specs.get("tube_length") is not None else None
+
+        if tube_od is None or tube_id is None or tube_length is None:
+            tube_config = select_tube_configuration(
+                area_required,
+                {"m_dot": hot["m_dot"], "density": hot["density"], "component": self.hot_in.component},
+                {"m_dot": cold["m_dot"], "density": cold["density"], "component": self.cold_in.component},
+            )
+            if tube_config:
+                tube_od = tube_config["tube_od"]
+                tube_id = tube_config["tube_id"]
+                tube_length = tube_config["tube_length"]
+                tube_count = tube_config["tube_count"]
+            else:
+                tube_od = 0.019
+                tube_id = 0.016
+                tube_length = 5.0
+                tube_count = 50
+        else:
+            area_per_tube = math.pi * tube_od * tube_length
+            tube_count = math.ceil(area_required / max(area_per_tube, 1e-12))
+
+        tube_count = self._round_tube_count_to_passes(tube_count, tube_passes)
+        tube_pitch = float(self.specs.get("tube_pitch", 1.25 * tube_od))
+        area = tube_count * math.pi * tube_od * tube_length
+        return {
+            "tube_od": tube_od,
+            "tube_id": tube_id,
+            "tube_length": tube_length,
+            "tube_count": tube_count,
+            "tube_pitch": tube_pitch,
+            "area": area,
+        }
+
+    def _calculate_bundle_diameter(self, tube_count: int) -> float:
+        k1 = float(self.specs.get("bundle_k1", 0.249))
+        n1 = float(self.specs.get("bundle_n1", 2.207))
+        return k1 * (max(tube_count, 1) ** (1.0 / max(n1, 1e-9)))
+
+    def _calculate_shell_diameter(self, bundle_diameter: float) -> float:
+        clearance = float(self.specs.get("bundle_clearance", max(0.02, 0.05 * bundle_diameter)))
+        return bundle_diameter + clearance
+
+    def _check_L_over_D(self, geometry: Dict[str, float], shell_diameter: float, tube_passes: int) -> Dict[str, float]:
+        ld = geometry["tube_length"] / max(shell_diameter, 1e-9)
+        if 5.0 <= ld <= 10.0:
+            return geometry
+
+        target_l = min(max(7.0 * shell_diameter, 0.5), 6.0)
+        if self.specs.get("tube_length") is None:
+            geometry["tube_length"] = target_l
+            area_per_tube = math.pi * geometry["tube_od"] * geometry["tube_length"]
+            geometry["tube_count"] = self._round_tube_count_to_passes(
+                math.ceil(geometry["area"] / max(area_per_tube, 1e-12)),
+                tube_passes,
+            )
+            geometry["area"] = geometry["tube_count"] * area_per_tube
+        return geometry
+
+    def _check_velocities(self, geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float],
+                          tube_passes: int, shell_diameter: float) -> Tuple[float, float, int]:
+        q_vol_hot = hot["m_dot"] / max(hot["density"], 1e-12)
+        q_vol_cold = cold["m_dot"] / max(cold["density"], 1e-12)
+
+        area_per_tube_flow = math.pi * geometry["tube_id"] ** 2 / 4.0
+        tube_flow = max(geometry["tube_count"] / max(tube_passes, 1) * area_per_tube_flow, 1e-12)
+        v_tube = q_vol_hot / tube_flow
+
+        v_min, v_max = get_velocity_range(self.hot_in.component)
+        if v_tube > v_max:
+            geometry["tube_count"] = self._round_tube_count_to_passes(int(math.ceil(geometry["tube_count"] * 1.1)), tube_passes)
+            tube_flow = max(geometry["tube_count"] / max(tube_passes, 1) * area_per_tube_flow, 1e-12)
+            v_tube = q_vol_hot / tube_flow
+
+        shell_flow = math.pi * shell_diameter ** 2 / 4.0
+        v_shell = q_vol_cold / max(shell_flow, 1e-12)
+        return v_tube, v_shell, geometry["tube_count"]
+
+    def _calculate_dimensionless(self, geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float],
+                                 v_tube: float, v_shell: float) -> Dict[str, float]:
+        re_t = Reynolds(
+            density=hot["density"],
+            velocity=v_tube,
+            diameter=geometry["tube_id"],
+            viscosity=hot["viscosity"],
+        ).calculate()
+        pr_t = max(hot["cp"] * hot["viscosity"] / max(hot["k"], 1e-12), 1e-12)
+        nu_t = DittusBoelter(reynolds=max(re_t, 1.0), prandtl=pr_t, n=0.4).calculate()
+
+        de_shell = max(1.27 * (geometry["tube_pitch"] ** 2 - 0.785 * geometry["tube_od"] ** 2) / geometry["tube_od"], 1e-6)
+        re_s = Reynolds(
+            density=cold["density"],
+            velocity=v_shell,
+            diameter=de_shell,
+            viscosity=cold["viscosity"],
+        ).calculate()
+        pr_s = max(cold["cp"] * cold["viscosity"] / max(cold["k"], 1e-12), 1e-12)
+        nu_s = KernShellNu(reynolds=max(re_s, 1.0), prandtl=pr_s).calculate()
+
+        return {"re_t": re_t, "pr_t": pr_t, "nu_t": nu_t, "de_shell": de_shell, "re_s": re_s, "pr_s": pr_s, "nu_s": nu_s}
+
+    def _calculate_htc(self, dimless: Dict[str, float], geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float]) -> Tuple[float, float]:
+        h_t = ConvectiveH(nusselt=dimless["nu_t"], k=hot["k"], diameter=geometry["tube_id"]).calculate().to("W/m2K").value
+        h_s = ConvectiveH(nusselt=dimless["nu_s"], k=cold["k"], diameter=dimless["de_shell"]).calculate().to("W/m2K").value
+        return h_t, h_s
+
+    def _calculate_overall_U(self, h_t: float, h_s: float, u_range: Tuple[float, float] | None) -> float:
+        u_calculated = self.overall_u(
+            h_tube=h_t,
+            h_shell=h_s,
+            fouling_factor=float(self.specs.get("fouling_factor", 0.0)),
+        )
+        u_min, u_max = u_range if u_range else (100.0, 1000.0)
+        return max(min(u_calculated, u_max), u_min)
+
+    def _iterate_U(self, q_watts: float, cltd: float, hot: Dict[str, float], cold: Dict[str, float],
+                   shell_passes: int, tube_passes: int, u_assumed: float,
+                   u_range: Tuple[float, float] | None) -> Dict[str, Any]:
+        state: Dict[str, Any] = {"iterations": 0, "u_assumed": u_assumed}
+        max_iter = 15
+
+        for i in range(1, max_iter + 1):
+            area_required = self._calculate_area(q_watts, state["u_assumed"], cltd)
+            geometry = self._select_tube_geometry(area_required, hot, cold, tube_passes)
+
+            bundle_diameter = self._calculate_bundle_diameter(geometry["tube_count"])
+            shell_diameter = self._calculate_shell_diameter(bundle_diameter)
+
+            geometry = self._check_L_over_D(geometry, shell_diameter, tube_passes)
+            bundle_diameter = self._calculate_bundle_diameter(geometry["tube_count"])
+            shell_diameter = self._calculate_shell_diameter(bundle_diameter)
+
+            v_tube, v_shell, tube_count = self._check_velocities(geometry, hot, cold, tube_passes, shell_diameter)
+            geometry["tube_count"] = tube_count
+            geometry["area"] = geometry["tube_count"] * math.pi * geometry["tube_od"] * geometry["tube_length"]
+
+            dimless = self._calculate_dimensionless(geometry, hot, cold, v_tube, v_shell)
+            h_t, h_s = self._calculate_htc(dimless, geometry, hot, cold)
+            u_calculated = self._calculate_overall_U(h_t, h_s, u_range)
+
+            state.update(
+                {
+                    "iterations": i,
+                    "area_required": area_required,
+                    "geometry": geometry,
+                    "bundle_diameter": bundle_diameter,
+                    "shell_diameter": shell_diameter,
+                    "v_tube": v_tube,
+                    "v_shell": v_shell,
+                    "dimless": dimless,
+                    "h_t": h_t,
+                    "h_s": h_s,
+                    "u_calculated": u_calculated,
+                }
+            )
+
+            if abs((u_calculated - state["u_assumed"]) / max(state["u_assumed"], 1e-9)) < 0.30:
+                break
+            state["u_assumed"] = u_calculated
+
+        return state
+
+    def _calculate_pressure_drop(self, hot: Dict[str, float], cold: Dict[str, float], shell_passes: int,
+                                 tube_passes: int, shell_diameter: float, tube_length: float,
+                                 tube_id: float, v_tube: float, v_shell: float) -> Tuple[float, float]:
+        f_tube = float(self.specs.get("f_tube", 0.005))
+        f_shell = float(self.specs.get("f_shell", 0.02))
+
+        tube_dp = DarcyDrop(
+            f=f_tube,
+            length=tube_length * tube_passes,
+            diameter=tube_id,
+            density=hot["density"],
+            velocity=v_tube,
+        ).calculate().to("Pa").value
+
+        shell_dp = DarcyDrop(
+            f=f_shell,
+            length=max(shell_passes, 1) * shell_diameter,
+            diameter=max(shell_diameter, 1e-6),
+            density=cold["density"],
+            velocity=v_shell,
+        ).calculate().to("Pa").value
+
+        return tube_dp, shell_dp
 
     def _dp_limit(self, props: Dict[str, float]) -> float:
         mu_cp = props["viscosity"] * 1000.0
@@ -61,9 +297,67 @@ class ShellAndTubeHX(HeatExchanger):
             return 60_000.0
         return 70_000.0
 
+    def _velocity_warnings(self, tube_v: float, shell_v: float, hot: Dict[str, float], cold: Dict[str, float]) -> List[str]:
+        warnings: List[str] = []
+        v_min, v_max = get_velocity_range(self.hot_in.component)
+        if tube_v > v_max * 1.5:
+            warnings.append(f"High tube velocity {tube_v:.2f} m/s → erosion risk")
+        elif tube_v > v_max:
+            warnings.append(f"Tube velocity slightly high ({v_min}-{v_max} m/s recommended)")
+        elif tube_v < v_min * 0.5:
+            warnings.append(f"Low tube velocity {tube_v:.2f} m/s → fouling risk")
+        elif tube_v < v_min:
+            warnings.append(f"Tube velocity slightly low ({v_min}-{v_max} m/s recommended)")
+
+        if cold["phase"] == "vapor":
+            p = cold["p_bar"]
+            target = (50, 70) if p < 1 else ((10, 30) if p <= 2 else (5, 10))
+        else:
+            target = (0.3, 1.0)
+        if not (target[0] <= shell_v <= target[1]):
+            warnings.append(f"Shell velocity {shell_v:.2f} m/s outside recommended {target[0]}-{target[1]} m/s")
+        return warnings
+
+    def _finalize_results(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        warnings = list(dict.fromkeys(payload["warnings"]))
+        critical: List[str] = []
+        advisory: List[str] = []
+        for w in warnings:
+            wl = w.lower()
+            if "pressure drop" in wl or "significantly undersized" in wl or "erosion risk" in wl:
+                critical.append(w)
+            else:
+                advisory.append(w)
+
+        if critical:
+            status = "VIOLATION"
+        elif advisory:
+            status = "WARNING"
+        else:
+            status = "OK"
+
+        return {
+            "hx_type": "shell_and_tube",
+            "Q": payload["q_watts"] / 1000.0,
+            "Area": payload["area"],
+            "U_assumed": payload["u_assumed"],
+            "U_calculated": payload["u_calculated"],
+            "LMTD": payload["lmtd"],
+            "tube_count": payload["geometry"]["tube_count"],
+            "shell_diameter": payload["shell_diameter"],
+            "tube_velocity": payload["v_tube"],
+            "shell_velocity": payload["v_shell"],
+            "tube_dp": payload["tube_dp"],
+            "shell_dp": payload["shell_dp"],
+            "iterations": payload["iterations"],
+            "status": status,
+            "warnings": warnings,
+        }
+
     def design(self) -> Dict[str, Any]:
         hot = self._stream_props(self.hot_in)
         cold = self._stream_props(self.cold_in)
+        self._validate_inputs(hot, cold)
 
         if hot["phase"] == "vapor":
             self.service_type = "condenser"
@@ -74,189 +368,60 @@ class ShellAndTubeHX(HeatExchanger):
         else:
             self.service_type = "heater"
 
-        q_w = self.heat_duty(hot, cold)
+        q_watts, th_out, tc_out = self._calculate_heat_duty(hot, cold)
+        lmtd = self._calculate_lmtd(hot, cold, th_out, tc_out)
 
-        shell_passes = int(self.specs.get("shell_passes", 1))
-        tube_passes = int(self.specs.get("tube_passes", 2))
-        tube_od = float(self.specs.get("tube_od", 0.019))
-        tube_id = float(self.specs.get("tube_id", 0.016))
-        tube_length = float(self.specs.get("tube_length", 5.0))
-        tube_pitch = float(self.specs.get("tube_pitch", 1.25 * tube_od))
-
-        # Temperatures
-        th_in = hot["t_k"]
-        tc_in = cold["t_k"]
-
-        if self.hot_out and self.hot_out.temperature:
-            th_out = self.hot_out.temperature.to("K").value
-        else:
-            th_out = th_in - q_w / max(hot["m_dot"] * hot["cp"], 1e-9)
-
-        if self.cold_out and self.cold_out.temperature:
-            tc_out = self.cold_out.temperature.to("K").value
-        else:
-            tc_out = tc_in + q_w / max(cold["m_dot"] * cold["cp"], 1e-9)
-
-        dtlm = self.lmtd(th_in, th_out, tc_in, tc_out)
+        shell_passes, tube_passes, ft = self._adjust_passes(hot, cold, th_out, tc_out)
+        cltd = max(ft * lmtd, 1e-9)
 
         u_assumed = self._assume_u(hot, cold)
         hot_type = getattr(self.hot_in.component, "hx_type", "generic")
         cold_type = getattr(self.cold_in.component, "hx_type", "generic")
         u_range = get_u_range("shell_and_tube", self.service_type, hot_type, cold_type)
 
-        iterations = 0
+        state = self._iterate_U(q_watts, cltd, hot, cold, shell_passes, tube_passes, u_assumed, u_range)
+
+        tube_dp, shell_dp = self._calculate_pressure_drop(
+            hot=hot,
+            cold=cold,
+            shell_passes=shell_passes,
+            tube_passes=tube_passes,
+            shell_diameter=state["shell_diameter"],
+            tube_length=state["geometry"]["tube_length"],
+            tube_id=state["geometry"]["tube_id"],
+            v_tube=state["v_tube"],
+            v_shell=state["v_shell"],
+        )
+
         warnings: List[str] = []
-        selected_geometry = None
-        while iterations < 25:
-            iterations += 1
-
-            # --- STEP 1: Thermal Area Requirement ---
-            q_watts = q_w * 1000
-            print(u_assumed)
-            area_required = q_watts / max(u_assumed * dtlm, 1e-6)
-
-            # --- STEP 2: Tube-side velocity design ---
-            v_target = float(self.specs.get("tube_velocity_target", 1.5))
-            q_vol_hot = hot["m_dot"] / hot["density"]
-            q_vol_cold = cold["m_dot"] / cold["density"]
-
-            flow_area_required = q_vol_hot / max(v_target, 1e-6)
-            area_per_tube_flow = math.pi * tube_id**2 / 4.0
-
-            tube_count_velocity = int(flow_area_required / max(area_per_tube_flow, 1e-12) * tube_passes)
-
-            # --- STEP 3: Thermal tube requirement ---
-            area_per_tube_surface = math.pi * tube_od * tube_length
-            tube_count_thermal = math.ceil(area_required / max(area_per_tube_surface, 1e-12))
-
-            # --- FINAL tube count ---
-            from .standards import select_standard_exchanger
-            
-            # --- STEP 3: preliminary tube count ---
-            tube_count_calc = max(tube_count_velocity, tube_count_thermal, 10)
-            
-            # --- STEP 4: select standard exchanger ---
-            # --- FIX: Freeze geometry after first selection ---
-            if selected_geometry is None:
-                selected_geometry = select_standard_exchanger(
-                    area_required,
-                    tube_length,
-                    tube_passes,
-                    hot["m_dot"],
-                    hot["density"],
-                    cold["m_dot"],
-                    cold["density"],
-                    tube_id
-                )
-            
-            selected = selected_geometry
-            
-            if selected:
-                tube_count = selected["n"]
-                shell_diameter = selected["Da"]
-                area = selected["AS"] * tube_length
-            else:
-                # fallback (rare)
-                tube_count = tube_count_calc
-                area = tube_count * math.pi * tube_od * tube_length
-                shell_diameter = math.sqrt(4 * area_required / math.pi)
-            print("AREA REQUIRED:", area_required)
-            print("SELECTED:", selected)
-            baffle_spacing = float(
-                self.specs.get(
-                    "baffle_spacing",
-                    max(0.3 * shell_diameter, min(0.5 * shell_diameter, 0.45 * shell_diameter))
-                )
-            )
-
-            # --- Velocities ---
-            tube_area_flow = max(tube_count / tube_passes * area_per_tube_flow, 1e-12)
-            v_tube = q_vol_hot / max(tube_area_flow, 1e-12)
-
-            shell_area_flow = math.pi * shell_diameter**2 / 4.0
-            v_shell = q_vol_cold / max(shell_area_flow, 1e-12)
-
-            # --- Heat transfer coefficients ---
-            re_t = Reynolds(density=hot["density"], velocity=v_tube, diameter=tube_id, viscosity=hot["viscosity"]).calculate()
-            pr_t = max(hot["cp"] * hot["viscosity"] / max(hot["k"], 1e-12), 1e-12)
-            nu_t = DittusBoelter(reynolds=max(re_t, 1.0), prandtl=pr_t, n=0.4).calculate()
-            h_t = ConvectiveH(nusselt=nu_t, k=hot["k"], diameter=tube_id).calculate().to("W/m2K").value
-
-            de_shell = max(1.27 * (tube_pitch**2 - 0.785 * tube_od**2) / tube_od, 1e-6)
-            re_s = Reynolds(density=cold["density"], velocity=v_shell, diameter=de_shell, viscosity=cold["viscosity"]).calculate()
-            pr_s = max(cold["cp"] * cold["viscosity"] / max(cold["k"], 1e-12), 1e-12)
-            nu_s = KernShellNu(reynolds=max(re_s, 1.0), prandtl=pr_s).calculate()
-            h_s = ConvectiveH(nusselt=nu_s, k=cold["k"], diameter=de_shell).calculate().to("W/m2K").value
-
-            u_calculated = self.overall_u(
-                h_tube=h_t,
-                h_shell=h_s,
-                fouling_factor=float(self.specs.get("fouling_factor", 0.0))
-            )
-            u_min, u_max = u_range if u_range else (100, 1000)
-            u_calculated = max(min(u_calculated, u_max), u_min)
-
-            # --- Convergence check ---
-            if abs((u_calculated - u_assumed) / max(u_assumed, 1e-6)) < 0.30:
-                break
-
-            u_assumed = u_calculated
-
-        # --- Pressure drop ---
-        f_tube = float(self.specs.get("f_tube", 0.005))
-        f_shell = float(self.specs.get("f_shell", 0.02))
-
-        tube_dp = DarcyDrop(
-            f=f_tube,
-            length=tube_length * tube_passes,
-            diameter=tube_id,
-            density=hot["density"],
-            velocity=v_tube
-        ).calculate().to("Pa").value
-
-        shell_dp = DarcyDrop(
-            f=f_shell,
-            length=max(shell_passes, 1) * shell_diameter,
-            diameter=max(shell_diameter, 1e-6),
-            density=cold["density"],
-            velocity=v_shell
-        ).calculate().to("Pa").value
-
-        # --- Limits ---
-        tube_limit = float(self.specs.get("tube_dp", self._dp_limit(hot)).to("Pa").value)
-        shell_limit = float(self.specs.get("shell_dp", self._dp_limit(cold)).to("Pa").value)
+        tube_limit_val = self.specs.get("tube_dp", self._dp_limit(hot))
+        shell_limit_val = self.specs.get("shell_dp", self._dp_limit(cold))
+        tube_limit = float(tube_limit_val.to("Pa").value) if hasattr(tube_limit_val, "to") else float(tube_limit_val)
+        shell_limit = float(shell_limit_val.to("Pa").value) if hasattr(shell_limit_val, "to") else float(shell_limit_val)
 
         if tube_dp > tube_limit:
             warnings.append(f"Tube-side pressure drop {tube_dp:.1f} Pa exceeds limit {tube_limit:.1f} Pa")
         if shell_dp > shell_limit:
             warnings.append(f"Shell-side pressure drop {shell_dp:.1f} Pa exceeds limit {shell_limit:.1f} Pa")
 
-        # --- Velocity warnings ---
-        warnings.extend(self._velocity_warnings(v_tube, v_shell, hot, cold))
+        warnings.extend(self._velocity_warnings(state["v_tube"], state["v_shell"], hot, cold))
 
-        # --- Thermal safety ---
-        if area < area_required:
-            warnings.append("Heat transfer area insufficient")
+        if state["geometry"]["area"] < 0.85 * state["area_required"]:
+            warnings.append("Area significantly undersized — redesign required")
+        elif state["geometry"]["area"] < state["area_required"]:
+            warnings.append("Area slightly undersized — acceptable with margin")
 
-        if area < area_required:
-            warnings.append("Selected standard exchanger undersized → next size required")
-
-        status = "OK" if (not warnings and iterations < 25) else "VIOLATION"
-
-        return {
-            "hx_type": "shell_and_tube",
-            "Q": q_w,
-            "Area": area,
-            "U_assumed": u_assumed,
-            "U_calculated": u_calculated,
-            "LMTD": dtlm,
-            "tube_count": tube_count,
-            "shell_diameter": shell_diameter,
-            "tube_velocity": v_tube,
-            "shell_velocity": v_shell,
+        payload = {
+            **state,
+            "warnings": warnings,
+            "q_watts": q_watts,
+            "lmtd": lmtd,
+            "cltd": cltd,
+            "ft": ft,
             "tube_dp": tube_dp,
             "shell_dp": shell_dp,
-            "iterations": iterations,
-            "status": status,
-            "warnings": warnings,
+            "area": state["geometry"]["area"],
+            "u_assumed": state["u_assumed"],
+            "u_calculated": state["u_calculated"],
         }
+        return self._finalize_results(payload)

--- a/processpi/equipment/heatexchangers/standards.py
+++ b/processpi/equipment/heatexchangers/standards.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional, Tuple
 import math
+from processpi.pipelines.standards import RECOMMENDED_VELOCITIES
 
 HX_U_STANDARDS = {
     "shell_and_tube": {
@@ -13,6 +14,19 @@ HX_U_STANDARDS = {
             ("gas_low_pressure", "gas_low_pressure"): (5, 35),
             ("gas_high_pressure", "gas_high_pressure"): (100, 300),
             ("water","organic"): (250,800),
+            ("water", "light_oil"): (200, 600),
+            ("water", "heavy_oil"): (100, 350),
+            ("water", "gas_low_pressure"): (100, 350),
+            ("water", "gas_high_pressure"): (200, 500),
+            ("organic", "light_oil"): (120, 350),
+            ("organic", "heavy_oil"): (80, 280),
+            ("organic", "gas_low_pressure"): (40, 180),
+            ("organic", "gas_high_pressure"): (120, 300),
+            ("light_oil", "heavy_oil"): (80, 220),
+            ("light_oil", "gas_low_pressure"): (30, 140),
+            ("light_oil", "gas_high_pressure"): (100, 250),
+            ("heavy_oil", "gas_low_pressure"): (15, 90),
+            ("heavy_oil", "gas_high_pressure"): (60, 200),
             
         },
         "cooler": {
@@ -22,19 +36,40 @@ HX_U_STANDARDS = {
             ("gas", "water"): (20, 300),
             ("gas_low_pressure", "water"): (20, 300),
             ("gas_high_pressure", "water"): (100, 300),
+            ("water", "water"): (900, 1800),
+            ("organic", "organic"): (120, 320),
+            ("light_oil", "organic"): (150, 400),
+            ("heavy_oil", "organic"): (80, 250),
+            ("gas_low_pressure", "organic"): (25, 200),
+            ("gas_high_pressure", "organic"): (120, 350),
+            ("gas_low_pressure", "light_oil"): (20, 160),
+            ("gas_high_pressure", "light_oil"): (90, 280),
         },
         "heater": {
             ("steam", "water"): (1500, 4000),
             ("steam", "organic"): (500, 1000),
             ("steam", "oil"): (300, 900),
+            ("steam", "light_oil"): (350, 950),
+            ("steam", "heavy_oil"): (220, 700),
+            ("hot_oil", "water"): (250, 650),
+            ("hot_oil", "organic"): (180, 450),
         },
         "condenser": {
             ("vapor", "water"): (700, 1500),
             ("water", "water"): (1000, 2000),
             ("water", "organic"): (600,1000),
+            ("vapor", "organic"): (350, 900),
+            ("vapor", "light_oil"): (250, 750),
+            ("vapor", "heavy_oil"): (120, 450),
+            ("steam", "water"): (1500, 3500),
+            ("steam", "organic"): (700, 1800),
         },
         "vaporizer": {
             ("steam", "liquid"): (900, 1500),
+            ("steam", "water"): (1200, 3000),
+            ("steam", "organic"): (600, 1400),
+            ("steam", "light_oil"): (500, 1100),
+            ("hot_oil", "organic"): (250, 700),
         },
     }
 }
@@ -54,64 +89,75 @@ def get_u_range(hx_type: str, service_type: str, hot_type: str, cold_type: str) 
 
     return None
 
-# --- DIN 28184 STANDARD DATA ---
-DIN_SHELL_TUBE_STANDARD = [
-    {"DN": 150, "tube_passes": 2, "Da": 0.168, "n": 14, "AS": 1.1},
-    {"DN": 200, "tube_passes": 2, "Da": 0.219, "n": 26, "AS": 2.0},
-    {"DN": 250, "tube_passes": 2, "Da": 0.273, "n": 44, "AS": 3.5},
-    {"DN": 300, "tube_passes": 2, "Da": 0.324, "n": 66, "AS": 5.2},
-    {"DN": 350, "tube_passes": 2, "Da": 0.355, "n": 76, "AS": 6.0},
-    {"DN": 400, "tube_passes": 2, "Da": 0.406, "n": 106, "AS": 8.3},
-    {"DN": 500, "tube_passes": 2, "Da": 0.508, "n": 180, "AS": 14.1},
-    {"DN": 600, "tube_passes": 2, "Da": 0.600, "n": 258, "AS": 20.3},
-    {"DN": 700, "tube_passes": 2, "Da": 0.700, "n": 364, "AS": 28.6},
-    {"DN": 800, "tube_passes": 2, "Da": 0.800, "n": 484, "AS": 38.0},
-    {"DN": 900, "tube_passes": 2, "Da": 0.900, "n": 622, "AS": 48.9},
-    {"DN": 1000, "tube_passes": 2, "Da": 1.000, "n": 776, "AS": 61.0},
+
+def get_velocity_range(component):
+    hx_type = getattr(component, "hx_type", None)
+
+    if hx_type and hx_type in RECOMMENDED_VELOCITIES:
+        return RECOMMENDED_VELOCITIES[hx_type]
+
+    name = getattr(component, "name", "").lower()
+    if name in RECOMMENDED_VELOCITIES:
+        return RECOMMENDED_VELOCITIES[name]
+
+    return (0.8, 2.5)
+
+TUBE_LENGTH_STANDARD = [
+    {"length": 0.5, "area": 10},
+    {"length": 1.0, "area": 20},
+    {"length": 2.5, "area": 40},
+    {"length": 3.0, "area": 60},
+    {"length": 4.0, "area": 80},
+    {"length": 5.0, "area": 100},
+    {"length": 6.0, "area": 120},
 ]
 
-def select_standard_exchanger(area_required, 
-                              hot_mdot , hot_density,
-                              cold_mdot, cold_density,
-                              tube_id = 25, tube_length = 3, tube_passes = 2 ):
+TUBE_DIAMETER_STANDARD = [
+    {"od": 0.012, "thickness": 0.001},
+    {"od": 0.016, "thickness": 0.0012},
+    {"od": 0.019, "thickness": 0.0015},
+    {"od": 0.025, "thickness": 0.002},
+    {"od": 0.032, "thickness": 0.0026},
+    {"od": 0.038, "thickness": 0.003},
+]
 
+
+def select_tube_configuration(area_required, hot, cold):
     best = None
     best_score = float("inf")
 
-    for item in DIN_SHELL_TUBE_STANDARD:
-        if item["tube_passes"] != tube_passes:
-            continue
+    hot_v_min, hot_v_max = get_velocity_range(hot["component"])
+    target_velocity = 0.5 * (hot_v_min + hot_v_max)
 
-        tube_count = item["n"]
-        shell_diameter = item["Da"]
-        area_available = item["AS"] * tube_length
-        print("Area Avaliable :", area_available)
-        print("Area Required :", area_required)
-        # --- HARD FILTER: MUST satisfy area ---
-        if area_available > area_required:
-            break
+    for tube in TUBE_DIAMETER_STANDARD:
+        tube_od = tube["od"]
+        tube_id = tube_od - 2 * tube["thickness"]
 
-        # --- Tube velocity ---
-        area_per_tube = math.pi * tube_id**2 / 4
-        tube_flow_area = tube_count / tube_passes * area_per_tube
-        v_tube = (hot_mdot / hot_density) / max(tube_flow_area, 1e-12)
+        for length_data in TUBE_LENGTH_STANDARD:
+            tube_length = length_data["length"]
 
-        # --- Shell velocity ---
-        shell_area = math.pi * shell_diameter**2 / 4
-        v_shell = (cold_mdot / cold_density) / max(shell_area, 1e-12)
+            area_per_tube = math.pi * tube_od * tube_length
+            tube_count = math.ceil(area_required / max(area_per_tube, 1e-12))
 
-        # --- SCORING ---
-        velocity_penalty = (
-            abs(v_tube - 1.5) * 3 +
-            abs(v_shell - 0.5) * 2
-        )
+            flow_area = tube_count * (math.pi * tube_id**2 / 4)
+            velocity = (hot["m_dot"] / hot["density"]) / max(flow_area, 1e-12)
+            total_area = tube_count * area_per_tube
 
-        oversize_penalty = (area_available - area_required) / area_required
+            area_penalty = abs((total_area - area_required) / max(area_required, 1e-12))
+            velocity_penalty = abs(velocity - target_velocity)
+            score = area_penalty * 2 + velocity_penalty
 
-        score = velocity_penalty + oversize_penalty
+            if score < best_score:
+                best_score = score
+                best = {
+                    "tube_od": tube_od,
+                    "tube_id": tube_id,
+                    "tube_length": tube_length,
+                    "tube_count": tube_count,
+                    "velocity": velocity,
+                    "area": total_area,
+                    "velocity_range": (hot_v_min, hot_v_max),
+                    "score": score,
+                }
 
-        if score < best_score:
-            best_score = score
-            best = item
-        #print(best)
     return best


### PR DESCRIPTION
### Motivation
- Break up a large monolithic `design` flow into testable, deterministic steps and make sizing more robust and flexible.
- Add stronger input validation and safer numeric handling to avoid divide-by-zero and invalid stream properties.
- Improve component/standard lookups and selection logic for tube geometry, velocities, and U-range guidance.
- Provide clearer warnings and status classification for design results (OK / WARNING / VIOLATION).

### Description
- Reworked `ShellAndTubeHX.design` into many helper methods including `\_validate_inputs`, `\_calculate_heat_duty`, `\_calculate_lmtd`, `\_calculate_ft`, `\_adjust_passes`, `\_calculate_area`, `\_select_tube_geometry`, `\_calculate_bundle_diameter`, `\_calculate_shell_diameter`, `\_check_L_over_D`, `\_check_velocities`, `\_calculate_dimensionless`, `\_calculate_htc`, `\_calculate_overall_U`, `\_iterate_U`, `\_calculate_pressure_drop`, `\_velocity_warnings`, and `\_finalize_results` to modularize the sizing/iteration and improve clarity.
- Replaced ad-hoc geometry selection with `select_tube_configuration` flow and logic to derive tube OD/ID, length, pitch, tube count and to round tube counts to meet pass constraints, and added standard tube diameters/lengths in `standards.py`.
- Improved thermal iteration by iterating on overall `U` with `\_iterate_U`, including CLTD/FT corrections and convergence tolerance, and tightened numerical guards for stability.
- Enhanced pressure-drop handling to accept numeric or quantity-like limits, added velocity recommendations via `get_velocity_range`, and made velocity warnings more descriptive and categorized into critical/advisory in `\_finalize_results`.
- Extended `HX_U_STANDARDS` in `standards.py` with more combinations and added `TUBE_LENGTH_STANDARD` / `TUBE_DIAMETER_STANDARD` tables and `select_tube_configuration` to replace the old `select_standard_exchanger` approach.

### Testing
- No automated tests were run during this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e088a7032883268b70d1f3a0604937)