### PR TITLE
Improve shell-and-tube HX design: robust Ft calculation, pass selection, velocity handling and multi-unit support

### DIFF
--- a/processpi/equipment/heatexchangers/shell_and_tube.py
+++ b/processpi/equipment/heatexchangers/shell_and_tube.py
@@ -61,33 +61,89 @@ class ShellAndTubeHX(HeatExchanger):
     def _calculate_lmtd(self, hot: Dict[str, float], cold: Dict[str, float], th_out: float, tc_out: float) -> float:
         return self.lmtd(hot["t_k"], th_out, cold["t_k"], tc_out)
 
+    def _safe_log_ratio(self, numerator: float, denominator: float) -> float:
+        if numerator <= 0.0 or denominator <= 0.0:
+            raise ValueError("Log ratio arguments must be positive")
+        return math.log(numerator / denominator)
+
+    def _ft_1shell(self, r: float, s: float) -> float:
+        try:
+            sqrt_term = math.sqrt(r**2 + 1.0)
+
+            numerator = sqrt_term * self._safe_log_ratio(1.0 - s, 1.0 - r * s)
+
+            den_a = 2.0 - s * (r + 1.0 - sqrt_term)
+            den_b = 2.0 - s * (r + 1.0 + sqrt_term)
+            denominator = (r - 1.0) * self._safe_log_ratio(den_a, den_b)
+            if abs(denominator) < 1e-12:
+                return 0.0
+
+            ft = numerator / denominator
+            return max(min(ft, 1.0), 0.0)
+        except Exception:
+            return 0.0
+
+    def _ft_2shell(self, r: float, s: float) -> float:
+        try:
+            if s <= 0.0:
+                return 0.0
+            sqrt_term = math.sqrt(r**2 + 1.0)
+
+            a_term = (2.0 / s) * math.sqrt((1.0 - s) * (1.0 - r * s))
+            numerator = self._safe_log_ratio(1.0 - s, 1.0 - r * s)
+
+            den_a = a_term + sqrt_term - 1.0 - r
+            den_b = a_term - sqrt_term - 1.0 - r
+            denominator = self._safe_log_ratio(den_a, den_b)
+            if abs(denominator) < 1e-12:
+                return 0.0
+
+            ft = numerator / denominator
+            return max(min(ft, 1.0), 0.0)
+        except Exception:
+            return 0.0
+
     def _calculate_ft(self, hot: Dict[str, float], cold: Dict[str, float], th_out: float, tc_out: float,
                       shell_passes: int, tube_passes: int) -> float:
-        dt1 = max(hot["t_k"] - tc_out, 1e-9)
-        dt2 = max(th_out - cold["t_k"], 1e-9)
-        r = max((hot["t_k"] - th_out) / max(tc_out - cold["t_k"], 1e-9), 1e-9)
-        p = (tc_out - cold["t_k"]) / max(hot["t_k"] - cold["t_k"], 1e-9)
+        th_in = hot["t_k"]
+        tc_in = cold["t_k"]
 
-        # practical deterministic approximation for 1-2 and multi-pass correction behavior
-        pass_factor = 1.0 / max((shell_passes * tube_passes) ** 0.08, 1.0)
-        shape_factor = max(0.70, min(1.0, 1.0 - 0.08 * abs(r - 1.0) - 0.12 * max(p - 0.7, 0.0)))
-        dt_ratio_factor = max(0.75, min(1.0, min(dt1, dt2) / max(dt1, dt2)))
-        return max(0.65, min(1.0, pass_factor * shape_factor * dt_ratio_factor))
+        r = (th_in - th_out) / max(tc_out - tc_in, 1e-12)
+        s = (tc_out - tc_in) / max(th_in - tc_in, 1e-12)
+
+        if shell_passes == 1:
+            return self._ft_1shell(r, s)
+        if shell_passes == 2:
+            return self._ft_2shell(r, s)
+        return 0.0
 
     def _adjust_passes(self, hot: Dict[str, float], cold: Dict[str, float], th_out: float, tc_out: float) -> Tuple[int, int, float]:
-        candidates = [(1, 2), (1, 4), (2, 4), (2, 6)]
-        if self.specs.get("shell_passes") is not None or self.specs.get("tube_passes") is not None:
-            candidates = [(int(self.specs.get("shell_passes", 1)), int(self.specs.get("tube_passes", 2)))] + candidates
+        candidates = [
+            (1, 2), (1, 4), (1, 6), (1, 8),
+            (2, 4), (2, 6), (2, 8),
+        ]
+        if self.specs.get("shell_passes") is not None and self.specs.get("tube_passes") is not None:
+            specified = (int(self.specs["shell_passes"]), int(self.specs["tube_passes"]))
+            candidates = [specified] + [c for c in candidates if c != specified]
 
