### PR TITLE
Enhance heat-exchanger standards and fluid metadata; improve ShellAndTube sizing and velocity logic

### DIFF
--- a/processpi/components/benzene.py
+++ b/processpi/components/benzene.py
@@ -68,11 +68,17 @@ class Benzene(Component):
         
         return SpecificHeat(cp_kg, "J/kgK")
 
+    def hx_data(self):
+        p = self.pressure.to("Pa").value
+        pvap = self.vapor_pressure().to("Pa").value
+        phase = "vapor" if p < pvap else "liquid"
+        return {"family": "organic", "phase": phase, "velocity_key": "benzene", "u_key": "organic", "fouling_key": "hydrocarbons", "corrosion_key": "hydrocarbon"}
+
     def httype(self):
         P = self.pressure.to("Pa").value
         Pvap = self.vapor_pressure().to("Pa").value
         if P < Pvap:
-            httype = "organicvapour"
+            httype = "vapor"
         else:
-            httype = "organicliquid"
+            httype = "organic"
         return httype

--- a/processpi/components/oil.py
+++ b/processpi/components/oil.py
@@ -18,12 +18,18 @@ class Oil(Component):
     _vapor_pressure_constants = [75, -7000, -7.2, 0.000007, 2]
     _enthalpy_constants = [4.5E-7, 0.34, 200, 3.6, 0]
 
+    def hx_data(self):
+        p = self.pressure.to("Pa").value
+        pvap = self.vapor_pressure().to("Pa").value
+        phase = "vapor" if p < pvap else "liquid"
+        return {"family": "oil", "phase": phase, "velocity_key": "oil", "u_key": "heavy_oil" if phase == "liquid" else "gas_low_pressure", "fouling_key": "oil", "corrosion_key": "hydrocarbon"}
+
     def httype(self):
         P = self.pressure.to("Pa").value
         Pvap = self.vapor_pressure().to("Pa").value
         if P < Pvap:
-            httype = "heavyoil"
+            httype = "oil"
         else:
-            httype = "lightoil"
+            httype = "oil"
         return httype
     

--- a/processpi/components/organic_liquid.py
+++ b/processpi/components/organic_liquid.py
@@ -6,7 +6,7 @@ class OrganicLiquid(Component):
     hx_type = "organic"
     formula = "R-CH"
     molecular_weight = 100.0
-    httype = "organicliquid"
+    httype = "organic"
     p_h = "liquid"
     _critical_temperature = Temperature(550, "K")
     _critical_pressure = Pressure(4.5, "MPa")
@@ -20,11 +20,17 @@ class OrganicLiquid(Component):
     _vapor_pressure_constants = [70, -6000, -7.0, 0.000006, 2]
     _enthalpy_constants = [4.2E-7, 0.3, 180, 3.5, 0]
     
+    def hx_data(self):
+        p = self.pressure.to("Pa").value
+        pvap = self.vapor_pressure().to("Pa").value
+        phase = "vapor" if p < pvap else "liquid"
+        return {"family": "organic", "phase": phase, "velocity_key": "organic_liquid", "u_key": "organic", "fouling_key": "hydrocarbons", "corrosion_key": "hydrocarbon"}
+
     def httype(self):
         P = self.pressure.to("Pa").value
         Pvap = self.vapor_pressure().to("Pa").value
         if P < Pvap:
-            httype = "organicvapour"
+            httype = "vapor"
         else:
-            httype = "organicliquid"
+            httype = "organic"
         return httype

--- a/processpi/components/toluene.py
+++ b/processpi/components/toluene.py
@@ -21,12 +21,18 @@ class Toluene(Component):
     _vapor_pressure_constants = [76.945, -6729.8, -8.179, 0.0000053017, 2] 
     _enthalpy_constants = [4.9507E-7, 0.37742, 0, 0, 0]  # Placeholder for enthalpy constants
 
+    def hx_data(self):
+        p = self.pressure.to("Pa").value
+        pvap = self.vapor_pressure().to("Pa").value
+        phase = "vapor" if p < pvap else "liquid"
+        return {"family": "organic", "phase": phase, "velocity_key": "toluene", "u_key": "organic", "fouling_key": "hydrocarbons", "corrosion_key": "hydrocarbon"}
+
     def httype(self):
         P = self.pressure.to("Pa").value
         Pvap = self.vapor_pressure().to("Pa").value
         if P < Pvap:
-            httype = "organicvapour"
+            httype = "vapor"
         else:
-            httype = "organicliquid"
+            httype = "organic"
         return httype
     

--- a/processpi/components/water.py
+++ b/processpi/components/water.py
@@ -24,6 +24,14 @@ class Water(Component):
         den = den * self.molecular_weight
         return Density(den, "kg/m3")
 
+    def hx_data(self):
+        p = 101325 if self.pressure is None else self.pressure.to("Pa").value
+        pvap = self.vapor_pressure().to("Pa").value
+        phase = "vapor" if p < pvap else "liquid"
+        velocity_key = "vapor" if phase == "vapor" else "water"
+        u_key = "steam" if phase == "vapor" else "water"
+        return {"family": "inorganic", "phase": phase, "velocity_key": velocity_key, "u_key": u_key, "fouling_key": "treated_water", "corrosion_key": "treated_water"}
+
     def httype(self):
         if self.pressure is None:
             # assume atmospheric if not provided

--- a/processpi/equipment/heatexchangers/shell_and_tube.py
+++ b/processpi/equipment/heatexchangers/shell_and_tube.py
@@ -12,7 +12,17 @@ from processpi.calculations.heat_transfer.hx_kern import (
 )
 
 from .base import HeatExchanger
-from .standards import get_u_range, get_velocity_range, select_tube_configuration, tube_length_select
+from .standards import (
+    DEFAULT_VELOCITY_RANGE,
+    RECOMMENDED_VELOCITIES,
+    CORROSION_SEVERITY_DATABASE,
+    FOULING_FACTOR_DATABASE,
+    STANDARD_TUBE_COUNT_TABLES,
+    get_u_range,
+    get_velocity_range,
+    select_tube_configuration,
+    tube_length_select,
+)
 
 
 class ShellAndTubeHX(HeatExchanger):
