### PR TITLE
Improve shell-and-tube HX sizing: Ft calculation, pass selection, velocities, multi-unit handling, and warnings

### DIFF
--- a/processpi/equipment/heatexchangers/shell_and_tube.py
+++ b/processpi/equipment/heatexchangers/shell_and_tube.py
@@ -61,33 +61,89 @@ class ShellAndTubeHX(HeatExchanger):
     def _calculate_lmtd(self, hot: Dict[str, float], cold: Dict[str, float], th_out: float, tc_out: float) -> float:
         return self.lmtd(hot["t_k"], th_out, cold["t_k"], tc_out)
 
+    def _safe_log_ratio(self, numerator: float, denominator: float) -> float:
+        if numerator <= 0.0 or denominator <= 0.0:
+            raise ValueError("Log ratio arguments must be positive")
+        return math.log(numerator / denominator)
+
+    def _ft_1shell(self, r: float, s: float) -> float:
+        try:
+            sqrt_term = math.sqrt(r**2 + 1.0)
+
+            numerator = sqrt_term * self._safe_log_ratio(1.0 - s, 1.0 - r * s)
+
+            den_a = 2.0 - s * (r + 1.0 - sqrt_term)
+            den_b = 2.0 - s * (r + 1.0 + sqrt_term)
+            denominator = (r - 1.0) * self._safe_log_ratio(den_a, den_b)
+            if abs(denominator) < 1e-12:
+                return 0.0
+
+            ft = numerator / denominator
+            return max(min(ft, 1.0), 0.0)
+        except Exception:
+            return 0.0
+
+    def _ft_2shell(self, r: float, s: float) -> float:
+        try:
+            if s <= 0.0:
+                return 0.0
+            sqrt_term = math.sqrt(r**2 + 1.0)
+
+            a_term = (2.0 / s) * math.sqrt((1.0 - s) * (1.0 - r * s))
+            numerator = self._safe_log_ratio(1.0 - s, 1.0 - r * s)
+
+            den_a = a_term + sqrt_term - 1.0 - r
+            den_b = a_term - sqrt_term - 1.0 - r
+            denominator = self._safe_log_ratio(den_a, den_b)
+            if abs(denominator) < 1e-12:
+                return 0.0
+
+            ft = numerator / denominator
+            return max(min(ft, 1.0), 0.0)
+        except Exception:
+            return 0.0
+
     def _calculate_ft(self, hot: Dict[str, float], cold: Dict[str, float], th_out: float, tc_out: float,
                       shell_passes: int, tube_passes: int) -> float:
-        dt1 = max(hot["t_k"] - tc_out, 1e-9)
-        dt2 = max(th_out - cold["t_k"], 1e-9)
-        r = max((hot["t_k"] - th_out) / max(tc_out - cold["t_k"], 1e-9), 1e-9)
-        p = (tc_out - cold["t_k"]) / max(hot["t_k"] - cold["t_k"], 1e-9)
+        th_in = hot["t_k"]
+        tc_in = cold["t_k"]
 
-        # practical deterministic approximation for 1-2 and multi-pass correction behavior
-        pass_factor = 1.0 / max((shell_passes * tube_passes) ** 0.08, 1.0)
-        shape_factor = max(0.70, min(1.0, 1.0 - 0.08 * abs(r - 1.0) - 0.12 * max(p - 0.7, 0.0)))
-        dt_ratio_factor = max(0.75, min(1.0, min(dt1, dt2) / max(dt1, dt2)))
-        return max(0.65, min(1.0, pass_factor * shape_factor * dt_ratio_factor))
+        r = (th_in - th_out) / max(tc_out - tc_in, 1e-12)
+        s = (tc_out - tc_in) / max(th_in - tc_in, 1e-12)
+
+        if shell_passes == 1:
+            return self._ft_1shell(r, s)
+        if shell_passes == 2:
+            return self._ft_2shell(r, s)
+        return 0.0
 
     def _adjust_passes(self, hot: Dict[str, float], cold: Dict[str, float], th_out: float, tc_out: float) -> Tuple[int, int, float]:
-        candidates = [(1, 2), (1, 4), (2, 4), (2, 6)]
-        if self.specs.get("shell_passes") is not None or self.specs.get("tube_passes") is not None:
-            candidates = [(int(self.specs.get("shell_passes", 1)), int(self.specs.get("tube_passes", 2)))] + candidates
+        candidates = [
+            (1, 2), (1, 4), (1, 6), (1, 8),
+            (2, 4), (2, 6), (2, 8),
+        ]
+        if self.specs.get("shell_passes") is not None and self.specs.get("tube_passes") is not None:
+            specified = (int(self.specs["shell_passes"]), int(self.specs["tube_passes"]))
+            candidates = [specified] + [c for c in candidates if c != specified]
 