-        best = (1, 2, 0.0)
+        best: Tuple[int, int, float] | None = None
+        best_ft = 0.0
         for shell_passes, tube_passes in candidates:
             ft = self._calculate_ft(hot, cold, th_out, tc_out, shell_passes, tube_passes)
-            print(f"Passes (shell={shell_passes}, tube={tube_passes}) → Ft = {ft:.4f}") 
-            if ft > best[2]:
+            print(f"Passes (shell={shell_passes}, tube={tube_passes}) → Ft = {ft:.4f}")
+
+            if ft > best_ft:
+                best_ft = ft
                 best = (shell_passes, tube_passes, ft)
-            if ft > 0.78:
+
+            if ft >= 0.78:
                 return shell_passes, tube_passes, ft
-        return best
+
+        warnings = getattr(self, "_warnings", [])
+        warnings.append("No pass configuration satisfies Ft ≥ 0.78 → using multiple exchangers in series")
+        self._warnings = warnings
+
+        return best if best is not None else (1, 2, 0.0)
 
     def _calculate_area(self, q_watts: float, u_assumed: float, cltd: float) -> float:
         return q_watts / max(u_assumed * cltd, 1e-9)
@@ -159,7 +215,7 @@ class ShellAndTubeHX(HeatExchanger):
         return geometry
 
     def _check_velocities(self, geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float],
-                          tube_passes: int, shell_diameter: float) -> Tuple[float, float, int]:
+                          tube_passes: int, shell_passes: int, shell_diameter: float) -> Tuple[float, float, int]:
         q_vol_hot = hot["m_dot"] / max(hot["density"], 1e-12)
         q_vol_cold = cold["m_dot"] / max(cold["density"], 1e-12)
 
@@ -172,9 +228,17 @@ class ShellAndTubeHX(HeatExchanger):
             geometry["tube_count"] = self._round_tube_count_to_passes(int(math.ceil(geometry["tube_count"] * 1.1)), tube_passes)
             tube_flow = max(geometry["tube_count"] / max(tube_passes, 1) * area_per_tube_flow, 1e-12)
             v_tube = q_vol_hot / tube_flow
+        elif v_tube < v_min:
+            reduced_tubes = max(tube_passes, int(math.floor(geometry["tube_count"] * 0.8)))
+            geometry["tube_count"] = self._round_tube_count_to_passes(reduced_tubes, tube_passes)
+            tube_flow = max(geometry["tube_count"] / max(tube_passes, 1) * area_per_tube_flow, 1e-12)
+            v_tube = q_vol_hot / tube_flow
 
-        shell_flow = math.pi * shell_diameter ** 2 / 4.0
-        v_shell = q_vol_cold / max(shell_flow, 1e-12)
+        pitch = max(geometry.get("tube_pitch", 1.25 * geometry["tube_od"]), geometry["tube_od"] * 1.01)
+        baffle_spacing = max(float(self.specs.get("baffle_spacing", 0.4 * shell_diameter)), 1e-6)
+        shell_flow_area = shell_diameter * baffle_spacing * (pitch - geometry["tube_od"]) / pitch
+        v_shell = q_vol_cold / max(shell_flow_area, 1e-12)
+        v_shell *= max(shell_passes, 1)
         return v_tube, v_shell, geometry["tube_count"]
 
     def _calculate_dimensionless(self, geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float],
@@ -231,7 +295,14 @@ class ShellAndTubeHX(HeatExchanger):
             bundle_diameter = self._calculate_bundle_diameter(geometry["tube_count"])
             shell_diameter = self._calculate_shell_diameter(bundle_diameter)
 
-            v_tube, v_shell, tube_count = self._check_velocities(geometry, hot, cold, tube_passes, shell_diameter)
+            v_tube, v_shell, tube_count = self._check_velocities(
+                geometry,
+                hot,
+                cold,
+                tube_passes,
+                shell_passes,
+                shell_diameter,
+            )
             geometry["tube_count"] = tube_count
             geometry["area"] = geometry["tube_count"] * math.pi * geometry["tube_od"] * geometry["tube_length"]
 