@@ -21,6 +31,7 @@ class ShellAndTubeHX(HeatExchanger):
         if self.method not in {"kern", "bell_delaware"}:
             raise ValueError("method must be 'kern' or 'bell_delaware'")
         super().__init__(*args, **kwargs)
+        self._load_standard_tables()
 
     def _assume_u(self, hot: Dict[str, float], cold: Dict[str, float]) -> float:
         if self.specs.get("U") is not None:
@@ -161,6 +172,178 @@ class ShellAndTubeHX(HeatExchanger):
     def _round_tube_count_to_passes(self, tube_count: int, tube_passes: int) -> int:
         return max(tube_passes, int(math.ceil(tube_count / max(tube_passes, 1)) * max(tube_passes, 1)))
 
+    def _debug(self, message: str) -> None:
+        print(f"[DEBUG] {message}")
+
+    def _load_standard_tables(self) -> None:
+        self._tube_count_tables = STANDARD_TUBE_COUNT_TABLES
+        self._fouling_db = FOULING_FACTOR_DATABASE
+        self._corrosion_db = CORROSION_SEVERITY_DATABASE
+
+    def _get_standard_layout(self) -> str:
+        return str(self.specs.get("tube_layout", "triangular")).lower()
+
+    def _get_nearest_shell_id(self, shell_id_in: float, shell_ids: List[float]) -> float:
+        nearest = min(shell_ids, key=lambda x: abs(x - shell_id_in))
+        if abs(nearest - shell_id_in) > 1e-9:
+            self._debug(f"Exact shell ID unavailable. Using nearest standard shell ID = {nearest} in")
+        return nearest
+
+    def _select_standard_tube_count(self, shell_id_m: float, tube_od_m: float, tube_passes: int) -> int | None:
+        layout = self._get_standard_layout()
+        od_in = round(tube_od_m / 0.0254, 2)
+        shell_in = shell_id_m / 0.0254
+        table = self._tube_count_tables.get(layout, {}).get(od_in)
+        if not table:
+            return None
+        pitch_key = next(iter(table.keys()))
+        shell_ids = list(table[pitch_key].keys())
+        nearest_shell = self._get_nearest_shell_id(shell_in, shell_ids)
+        return table[pitch_key][nearest_shell].get(tube_passes)
+
+    def _calculate_required_area(self, q_watts: float, u_assumed: float, cltd: float) -> float:
+        return self._calculate_area(q_watts, u_assumed, cltd)
+
+    def _estimate_required_tube_count(self, area_required: float, tube_od: float, tube_length: float, tube_passes: int) -> int:
+        area_per_tube = math.pi * tube_od * tube_length
+        min_count = math.ceil(area_required / max(area_per_tube, 1e-12))
+        return self._round_tube_count_to_passes(min_count, tube_passes)
+
+    def _select_best_standard_geometry(self, area_required: float, tube_od: float, tube_length: float, tube_passes: int) -> Dict[str, float]:
+        required_count = self._estimate_required_tube_count(area_required, tube_od, tube_length, tube_passes)
+        layout = self._get_standard_layout()
+        od_in = round(tube_od / 0.0254, 2)
+        table = self._tube_count_tables.get(layout, {}).get(od_in, {})
+        if not table:
+            return {"tube_count": required_count}
+        pitch_key = next(iter(table.keys()))
+        candidates: List[Tuple[int, int]] = []
+        for shell_id, pass_map in table[pitch_key].items():
+            count = pass_map.get(tube_passes)
+            if count is not None and count >= required_count:
+                candidates.append((shell_id, count))
+        if not candidates:
+            return {"tube_count": required_count}
+        candidates.sort(key=lambda x: (x[1] - required_count, x[0]))
+        shell_id, count = candidates[0]
+        self._debug(f"Standard geometry selected: shell ID={shell_id} in, tube_count={count}, required={required_count}")
+        return {"tube_count": count, "shell_id_in": shell_id}
+
+    def _select_next_tube_size(self, tube_od_m: float, direction: str) -> float:
+        series = [0.5, 0.75, 1.0, 1.25, 1.5]
+        cur = round(tube_od_m / 0.0254, 2)
+        if cur not in series:
+            cur = min(series, key=lambda x: abs(x-cur))
+        idx = series.index(cur)
+        if direction == "larger" and idx < len(series)-1:
+            return series[idx+1] * 0.0254
+        if direction == "smaller" and idx > 0:
+            return series[idx-1] * 0.0254
+        return tube_od_m
+
+    def _get_velocity_limits(self, component: Any, props: Dict[str, float]) -> Tuple[float, float]:
+        hx_data = component.hx_data() if hasattr(component, "hx_data") else {}
+        key = hx_data.get("velocity_key", "water" if props.get("phase") != "vapor" else "vapor")
+        limits = RECOMMENDED_VELOCITIES.get(key, DEFAULT_VELOCITY_RANGE)
+        self._debug(f"Velocity lookup key = {key}, limits={limits}")
+        return limits
+
+    def _regenerate_geometry(self, geometry: Dict[str, float], tube_passes: int, hot: Dict[str, float] | None = None) -> Dict[str, float]:
+        area_per_tube = math.pi * geometry["tube_od"] * geometry["tube_length"]
+        geometry["tube_count"] = self._round_tube_count_to_passes(geometry["tube_count"], tube_passes)
+        geometry["area"] = geometry["tube_count"] * area_per_tube
+        geometry["area_per_tube"] = area_per_tube
+        geometry["tube_pitch"] = float(self.specs.get("tube_pitch", 1.25 * geometry["tube_od"]))
+        geometry["bundle_diameter"] = self._calculate_bundle_diameter(geometry["tube_count"], geometry["tube_od"])
+        geometry["shell_diameter"] = self._calculate_shell_diameter(geometry["bundle_diameter"])
+        area_per_tube_flow = math.pi * geometry["tube_id"] ** 2 / 4.0
+        geometry["tube_flow_area"] = max(geometry["tube_count"] / max(tube_passes, 1) * area_per_tube_flow, 1e-12)
+        if hot is not None:
+            q_vol_hot = hot["m_dot"] / max(hot["density"], 1e-12)
+            geometry["tube_velocity"] = q_vol_hot / geometry["tube_flow_area"]
+        self._debug("Geometry regenerated after change")
+        return geometry
+
+    def _recalculate_required_tubes(self, base_required_area: float, geometry: Dict[str, float], tube_passes: int) -> int:
+        area_per_tube = math.pi * geometry["tube_od"] * geometry["tube_length"]
+        required_tubes = math.ceil(base_required_area / max(area_per_tube, 1e-12))
+        required_tubes = self._round_tube_count_to_passes(required_tubes, tube_passes)
+        self._debug(f"Recalculated required tubes={required_tubes} for base area={base_required_area:.4f}")
+        return required_tubes
+
+    def _get_fouling_factor(self, fluid_name: str, velocity: float | None = None, temperature_k: float | None = None) -> float:
+        key = (fluid_name or "").lower()
+        best = None
+        for k,v in self._fouling_db.items():
+            if k in key or key in k:
+                best = v
+                break
+        if best is None:
+            best = {"base": float(self.specs.get("fouling_factor", 0.0002))}
+        ff = best["base"]
+        if best.get("velocity_sensitive") and velocity:
+            ff *= 1.15 if velocity < 1.0 else 0.9
+        if best.get("temperature_sensitive") and temperature_k:
+            ff *= 1.1 if temperature_k > 370 else 1.0
+        return ff
+
+    def _get_corrosion_severity(self, fluid_name: str) -> str:
+        key = (fluid_name or "").lower()
+        for k,v in self._corrosion_db.items():
+            if k in key or key in k:
+                return v
+        return "medium"
+
+    def _calculate_tube_side_score(self, props: Dict[str, float], meta: Dict[str, Any]) -> float:
+        score = 0.0
+        score += 5.0 if props.get("p_bar", 0) > 10 else 0.0
+        score += 5.0 if meta.get("hazardous") else 0.0
+        score += 4.0 if meta.get("fouling", 0.0) >= 0.0003 else 0.0
+        score += 4.0 if meta.get("corrosion") in {"high", "medium-high"} else 0.0
+        return score
+
+    def _calculate_shell_side_score(self, props: Dict[str, float], meta: Dict[str, Any]) -> float:
+        score = 0.0
+        score += 4.0 if props.get("viscosity", 0) > 0.003 else 0.0
+        score += 5.0 if meta.get("phase") in {"condensing", "boiling", "two_phase"} else 0.0
+        score += 3.0 if props.get("density", 2000) < 15 else 0.0
+        score += 2.0 if props.get("t_k", 0) > 500 else 0.0
+        return score
+
+    def _assign_fluids_to_sides(self, hot: Dict[str, float], cold: Dict[str, float]) -> Dict[str, Any]:
+        hot_name = getattr(self.hot_in.component, "name", "hot")
+        cold_name = getattr(self.cold_in.component, "name", "cold")
+        hot_meta = {
+            "hazardous": bool(self.specs.get("hot_hazardous", False)),
+            "fouling": float(self.specs.get("hot_fouling_factor", self._get_fouling_factor(hot_name, temperature_k=hot["t_k"]))),
+            "corrosion": str(self.specs.get("hot_corrosion_level", self._get_corrosion_severity(hot_name))),
+            "phase": str(self.specs.get("hot_phase", hot.get("phase", "liquid"))),
+        }
+        cold_meta = {
+            "hazardous": bool(self.specs.get("cold_hazardous", False)),
+            "fouling": float(self.specs.get("cold_fouling_factor", self._get_fouling_factor(cold_name, temperature_k=cold["t_k"]))),
+            "corrosion": str(self.specs.get("cold_corrosion_level", self._get_corrosion_severity(cold_name))),
+            "phase": str(self.specs.get("cold_phase", cold.get("phase", "liquid"))),
+        }
+        hot_tube = self._calculate_tube_side_score(hot, hot_meta) - self._calculate_shell_side_score(hot, hot_meta)
+        cold_tube = self._calculate_tube_side_score(cold, cold_meta) - self._calculate_shell_side_score(cold, cold_meta)
+        self._debug(f"Hot fluid scoring: tube={self._calculate_tube_side_score(hot, hot_meta):.2f}, shell={self._calculate_shell_side_score(hot, hot_meta):.2f}")
+        self._debug(f"Cold fluid scoring: tube={self._calculate_tube_side_score(cold, cold_meta):.2f}, shell={self._calculate_shell_side_score(cold, cold_meta):.2f}")
+        if self.specs.get("force_hot_in_tubes"):
+            tube, shell = hot_name, cold_name
+            reason=["Forced by user: hot in tubes"]
+        elif self.specs.get("force_cold_in_tubes"):
+            tube, shell = cold_name, hot_name
+            reason=["Forced by user: cold in tubes"]
+        elif hot_tube >= cold_tube:
+            tube, shell = hot_name, cold_name
+            reason=[f"Hot fluid tube-side score {hot_tube:.2f} >= cold score {cold_tube:.2f}"]
+        else:
+            tube, shell = cold_name, hot_name
+            reason=[f"Cold fluid tube-side score {cold_tube:.2f} > hot score {hot_tube:.2f}"]
+        self._debug(f"Fluid assignment: tube={tube}, shell={shell}, reason={reason}")
+        return {"tube_side_fluid": tube, "shell_side_fluid": shell, "assignment_reason": reason}
+
     def _select_tube_geometry(self, area_required: float, hot: Dict[str, float], cold: Dict[str, float],
                               tube_passes: int) -> Dict[str, float]:
         tube_od = float(self.specs.get("tube_od")) if self.specs.get("tube_od") is not None else None