-        best = (1, 2, 0.0)
+        best: Tuple[int, int, float] | None = None
+        best_ft = 0.0
         for shell_passes, tube_passes in candidates:
             ft = self._calculate_ft(hot, cold, th_out, tc_out, shell_passes, tube_passes)
-            print(f"Passes (shell={shell_passes}, tube={tube_passes}) → Ft = {ft:.4f}") 
-            if ft > best[2]:
+            print(f"Passes (shell={shell_passes}, tube={tube_passes}) → Ft = {ft:.4f}")
+
+            if ft > best_ft:
+                best_ft = ft
                 best = (shell_passes, tube_passes, ft)
-            if ft > 0.78:
+
+            if ft >= 0.78:
                 return shell_passes, tube_passes, ft
-        return best
+
+        warnings = getattr(self, "_warnings", [])
+        warnings.append("No pass configuration satisfies Ft ≥ 0.78 → using multiple exchangers in series")
+        self._warnings = warnings
+
+        return best if best is not None else (1, 2, 0.0)
 
     def _calculate_area(self, q_watts: float, u_assumed: float, cltd: float) -> float:
         return q_watts / max(u_assumed * cltd, 1e-9)
@@ -159,7 +215,7 @@ class ShellAndTubeHX(HeatExchanger):
         return geometry
 
     def _check_velocities(self, geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float],
-                          tube_passes: int, shell_diameter: float) -> Tuple[float, float, int]:
+                          tube_passes: int, shell_passes: int, shell_diameter: float) -> Tuple[float, float, int, float]:
         q_vol_hot = hot["m_dot"] / max(hot["density"], 1e-12)
         q_vol_cold = cold["m_dot"] / max(cold["density"], 1e-12)
 
@@ -172,10 +228,35 @@ class ShellAndTubeHX(HeatExchanger):
             geometry["tube_count"] = self._round_tube_count_to_passes(int(math.ceil(geometry["tube_count"] * 1.1)), tube_passes)
             tube_flow = max(geometry["tube_count"] / max(tube_passes, 1) * area_per_tube_flow, 1e-12)
             v_tube = q_vol_hot / tube_flow
+        elif v_tube < v_min:
+            reduced_tubes = max(tube_passes, int(math.floor(geometry["tube_count"] * 0.85)))
+            geometry["tube_count"] = self._round_tube_count_to_passes(reduced_tubes, tube_passes)
+            tube_flow = max(geometry["tube_count"] / max(tube_passes, 1) * area_per_tube_flow, 1e-12)
+            v_tube = q_vol_hot / tube_flow
 
-        shell_flow = math.pi * shell_diameter ** 2 / 4.0
-        v_shell = q_vol_cold / max(shell_flow, 1e-12)
-        return v_tube, v_shell, geometry["tube_count"]
+        pitch = 1.25 * geometry["tube_od"]
+        porosity = 0.6
+
+        v_shell = 0.0
+        for _ in range(5):
+            baffle_spacing = max(0.4 * shell_diameter, 1e-6)
+            shell_flow_area = (
+                shell_diameter
+                * baffle_spacing
+                * porosity
+                * (pitch - geometry["tube_od"]) / max(pitch, 1e-12)
+            )
+            v_shell = q_vol_cold / max(shell_flow_area, 1e-12)
+            v_shell *= max(shell_passes, 1)
+
+            if v_shell < 0.3:
+                shell_diameter *= 0.85
+            elif v_shell > 1.0:
+                shell_diameter *= 1.1
+            else:
+                break
+
+        return v_tube, v_shell, geometry["tube_count"], shell_diameter
 
     def _calculate_dimensionless(self, geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float],
                                  v_tube: float, v_shell: float) -> Dict[str, float]:
@@ -231,7 +312,14 @@ class ShellAndTubeHX(HeatExchanger):
             bundle_diameter = self._calculate_bundle_diameter(geometry["tube_count"])
             shell_diameter = self._calculate_shell_diameter(bundle_diameter)
 
-            v_tube, v_shell, tube_count = self._check_velocities(geometry, hot, cold, tube_passes, shell_diameter)
+            v_tube, v_shell, tube_count, shell_diameter = self._check_velocities(
+                geometry,
+                hot,
+                cold,
+                tube_passes,
+                shell_passes,
+                shell_diameter,
+            )
             geometry["tube_count"] = tube_count
             geometry["area"] = geometry["tube_count"] * math.pi * geometry["tube_od"] * geometry["tube_length"]
 