@@ -360,6 +431,7 @@ class ShellAndTubeHX(HeatExchanger):
     def design(self) -> Dict[str, Any]:
         hot = self._stream_props(self.hot_in)
         cold = self._stream_props(self.cold_in)
+        self._warnings = []
         self._validate_inputs(hot, cold)
 
         if hot["phase"] == "vapor":
@@ -378,6 +450,15 @@ class ShellAndTubeHX(HeatExchanger):
 
         shell_passes, tube_passes, ft = self._adjust_passes(hot, cold, th_out, tc_out)
         print(ft, shell_passes, tube_passes)
+        warnings: List[str] = list(getattr(self, "_warnings", []))
+
+        n_units = 1
+        effective_q_watts = q_watts
+        if ft < 0.78:
+            n_units = int(math.ceil(0.78 / max(ft, 1e-6)))
+            effective_q_watts = q_watts / n_units
+            warnings.append(f"Using {n_units} exchangers in series to satisfy Ft requirement")
+
         cltd = max(ft * lmtd, 1e-9)
         print(cltd)
 
@@ -387,7 +468,10 @@ class ShellAndTubeHX(HeatExchanger):
         cold_type = getattr(self.cold_in.component, "hx_type", "generic")
         u_range = get_u_range("shell_and_tube", self.service_type, hot_type, cold_type)
 
-        state = self._iterate_U(q_watts, cltd, hot, cold, shell_passes, tube_passes, u_assumed, u_range)
+        state = self._iterate_U(effective_q_watts, cltd, hot, cold, shell_passes, tube_passes, u_assumed, u_range)
+
+        if state["shell_diameter"] > 1.5:
+            warnings.append("Shell diameter too large → consider multi-shell exchanger")
 
         tube_dp, shell_dp = self._calculate_pressure_drop(
             hot=hot,
@@ -401,7 +485,6 @@ class ShellAndTubeHX(HeatExchanger):
             v_shell=state["v_shell"],
         )
 
-        warnings: List[str] = []
         tube_limit_val = self.specs.get("tube_dp", self._dp_limit(hot))
         shell_limit_val = self.specs.get("shell_dp", self._dp_limit(cold))
         tube_limit = float(tube_limit_val.to("Pa").value) if hasattr(tube_limit_val, "to") else float(tube_limit_val)
@@ -422,10 +505,11 @@ class ShellAndTubeHX(HeatExchanger):
         payload = {
             **state,
             "warnings": warnings,
-            "q_watts": q_watts,
+            "q_watts": effective_q_watts,
             "lmtd": lmtd,
             "cltd": cltd,
             "ft": ft,
+            "n_units": n_units,
             "tube_dp": tube_dp,
             "shell_dp": shell_dp,
             "area": state["geometry"]["area"],


### PR DESCRIPTION
### Motivation
- Make the shell-and-tube design calculations more robust and physically meaningful for a wider range of conditions by replacing heuristic Ft approximations with dedicated functions and safer math operations. 
- Improve pass selection logic and add handling for cases where a single exchanger cannot meet Ft requirements by allowing multiple units in series. 
- Improve velocity and shell-flow area calculations and provide actionable warnings when geometry/limits are problematic.

### Description
- Added `_safe_log_ratio`, `_ft_1shell`, and `_ft_2shell` to compute correction factor Ft with protection against invalid log arguments and edge cases, and clamped Ft to [0,1].
- Reworked `_calculate_ft` to compute thermal ratio `r` and capacity ratio `s` and dispatch to the new Ft functions for 1- and 2-shell configurations; legacy heuristic removed.
- Expanded `_adjust_passes` candidate set, supported honoring specified passes, selected the best Ft candidate with early exit when Ft ≥ 0.78, and append a warning if no candidate meets the target.
- Added multi-unit support in `design`: initialize `_warnings`, compute `n_units` and `effective_q_watts` when Ft < 0.78, and adjust the subsequent sizing iteration to split duty across units; included `n_units` in the returned payload.
- Changed `_check_velocities` signature to accept `shell_passes`, implemented more realistic shell flow area calculation using pitch and baffle spacing, scaled shell-side velocity by the number of shell passes, and added logic to reduce tube count if tube velocity is below the minimum.
- Updated `_iterate_U` and `design` to use `effective_q_watts`, add warnings for large shell diameters, and return the warnings list in the final payload.

### Testing
- Ran the heat exchanger unit tests: `pytest tests/test_heatexchangers.py::test_shell_and_tube_design`, which passed.
- Ran the full test suite with `pytest -q` to validate integrations and regressions, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e862567e2483269d62d250bc299c9a)