@@ -189,6 +372,11 @@ class ShellAndTubeHX(HeatExchanger):
             tube_count = math.ceil(area_required / max(area_per_tube, 1e-12))
             print("Tube Count: ",tube_count)
 
+        standard_geom = self._select_best_standard_geometry(area_required, tube_od, tube_length, tube_passes)
+        std_tube_count = standard_geom.get("tube_count")
+        if std_tube_count and std_tube_count >= tube_count:
+            self._debug(f"Using standard tube count lookup >= required: {std_tube_count}")
+            tube_count = std_tube_count
         tube_count = self._round_tube_count_to_passes(tube_count, tube_passes)
         print("Tube Count Round: ",tube_count)
         tube_pitch = float(self.specs.get("tube_pitch", 1.25 * tube_od))
@@ -214,7 +402,7 @@ class ShellAndTubeHX(HeatExchanger):
         clearance = float(self.specs.get("bundle_clearance", max(0.02, 0.05 * bundle_diameter)))
         return bundle_diameter + clearance
 
-    def _check_L_over_D(self, geometry: Dict[str, float], shell_diameter: float, tube_passes: int) -> Dict[str, float]:
+    def _check_L_over_D(self, geometry: Dict[str, float], shell_diameter: float, tube_passes: int, base_required_area: float | None = None, hot: Dict[str, float] | None = None) -> Dict[str, float]:
         ld = geometry["tube_length"] / max(shell_diameter, 1e-9)
         print("L/D: ",ld)
         if 5.0 <= ld <= 10.0:
@@ -226,18 +414,14 @@ class ShellAndTubeHX(HeatExchanger):
             print(f"geometry:{geometry}")
         #target_l = min(max(7.0 * shell_diameter, 0.5), 6.0)
         if self.specs.get("tube_length") is None:
-            #geometry["tube_length"] = target_l
-            area_per_tube = math.pi * geometry["tube_od"] * geometry["tube_length"]
-            geometry["tube_count"] = self._round_tube_count_to_passes(
-                math.ceil(geometry["area"] / max(area_per_tube, 1e-12)),
-                tube_passes,
-            )
-            geometry["area"] = geometry["tube_count"] * area_per_tube
+            if base_required_area is not None:
+                geometry["tube_count"] = self._recalculate_required_tubes(base_required_area, geometry, tube_passes)
+            geometry = self._regenerate_geometry(geometry, tube_passes, hot)
             print("Geometry :",geometry)
         return geometry
 
     def _check_velocities(self, geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float],
-                          tube_passes: int, shell_passes: int, shell_diameter: float) -> Tuple[float, float, int, float]:
+                          tube_passes: int, shell_passes: int, shell_diameter: float) -> Tuple[float, float, int, float, int]:
         q_vol_hot = hot["m_dot"] / max(hot["density"], 1e-12)
         q_vol_cold = cold["m_dot"] / max(cold["density"], 1e-12)
 
@@ -248,29 +432,32 @@ class ShellAndTubeHX(HeatExchanger):
         v_tube = q_vol_hot / tube_flow
         print("Tube Velocity:", v_tube)
 
-        v_min, v_max = get_velocity_range(self.hot_in.component)
+        v_min, v_max = self._get_velocity_limits(self.hot_in.component, hot)
+        self._debug(f"Velocity target range = ({v_min}, {v_max})")
         max_iter = 20
         iteration = 0
         
+        valid_passes = [1, 2, 4, 6, 8]
         while (v_tube > v_max or v_tube < v_min) and iteration < max_iter:
-            print(f"\nIteration: {iteration}")
-            print(f"Current velocity: {v_tube}")
+            self._debug(f"Velocity correction iteration={iteration}, current tube velocity={v_tube:.4f} m/s")
         
             if v_tube > v_max:
-                print("Velocity too LOW → decreasing passes")
-        
-                tube_passes = max(int(tube_passes / 2), 1)
+                self._debug("Velocity too HIGH -> decreasing passes")
+                lower = [p for p in valid_passes if p < tube_passes]
+                new_passes = max(lower) if lower else 1
                 
         
             elif v_tube < v_min:
-                print("Velocity too HIGH → increasing passes")
-        
-                tube_passes = min(int(tube_passes * 2), 8)  # cap at 8
-                if tube_passes < 1:
-                    tube_passes = 1
+                self._debug("Velocity too LOW -> increasing passes")
+                higher = [p for p in valid_passes if p > tube_passes]
+                new_passes = min(higher) if higher else 8
+            if new_passes == tube_passes:
+                self._debug("Pass optimization saturated")
+                break
+            tube_passes = new_passes
                 
         
-            print(f"Updated tube passes: {tube_passes}")
+            self._debug(f"Updated tube passes={tube_passes}")
         
             tube_flow = max(
                 geometry["tube_count"] / tube_passes * area_per_tube_flow,
@@ -279,14 +466,25 @@ class ShellAndTubeHX(HeatExchanger):
         
             v_tube = q_vol_hot / tube_flow
         
-            print(f"Updated tube flow: {tube_flow}")
-            print(f"Updated velocity: {v_tube}")
+            self._debug(f"Updated tube flow={tube_flow:.6f} m2")
+            self._debug(f"Updated velocity={v_tube:.6f} m/s")
         
             iteration += 1
         
-        # Final safety
-        if iteration == max_iter:
-            print("⚠️ Warning: Velocity did not converge")
+        if (v_tube > v_max or v_tube < v_min) and iteration == max_iter:
+            self._debug("Tube velocity did not converge with pass-only optimization")
+            direction = "larger" if v_tube > v_max else "smaller"
+            next_od = self._select_next_tube_size(geometry["tube_od"], direction)
+            if abs(next_od - geometry["tube_od"]) > 1e-12:
+                self._debug(f"Tube velocity out of range. Current tube OD = {geometry['tube_od']/0.0254:.2f} in")
+                self._debug(f"Selecting {direction} tube OD = {next_od/0.0254:.2f} in and restarting sizing")
+                geometry["tube_od"] = next_od
+                geometry["tube_id"] = max(0.8 * next_od, 1e-6)
+                area_per_tube_flow = math.pi * geometry["tube_id"] ** 2 / 4.0
+                tube_flow = max(geometry["tube_count"] / max(tube_passes, 1) * area_per_tube_flow, 1e-12)
+                v_tube = q_vol_hot / tube_flow
+            else:
+                self._debug("No further tube OD resizing possible; retaining current geometry")
 
         pitch = 1.25 * geometry["tube_od"]
         porosity = 0.6
@@ -310,7 +508,7 @@ class ShellAndTubeHX(HeatExchanger):
             else:
                 break
 
-        return v_tube, v_shell, geometry["tube_count"], shell_diameter
+        return v_tube, v_shell, geometry["tube_count"], shell_diameter, tube_passes
 
     def _calculate_dimensionless(self, geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float],
                                  v_tube: float, v_shell: float) -> Dict[str, float]:
@@ -349,27 +547,59 @@ class ShellAndTubeHX(HeatExchanger):
         u_min, u_max = u_range if u_range else (100.0, 1000.0)
         return max(min(u_calculated, u_max), u_min)
 
+    def _validate_geometry(self, state: Dict[str, Any], tube_dp: float, shell_dp: float, hot: Dict[str, float], cold: Dict[str, float]) -> List[str]:
+        violations: List[str] = []
+        if state["geometry"]["area"] < state["area_required"]:
+            violations.append("area")
+        vmin, vmax = self._get_velocity_limits(self.hot_in.component, hot)
+        if not (vmin <= state["v_tube"] <= vmax):
+            violations.append("tube_velocity")
+        shell_v_target = self._get_velocity_limits(self.cold_in.component, cold)
+        if not (shell_v_target[0] <= state["v_shell"] <= shell_v_target[1]):
+            violations.append("shell_velocity")
+        if tube_dp > self._dp_limit(hot):
+            violations.append("tube_dp")
+        if shell_dp > self._dp_limit(cold):
+            violations.append("shell_dp")
+        ld = state["geometry"]["tube_length"] / max(state["shell_diameter"], 1e-9)
+        if not (5.0 <= ld <= 10.0):
+            violations.append("ld_ratio")
+        return violations
+
     def _iterate_U(self, q_watts: float, cltd: float, hot: Dict[str, float], cold: Dict[str, float],
                    shell_passes: int, tube_passes: int, u_assumed: float,
                    u_range: Tuple[float, float] | None) -> Dict[str, Any]:
         state: Dict[str, Any] = {"iterations": 0, "u_assumed": u_assumed}
         max_iter = 15
+        max_redesign_iterations = 10
+        base_required_area: float | None = None
 
         for i in range(1, max_iter + 1):
-            area_required = self._calculate_area(q_watts, state["u_assumed"], cltd)
+            self._debug(f"Iteration = {i}")
+            if base_required_area is None:
+                base_required_area = self._calculate_required_area(q_watts, state["u_assumed"], cltd)
+            area_required = base_required_area
+            self._debug(f"Base required area = {area_required:.4f} m2")
             geometry = self._select_tube_geometry(area_required, hot, cold, tube_passes)
+            geometry["tube_count"] = self._recalculate_required_tubes(area_required, geometry, tube_passes)
+            geometry = self._regenerate_geometry(geometry, tube_passes, hot)
 
             bundle_diameter = self._calculate_bundle_diameter(geometry["tube_count"],geometry["tube_od"])
             print("Bundle Dia: ",bundle_diameter)
             shell_diameter = self._calculate_shell_diameter(bundle_diameter)
             print("Shell Dia: ",shell_diameter)
-            geometry = self._check_L_over_D(geometry, shell_diameter, tube_passes)
+            geometry = self._check_L_over_D(geometry, shell_diameter, tube_passes, area_required, hot)
+            geometry["tube_count"] = self._recalculate_required_tubes(area_required, geometry, tube_passes)
+            standard_geom = self._select_best_standard_geometry(area_required, geometry["tube_od"], geometry["tube_length"], tube_passes)
+            if standard_geom.get("tube_count", 0) >= geometry["tube_count"]:
+                geometry["tube_count"] = standard_geom["tube_count"]
+            geometry = self._regenerate_geometry(geometry, tube_passes, hot)
             bundle_diameter = self._calculate_bundle_diameter(geometry["tube_count"],geometry["tube_od"])
             print("Bundle Dia: ",bundle_diameter)
             shell_diameter = self._calculate_shell_diameter(bundle_diameter)
             print("Shell Dia: ",shell_diameter)
 
-            v_tube, v_shell, tube_count, shell_diameter = self._check_velocities(
+            v_tube, v_shell, tube_count, shell_diameter, tube_passes = self._check_velocities(
                 geometry,
                 hot,
                 cold,
@@ -378,7 +608,7 @@ class ShellAndTubeHX(HeatExchanger):
                 shell_diameter,
             )
             geometry["tube_count"] = tube_count
-            geometry["area"] = geometry["tube_count"] * math.pi * geometry["tube_od"] * geometry["tube_length"]
+            geometry = self._regenerate_geometry(geometry, tube_passes, hot)
 
             dimless = self._calculate_dimensionless(geometry, hot, cold, v_tube, v_shell)
             h_t, h_s = self._calculate_htc(dimless, geometry, hot, cold)
@@ -399,9 +629,31 @@ class ShellAndTubeHX(HeatExchanger):
                     "u_calculated": u_calculated,
                 }
             )
+            tube_dp_i, shell_dp_i = self._calculate_pressure_drop(hot, cold, shell_passes, tube_passes, shell_diameter, geometry["tube_length"], geometry["tube_id"], v_tube, v_shell)
+            violations = self._validate_geometry(state, tube_dp_i, shell_dp_i, hot, cold)
+            self._debug(f"Selected tube count = {geometry['tube_count']}")
+            self._debug(f"Selected shell ID ~= {shell_diameter/0.0254:.2f} in")
+            self._debug(f"Tube velocity = {v_tube:.4f} m/s")
+            self._debug(f"Shell velocity = {v_shell:.4f} m/s")
+            self._debug(f"Tube dp = {tube_dp_i:.2f} Pa")
+            self._debug(f"Shell dp = {shell_dp_i:.2f} Pa")
+            self._debug(f"Actual provided area = {geometry['area']:.4f} m2")
+            self._debug(f"Area margin = {(geometry['area'] - area_required):.4f} m2")
+            self._debug(f"Constraint violations = {violations}")
 
-            if abs((u_calculated - state["u_assumed"]) / max(state["u_assumed"], 1e-9)) < 0.30:
+            if not violations and abs((u_calculated - state["u_assumed"]) / max(state["u_assumed"], 1e-9)) < 0.30:
                 break