@@ -341,7 +429,7 @@ class ShellAndTubeHX(HeatExchanger):
 
         return {
             "hx_type": "shell_and_tube",
-            "Q": payload["q_watts"] / 1000.0,
+            "Q": payload["q_watts_original"] / 1000.0,
             "Area": payload["area"],
             "U_assumed": payload["u_assumed"],
             "U_calculated": payload["u_calculated"],
@@ -360,6 +448,7 @@ class ShellAndTubeHX(HeatExchanger):
     def design(self) -> Dict[str, Any]:
         hot = self._stream_props(self.hot_in)
         cold = self._stream_props(self.cold_in)
+        self._warnings = []
         self._validate_inputs(hot, cold)
 
         if hot["phase"] == "vapor":
@@ -378,6 +467,15 @@ class ShellAndTubeHX(HeatExchanger):
 
         shell_passes, tube_passes, ft = self._adjust_passes(hot, cold, th_out, tc_out)
         print(ft, shell_passes, tube_passes)
+        warnings: List[str] = list(getattr(self, "_warnings", []))
+
+        n_units = 1
+        effective_q_watts = q_watts
+        if ft < 0.78:
+            n_units = int(math.ceil(0.78 / max(ft, 1e-6)))
+            effective_q_watts = q_watts / n_units
+            warnings.append(f"Using {n_units} exchangers in series to satisfy Ft requirement")
+
         cltd = max(ft * lmtd, 1e-9)
         print(cltd)
 
@@ -387,7 +485,10 @@ class ShellAndTubeHX(HeatExchanger):
         cold_type = getattr(self.cold_in.component, "hx_type", "generic")
         u_range = get_u_range("shell_and_tube", self.service_type, hot_type, cold_type)
 
-        state = self._iterate_U(q_watts, cltd, hot, cold, shell_passes, tube_passes, u_assumed, u_range)
+        state = self._iterate_U(effective_q_watts, cltd, hot, cold, shell_passes, tube_passes, u_assumed, u_range)
+
+        if state["shell_diameter"] > 1.5:
+            warnings.append("Shell diameter too large → consider multi-shell exchanger")
 
         tube_dp, shell_dp = self._calculate_pressure_drop(
             hot=hot,
@@ -401,7 +502,6 @@ class ShellAndTubeHX(HeatExchanger):
             v_shell=state["v_shell"],
         )
 
-        warnings: List[str] = []
         tube_limit_val = self.specs.get("tube_dp", self._dp_limit(hot))
         shell_limit_val = self.specs.get("shell_dp", self._dp_limit(cold))
         tube_limit = float(tube_limit_val.to("Pa").value) if hasattr(tube_limit_val, "to") else float(tube_limit_val)
@@ -417,15 +517,17 @@ class ShellAndTubeHX(HeatExchanger):
         if state["geometry"]["area"] < 0.85 * state["area_required"]:
             warnings.append("Area significantly undersized — redesign required")
         elif state["geometry"]["area"] < state["area_required"]:
-            warnings.append("Area slightly undersized — acceptable with margin")
+            warnings.append("Area slightly undersized — acceptable")
 
         payload = {
             **state,
             "warnings": warnings,
-            "q_watts": q_watts,
+            "q_watts_original": q_watts,
+            "q_watts_effective": effective_q_watts,
             "lmtd": lmtd,
             "cltd": cltd,
             "ft": ft,
+            "n_units": n_units,
             "tube_dp": tube_dp,
             "shell_dp": shell_dp,
             "area": state["geometry"]["area"],


### PR DESCRIPTION
### Motivation

- Make Ft (correction factor) calculation more robust and physically representative for 1- and 2-shell configurations and improve pass selection logic.
- Improve hydraulic sizing by iterating a shell flow area model and enforcing tube velocity bounds, and surface area/units handling when Ft is insufficient.
- Provide clearer warnings and preserve original vs effective heat duty in results for multi-unit solutions.

### Description

- Added `_safe_log_ratio`, `_ft_1shell`, and `_ft_2shell` helpers and replaced prior heuristic `_calculate_ft` with physics-based evaluations for 1- and 2-shell cases while clamping results to [0,1].
- Reworked `_adjust_passes` to consider a wider candidate set, accept specified passes, prefer best Ft, short-circuit when `Ft >= 0.78`, and append warnings when no config meets the threshold.
- Enhanced velocity checks in `_check_velocities` to enforce minimum tube velocity, model shell-side flow area iteratively (baffle spacing/pitch/porosity), and return an updated `shell_diameter` along with tube velocity and tube count.
- Changed `_iterate_U` and callers to pass `shell_passes` through `_check_velocities` and to accept adjusted `shell_diameter` returned from that routine.
- Implemented multi-unit handling in `design`: compute `n_units` and split `q_watts` into `effective_q_watts` when `ft < 0.78`, and include `q_watts_original`, `q_watts_effective`, `ft`, and `n_units` in the payload.
- Improved result finalization to report original heat duty (`Q` uses `q_watts_original`) and collect/classify warnings, and added a check/warning when `shell_diameter > 1.5`.
- Minor UX/wording tweaks to warnings and safer numeric protections (small denominators, clamping).

### Testing

- Ran the repository test suite with `pytest` including targeted tests for shell-and-tube sizing and Ft/pass-selection logic, and all tests passed.
- Ran static checks and basic smoke runs of `ShellAndTubeHX.design()` on representative hot/cold streams to validate no exceptions and sensible outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e862567e2483269d62d250bc299c9a)