+            if i >= max_redesign_iterations:
+                self._debug("Redesign iterations exceeded; returning best feasible geometry")
+                state["status_override"] = "PARTIAL"
+                break
+            if "area" in violations:
+                self._debug("Redesign reason = insufficient area; increasing tube count")
+                area_per_tube = math.pi * geometry["tube_od"] * geometry["tube_length"]
+                required_extra_area = area_required - geometry["area"]
+                additional_tubes = math.ceil(required_extra_area / max(area_per_tube, 1e-12))
+                geometry["tube_count"] = self._round_tube_count_to_passes(geometry["tube_count"] + max(additional_tubes, 1), tube_passes)
+                geometry = self._regenerate_geometry(geometry, tube_passes, hot)
             state["u_assumed"] = u_calculated
 
         return state
@@ -447,7 +699,7 @@ class ShellAndTubeHX(HeatExchanger):
 
     def _velocity_warnings(self, tube_v: float, shell_v: float, hot: Dict[str, float], cold: Dict[str, float]) -> List[str]:
         warnings: List[str] = []
-        v_min, v_max = get_velocity_range(self.hot_in.component)
+        v_min, v_max = self._get_velocity_limits(self.hot_in.component, hot)
         if tube_v > v_max * 1.5:
             warnings.append(f"High tube velocity {tube_v:.2f} m/s → erosion risk")
         elif tube_v > v_max:
@@ -457,11 +709,7 @@ class ShellAndTubeHX(HeatExchanger):
         elif tube_v < v_min:
             warnings.append(f"Tube velocity slightly low ({v_min}-{v_max} m/s recommended)")
 
-        if cold["phase"] == "vapor":
-            p = cold["p_bar"]
-            target = (50, 70) if p < 1 else ((10, 30) if p <= 2 else (5, 10))
-        else:
-            target = (0.3, 1.0)
+        target = self._get_velocity_limits(self.cold_in.component, cold)
         if not (target[0] <= shell_v <= target[1]):
             warnings.append(f"Shell velocity {shell_v:.2f} m/s outside recommended {target[0]}-{target[1]} m/s")
         return warnings
@@ -477,7 +725,11 @@ class ShellAndTubeHX(HeatExchanger):
             else:
                 advisory.append(w)
 
-        if critical:
+        if payload.get("status_override") == "PARTIAL":
+            status = "PARTIAL"
+        elif "Area significantly undersized — redesign required" in warnings:
+            status = "FAILED"
+        elif critical:
             status = "VIOLATION"
         elif advisory:
             status = "WARNING"
@@ -507,6 +759,10 @@ class ShellAndTubeHX(HeatExchanger):
             "h_shell": payload.get("h_s"),
             "status": status,
             "warnings": warnings,
+            "tube_side_fluid": payload.get("assignment", {}).get("tube_side_fluid"),
+            "shell_side_fluid": payload.get("assignment", {}).get("shell_side_fluid"),
+            "assignment_reason": payload.get("assignment", {}).get("assignment_reason", []),
+            "assignment": payload.get("assignment", {}),
         }
 
     def _design_kern(self) -> Dict[str, Any]:
@@ -514,6 +770,7 @@ class ShellAndTubeHX(HeatExchanger):
         cold = self._stream_props(self.cold_in)
         self._warnings = []
         self._validate_inputs(hot, cold)
+        assignment = self._assign_fluids_to_sides(hot, cold)
 
         if hot["phase"] == "vapor":
             self.service_type = "condenser"
@@ -545,9 +802,11 @@ class ShellAndTubeHX(HeatExchanger):
 
         u_assumed = self._assume_u(hot, cold)
         print(u_assumed)
-        hot_type = getattr(self.hot_in.component, "hx_type", "generic")
-        cold_type = getattr(self.cold_in.component, "hx_type", "generic")
-        u_range = get_u_range("shell_and_tube", self.service_type, hot_type, cold_type)
+        hot_hx = self.hot_in.component.hx_data() if hasattr(self.hot_in.component, "hx_data") else {"u_key": getattr(self.hot_in.component, "hx_type", "generic")}
+        cold_hx = self.cold_in.component.hx_data() if hasattr(self.cold_in.component, "hx_data") else {"u_key": getattr(self.cold_in.component, "hx_type", "generic")}
+        self._debug(f"Hot hx_data = {hot_hx}")
+        self._debug(f"Cold hx_data = {cold_hx}")
+        u_range = get_u_range("shell_and_tube", self.service_type, hot_hx.get("u_key", "generic"), cold_hx.get("u_key", "generic"))
 
         state = self._iterate_U(effective_q_watts, cltd, hot, cold, shell_passes, tube_passes, u_assumed, u_range)
 
@@ -586,6 +845,10 @@ class ShellAndTubeHX(HeatExchanger):
         payload = {
             **state,
             "warnings": warnings,
+            "tube_side_fluid": assignment.get("tube_side_fluid"),
+            "shell_side_fluid": assignment.get("shell_side_fluid"),
+            "assignment_reason": assignment.get("assignment_reason", []),
+            "assignment": assignment,
             "q_watts_original": q_watts,
             "q_watts_effective": effective_q_watts,
             "lmtd": lmtd,

--- a/processpi/equipment/heatexchangers/standards.py
+++ b/processpi/equipment/heatexchangers/standards.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Optional, Tuple
 import math
-from processpi.pipelines.standards import RECOMMENDED_VELOCITIES
 
 HX_U_STANDARDS = {
     "shell_and_tube": {
@@ -100,7 +99,7 @@ def get_velocity_range(component):
     if name in RECOMMENDED_VELOCITIES:
         return RECOMMENDED_VELOCITIES[name]
 
-    return (0.8, 2.5)
+    return DEFAULT_VELOCITY_RANGE
 
 TUBE_LENGTH_STANDARD = [
     {"length": 0.5, "area": 10},
@@ -287,3 +286,77 @@ def tube_length_select(tube_length, ld):
     else:
         print("[5 <= L/D <= 10] Length is acceptable. No change.")
         return current_length
+
+
+# -------------------------------
+# Industrial standards databases
+# -------------------------------
+STANDARD_TUBE_COUNT_TABLES = {
+    "triangular": {
+        0.75: {"0.9375_pitch": {8: {1: 37, 2: 30, 4: 24, 6: 20, 8: 18}, 10: {1: 61, 2: 50, 4: 40, 6: 34, 8: 30}, 12: {1: 91, 2: 76, 4: 62, 6: 52, 8: 46}}},
+        1.0: {"1.25_pitch": {10: {1: 37, 2: 30, 4: 24, 6: 20, 8: 18}, 12: {1: 55, 2: 44, 4: 36, 6: 30, 8: 26}, 16: {1: 97, 2: 80, 4: 64, 6: 54, 8: 46}}},
+        1.25: {"1.5625_pitch": {14: {1: 37, 2: 30, 4: 24, 6: 20, 8: 18}, 18: {1: 61, 2: 50, 4: 40, 6: 34, 8: 30}, 24: {1: 127, 2: 104, 4: 84, 6: 70, 8: 60}}},
+        1.5: {"1.875_pitch": {18: {1: 37, 2: 30, 4: 24, 6: 20, 8: 18}, 24: {1: 73, 2: 58, 4: 46, 6: 40, 8: 34}, 30: {1: 127, 2: 102, 4: 82, 6: 70, 8: 60}}},
+    },
+    "square": {
+        0.75: {"1.0_pitch": {8: {1: 31, 2: 24, 4: 20, 6: 18, 8: 16}, 10: {1: 49, 2: 40, 4: 32, 6: 28, 8: 24}, 12: {1: 71, 2: 58, 4: 48, 6: 40, 8: 34}}},
+        1.0: {"1.25_pitch": {10: {1: 31, 2: 24, 4: 20, 6: 18, 8: 16}, 12: {1: 45, 2: 36, 4: 30, 6: 26, 8: 22}, 16: {1: 79, 2: 64, 4: 52, 6: 44, 8: 38}}},
+        1.25: {"1.5625_pitch": {14: {1: 31, 2: 24, 4: 20, 6: 18, 8: 16}, 18: {1: 49, 2: 40, 4: 32, 6: 28, 8: 24}, 24: {1: 105, 2: 84, 4: 68, 6: 58, 8: 50}}},
+        1.5: {"1.875_pitch": {18: {1: 31, 2: 24, 4: 20, 6: 18, 8: 16}, 24: {1: 59, 2: 46, 4: 38, 6: 32, 8: 28}, 30: {1: 105, 2: 84, 4: 68, 6: 58, 8: 50}}},
+    },
+}
+
+STANDARD_EXCHANGER_TUBES = {
+    0.5: {20: {"wall_in": 0.035, "id_in": 0.43}, 18: {"wall_in": 0.049, "id_in": 0.402}, 16: {"wall_in": 0.065, "id_in": 0.37}, 14: {"wall_in": 0.083, "id_in": 0.334}, 12: {"wall_in": 0.109, "id_in": 0.282}},
+    0.75: {20: {"wall_in": 0.035, "id_in": 0.68}, 18: {"wall_in": 0.049, "id_in": 0.652}, 16: {"wall_in": 0.065, "id_in": 0.62}, 14: {"wall_in": 0.083, "id_in": 0.584}, 12: {"wall_in": 0.109, "id_in": 0.532}},
+    1.0: {20: {"wall_in": 0.035, "id_in": 0.93}, 18: {"wall_in": 0.049, "id_in": 0.902}, 16: {"wall_in": 0.065, "id_in": 0.87}, 14: {"wall_in": 0.083, "id_in": 0.834}, 12: {"wall_in": 0.109, "id_in": 0.782}},
+    1.25: {20: {"wall_in": 0.035, "id_in": 1.18}, 18: {"wall_in": 0.049, "id_in": 1.152}, 16: {"wall_in": 0.065, "id_in": 1.12}, 14: {"wall_in": 0.083, "id_in": 1.084}, 12: {"wall_in": 0.109, "id_in": 1.032}},
+    1.5: {20: {"wall_in": 0.035, "id_in": 1.43}, 18: {"wall_in": 0.049, "id_in": 1.402}, 16: {"wall_in": 0.065, "id_in": 1.37}, 14: {"wall_in": 0.083, "id_in": 1.334}, 12: {"wall_in": 0.109, "id_in": 1.282}},
+}
+
+STANDARD_PIPE_TABLES = {
+    0.125: {40: {"od_in": 0.405, "id_in": 0.269}, 80: {"od_in": 0.405, "id_in": 0.215}},
+    0.5: {20: {"od_in": 0.84, "id_in": 0.622}, 40: {"od_in": 0.84, "id_in": 0.622}, 80: {"od_in": 0.84, "id_in": 0.546}},
+    1.0: {20: {"od_in": 1.315, "id_in": 1.049}, 40: {"od_in": 1.315, "id_in": 1.049}, 80: {"od_in": 1.315, "id_in": 0.957}},
+    2.0: {20: {"od_in": 2.375, "id_in": 2.067}, 40: {"od_in": 2.375, "id_in": 2.067}, 80: {"od_in": 2.375, "id_in": 1.939}},
+    4.0: {20: {"od_in": 4.5, "id_in": 4.154}, 40: {"od_in": 4.5, "id_in": 4.026}, 80: {"od_in": 4.5, "id_in": 3.826}},
+    6.0: {20: {"od_in": 6.625, "id_in": 6.357}, 40: {"od_in": 6.625, "id_in": 6.065}, 80: {"od_in": 6.625, "id_in": 5.761}},
+    8.0: {20: {"od_in": 8.625, "id_in": 8.329}, 40: {"od_in": 8.625, "id_in": 7.981}, 80: {"od_in": 8.625, "id_in": 7.625}},
+    10.0: {20: {"od_in": 10.75, "id_in": 10.42}, 40: {"od_in": 10.75, "id_in": 10.02}, 80: {"od_in": 10.75, "id_in": 9.564}},
+    12.0: {20: {"od_in": 12.75, "id_in": 12.39}, 40: {"od_in": 12.75, "id_in": 11.938}, 80: {"od_in": 12.75, "id_in": 11.376}},
+    16.0: {20: {"od_in": 16.0, "id_in": 15.25}, 40: {"od_in": 16.0, "id_in": 15.0}, 80: {"od_in": 16.0, "id_in": 14.5}},
+    24.0: {20: {"od_in": 24.0, "id_in": 23.25}, 40: {"od_in": 24.0, "id_in": 23.0}, 80: {"od_in": 24.0, "id_in": 22.5}},
+}
+
+FOULING_FACTOR_DATABASE = {
+    "seawater": {"base": 0.00035, "velocity_sensitive": True},
+    "brackish_water": {"base": 0.00030, "velocity_sensitive": True},
+    "cooling_tower_water": {"base": 0.00025, "velocity_sensitive": True},
+    "distilled_water": {"base": 0.00009, "velocity_sensitive": False},
+    "treated_water": {"base": 0.00018, "velocity_sensitive": True},
+    "river_water": {"base": 0.00035, "velocity_sensitive": True},
+    "hydrocarbons": {"base": 0.00020, "velocity_sensitive": True},
+    "crude": {"base": 0.00050, "velocity_sensitive": True, "temperature_sensitive": True},
+    "steam": {"base": 0.00009, "velocity_sensitive": False},
+    "vapor": {"base": 0.00012, "velocity_sensitive": False},
+    "reboiler": {"base": 0.00035, "velocity_sensitive": True, "temperature_sensitive": True},
+    "condenser": {"base": 0.00018, "velocity_sensitive": False},
+    "refinery": {"base": 0.00040, "velocity_sensitive": True},
+    "oil": {"base": 0.00030, "velocity_sensitive": True, "temperature_sensitive": True},
+}
+
+CORROSION_SEVERITY_DATABASE = {
+    "seawater": "high",
+    "brackish_water": "high",
+    "acid": "high",
+    "hydrocarbon": "low-medium",
+    "steam_condensate": "low",
+    "refinery": "medium-high",
+    "treated_water": "medium",
+    "crude": "medium-high",
+    "amine": "high",
+}
+
+
+DEFAULT_VELOCITY_RANGE = (0.8, 2.5)
+RECOMMENDED_VELOCITIES = {"organic_liquid": (1.8, 2.0),"inorganic_liquid": (1.2, 1.8),"oil": (1.8, 2.0),"gas": (15.0, 30.0),"vapor": (15.0, 30.0),"water": (1.0, 2.5),"acetic_acid": (1.0, 2.0),"acetone": (1.0, 2.0),"acrylic_acid": (1.0, 2.0),"air": (10.0, 20.0),"ammonia": (8.0, 15.0),"benzene": (1.0, 2.0),"benzoic_acid": (1.0, 2.0),"bromine": (0.8, 1.5),"butane": (10.0, 18.0),"carbon_dioxide": (8.0, 15.0),"carbon_monoxide": (8.0, 15.0),"carbon_tetrachloride": (0.8, 1.5),"chlorine": (5.0, 10.0),"chlorobenzene": (1.0, 2.0),"chloroform": (0.8, 1.5),"chloromethane": (8.0, 15.0),"cyanogen": (8.0, 15.0),"cyclohexane": (1.0, 2.0),"ethane": (10.0, 20.0),"ethanol": (1.0, 2.0),"ethyl_acetate": (1.0, 2.0),"ethylene": (10.0, 20.0),"fluorine": (5.0, 10.0),"fluorobenzene": (1.0, 2.0),"formic_acid": (1.0, 2.0),"helium_4": (20.0, 40.0),"hydrogen_chloride": (8.0, 15.0),"hydrogen_cyanide": (8.0, 15.0),"hydrogen_sulfide": (8.0, 15.0),"methane": (10.0, 20.0),"methanol": (1.0, 2.0),"neon": (15.0, 30.0),"nitrogen": (10.0, 20.0),"nitrous_oxide": (8.0, 15.0),"nitric_oxide": (8.0, 15.0),"oxygen": (10.0, 20.0),"ozone": (8.0, 15.0),"phenol": (1.0, 2.0),"propane": (10.0, 18.0),"propionic_acid": (1.0, 2.0),"styrene": (1.0, 2.0),"sulfur_dioxide": (8.0, 15.0),"toluene": (1.0, 2.0)}


### PR DESCRIPTION
### Motivation
- Provide richer fluid metadata for heat-exchanger sizing and normalize fluid heat-transfer type names to a common set (e.g. `vapor`, `organic`).
- Improve shell-and-tube geometric selection, velocity constraints, fouling/corrosion handling and standardization to produce more realistic, standards-driven sizing results.

### Description
- Added `hx_data` methods to `benzene`, `toluene`, `organic_liquid`, `oil`, and `water` components to expose fluid family, phase, velocity/u/fouling/corrosion lookup keys and normalized `hx_type`/`httype` values.
- Reworked `ShellAndTubeHX` with many helper methods: standards loader, debug helper, standard tube-count selection, geometry regeneration, tube-size stepping, velocity limits lookup, fouling factor and corrosion severity lookups, tube/shell scoring and automatic assignment of fluids to tube/shell sides, and geometry validation.
- Improved velocity control and pass-selection algorithm to iterate tube passes, fall back to tube OD changes when needed, and return the updated passes; added DP calculations and constraint-driven redesign logic in `_iterate_U` with partial-status handling.
- Extended `standards.py` with industrial tables and databases: `STANDARD_TUBE_COUNT_TABLES`, `STANDARD_EXCHANGER_TUBES`, `STANDARD_PIPE_TABLES`, `FOULING_FACTOR_DATABASE`, `CORROSION_SEVERITY_DATABASE`, `DEFAULT_VELOCITY_RANGE`, and `RECOMMENDED_VELOCITIES`, and updated `get_velocity_range` to return the default range when not found.

### Testing
- Ran project import/smoke checks for the modified modules (`processpi.components.*`, `processpi.equipment.heatexchangers.*`) and confirmed no import errors.
- Executed the repository unit test suite and linters (where present) against the changes; all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc30d04e208326a842f9ea3d70b9d3)