### PR TITLE
Add phase-change heat exchanger models, logging, and examples

### DIFF
--- a/examples/phase_change_hx_examples.py
+++ b/examples/phase_change_hx_examples.py
@@ -1,0 +1,78 @@
+"""ProcessPI v0.3.0 phase-change heat-exchanger examples.
+
+Includes design/rate scenarios for condenser, evaporator, and reboiler
+with horizontal and vertical orientation variants.
+"""
+
+from processpi.equipment.heatexchangers import HeatExchangerEngine
+
+
+def condenser_design(hot_in, cold_in):
+    return (
+        HeatExchangerEngine(method="kern")
+        .fit(
+            hot_in=hot_in,
+            cold_in=cold_in,
+            hx_type="condenser",
+            mode="design",
+            orientation="horizontal",
+            condensation_mode="total",
+            condensing_side="shell",
+            latent_heat=2.1e6,
+        )
+        .run()
+    )
+
+
+def condenser_rate(hot_in, cold_in):
+    return (
+        HeatExchangerEngine(method="kern")
+        .fit(
+            hot_in=hot_in,
+            cold_in=cold_in,
+            hx_type="condenser",
+            mode="rate",
+            orientation="vertical",
+            condensation_mode="partial",
+            vapor_fraction_condensed=0.7,
+            latent_heat=2.1e6,
+            tube_od=0.01905,
+            tube_id=0.016,
+            tube_length=6.0,
+            area=120.0,
+        )
+        .run()
+    )
+
+
+def evaporator_design(hot_in, cold_in):
+    return (
+        HeatExchangerEngine(method="kern")
+        .fit(
+            hot_in=hot_in,
+            cold_in=cold_in,
+            hx_type="evaporator",
+            mode="design",
+            orientation="vertical",
+            boiling_side="shell",
+            latent_heat=2.25e6,
+        )
+        .run()
+    )
+
+
+def reboiler_design(hot_in, cold_in):
+    return (
+        HeatExchangerEngine(method="kern")
+        .fit(
+            hot_in=hot_in,
+            cold_in=cold_in,
+            hx_type="reboiler",
+            mode="design",
+            reboiler_type="vertical_thermosyphon",
+            orientation="vertical",
+            boiling_side="shell",
+            latent_heat=2.3e6,
+        )
+        .run()
+    )

--- a/processpi/equipment/heatexchangers/base.py
+++ b/processpi/equipment/heatexchangers/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+import logging
 from typing import Any, Dict, Optional
 
 from processpi.calculations.heat_transfer import HeatExchangerArea, LMTD, OverallHeatTransferCoefficient
@@ -8,13 +9,29 @@ from processpi.calculations.heat_transfer.hx_kern import LatentDuty, SensibleDut
 from processpi.streams.material import MaterialStream
 
 
-class HeatExchanger(ABC):
+class HeatExchangerBaseMixin:
+    def _init_runtime(self) -> None:
+        self.verbose = bool(self.specs.get("verbose", False))
+        self.logger = self.specs.get("logger") or logging.getLogger(f"processpi.hx.{self.__class__.__name__.lower()}")
+        self._warnings: list[str] = []
+
+    def _debug(self, *args: object) -> None:
+        if self.verbose:
+            self.logger.debug(" ".join(str(a) for a in args))
+
+    def _warn(self, message: str) -> None:
+        self._warnings.append(message)
+        self.logger.warning(message)
+
+
+class HeatExchanger(HeatExchangerBaseMixin, ABC):
     def __init__(self, hot_in: MaterialStream, cold_in: MaterialStream, hot_out: Optional[MaterialStream] = None, cold_out: Optional[MaterialStream] = None, **specs: Any):
         self.hot_in = hot_in
         self.cold_in = cold_in
         self.hot_out = hot_out
         self.cold_out = cold_out
         self.specs = specs
+        self._init_runtime()
 
     def _stream_props(self, s: MaterialStream) -> Dict[str, float]:
         return {

--- a/processpi/equipment/heatexchangers/condenser.py
+++ b/processpi/equipment/heatexchangers/condenser.py
@@ -1,221 +1,138 @@
 from __future__ import annotations
 
-import math
 from typing import Any, Dict
 
-from processpi.calculations.heat_transfer.hx_kern import (
-    CondensationHTC,
-    LatentDuty,
-)
+from processpi.calculations.heat_transfer.hx_kern import CondensationHTC, LatentDuty
 
 from .shell_and_tube import ShellAndTubeHX
 
 
 class CondenserHX(ShellAndTubeHX):
+    """Production-oriented shell-and-tube condenser with phase-change safeguards."""
 
-    """
-    Shell-and-tube condenser.
-
-    Architecture:
-    - Reuses ShellAndTubeHX geometry engine
-    - Reuses pressure-drop framework
-    - Reuses Bell/Kern infrastructure
-    - Adds condensation heat transfer handling
-    """
-
-    def __init__(
-        self,
-        *args: Any,
-        method: str = "kern",
-        **kwargs: Any,
-    ):
-
-        super().__init__(
-            *args,
-            method=method,
-            **kwargs,
-        )
-
+    def __init__(self, *args: Any, method: str = "kern", **kwargs: Any):
+        super().__init__(*args, method=method, **kwargs)
         self.service_type = "condenser"
+        self.orientation = str(self.specs.get("orientation", "horizontal")).lower()
+        self.condensing_side = str(self.specs.get("condensing_side", "shell")).lower()
+        self.condensation_mode = str(self.specs.get("condensation_mode", "total")).lower()
 
-    # ==========================================================
-    # OVERRIDE DUTY
-    # ==========================================================
-
-    def _calculate_heat_duty(
-        self,
-        hot: Dict[str, float],
-        cold: Dict[str, float],
-    ):
-
+    def _calculate_heat_duty(self, hot: Dict[str, float], cold: Dict[str, float], **kwargs: Any):
         latent_heat = self.specs.get("latent_heat")
-
         if latent_heat is None:
+            raise ValueError("Condenser requires latent_heat for condensation service")
 
-            raise ValueError(
-                "Condenser requires latent_heat "
-                "for vapor condensation."
-            )
+        vapor_fraction = float(self.specs.get("vapor_fraction_condensed", 1.0 if self.condensation_mode == "total" else 0.5))
+        vapor_fraction = max(0.05, min(vapor_fraction, 1.0))
 
-        q_watts = (
-            LatentDuty(
-                m_dot=hot["m_dot"],
-                latent_heat=latent_heat,
-            )
-            .calculate()
-            .to("W")
-            .value
-        )
-
+        q_watts = LatentDuty(m_dot=hot["m_dot"] * vapor_fraction, latent_heat=latent_heat).calculate().to("W").value
         th_in = hot["t_k"]
-
-        # Condensing vapor assumed nearly constant temperature
-        th_out = th_in
-
         tc_in = cold["t_k"]
 
-        tc_out = (
-            tc_in
-            + q_watts
-            / max(
-                cold["m_dot"] * cold["cp"] * 1000.0,
-                1e-12,
-            )
-        )
+        # Near-isothermal condensing side temperature
+        th_out = th_in - float(self.specs.get("subcooling", 0.0))
+        tc_out = tc_in + q_watts / max(cold["m_dot"] * cold["cp"] * 1000.0, 1e-12)
 
-        return (
-            q_watts,
-            th_out,
-            tc_out,
-        )
+        if tc_out >= th_in:
+            self._warn("Condenser cold outlet approaches/exceeds condensing temperature; clipping to feasible approach")
+            tc_out = th_in - 1.0
 
-    # ==========================================================
-    # CONDENSATION HTC
-    # ==========================================================
+        return q_watts, th_out, tc_out
 
-    def _calculate_condensation_htc(
+    def _calculate_ft(self, *args: Any, **kwargs: Any) -> float:
+        # Phase change service: bypass standard Ft correction.
+        return 1.0
+
+    def _calculate_condensation_htc(self, hot: Dict[str, float], geometry: Dict[str, float]) -> float:
+        vapor_density = max(hot.get("density", 1.0), 0.1)
+        liquid_density = max(float(self.specs.get("condensate_density", vapor_density * 50.0)), vapor_density + 1.0)
+        liquid_viscosity = max(float(self.specs.get("condensate_viscosity", 3e-4)), 1e-5)
+        liquid_k = max(float(self.specs.get("condensate_k", 0.1)), 0.01)
+        latent_heat = float(self.specs.get("latent_heat", 2.2e6))
+        delta_t = max(float(self.specs.get("condensation_dT", 5.0)), 0.5)
+        length = max(float(geometry.get("tube_length", 6.0)), 0.5)
+
+        h_base = CondensationHTC(
+            rho_l=liquid_density,
+            rho_v=vapor_density,
+            mu_l=liquid_viscosity,
+            k_l=liquid_k,
+            h_fg=latent_heat,
+            delta_t=delta_t,
+            length=length,
+        ).calculate().to("W/m2K").value
+
+        orientation_factor = 1.0 if self.orientation == "vertical" else 0.85
+        side_factor = 0.9 if self.condensing_side == "tube" else 1.0
+        h_cond = h_base * orientation_factor * side_factor
+        return max(1200.0, min(h_cond, 20000.0))
+
+    def _calculate_htc(self, dimless: Dict[str, float], geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float], **kwargs: Any):
+        h_tube, h_shell = super()._calculate_htc(dimless, geometry, hot, cold)
+        h_cond = self._calculate_condensation_htc(hot, geometry)
+
+        if self.condensing_side == "tube":
+            h_tube = h_cond
+        else:
+            h_shell = h_cond
+        return h_tube, h_shell
+
+    def _calculate_pressure_drop(
         self,
-        hot: Dict[str, float],
-        geometry: Dict[str, float],
-    ) -> float:
-
-        vapor_density = hot.get("density", 1.0)
-
-        liquid_density = self.specs.get(
-            "condensate_density",
-            vapor_density * 50.0,
-        )
-
-        liquid_viscosity = self.specs.get(
-            "condensate_viscosity",
-            0.0003,
-        )
-
-        liquid_k = self.specs.get(
-            "condensate_k",
-            0.1,
-        )
-
-        latent_heat = self.specs.get(
-            "latent_heat",
-        )
-
-        delta_t = max(
-            self.specs.get("condensation_dT", 5.0),
-            1e-6,
-        )
-
-        tube_length = geometry["tube_length"]
-
-        try:
-
-            h_cond = (
-                CondensationHTC(
-                    rho_l=liquid_density,
-                    rho_v=vapor_density,
-                    mu_l=liquid_viscosity,
-                    k_l=liquid_k,
-                    h_fg=latent_heat,
-                    delta_t=delta_t,
-                    length=tube_length,
-                )
-                .calculate()
-                .to("W/m2K")
-                .value
-            )
-
-        except Exception:
-
-            # fallback realistic range
-            h_cond = 5000.0
-
-        return max(h_cond, 1000.0)
-
-    # ==========================================================
-    # OVERRIDE HTC CALCULATION
-    # ==========================================================
-
-    def _calculate_htc(
-        self,
-        dimless: Dict[str, float],
         geometry: Dict[str, float],
         hot: Dict[str, float],
         cold: Dict[str, float],
+        shell_velocity: float | None = None,
+        tube_velocity: float | None = None,
+        **kwargs: Any,
     ):
-
-        # ======================================================
-        # HOT SIDE = CONDENSING VAPOR
-        # ======================================================
-
-        h_cond = self._calculate_condensation_htc(
-            hot,
-            geometry,
+        shell_velocity = (
+            shell_velocity
+            if shell_velocity is not None
+            else float(kwargs.get("shell_velocity", 0.0))
         )
-
-        # ======================================================
-        # COLD SIDE = NORMAL COOLING FLUID
-        # ======================================================
-
-        _, h_shell = super()._calculate_htc(
-            dimless,
-            geometry,
-            hot,
-            cold,
+        tube_velocity = (
+            tube_velocity
+            if tube_velocity is not None
+            else float(kwargs.get("tube_velocity", 0.0))
         )
+        shell_passes = int(kwargs.get("shell_passes", 1))
+        tube_passes = int(kwargs.get("tube_passes", 1))
+        _shell_diameter = kwargs.get("shell_diameter")
 
-        return (
-            h_cond,
-            h_shell,
+        tube_dp, shell_dp = super()._calculate_pressure_drop(
+            geometry=geometry,
+            hot=hot,
+            cold=cold,
+            shell_velocity=shell_velocity,
+            tube_velocity=tube_velocity,
+            shell_passes=shell_passes,
+            tube_passes=tube_passes,
         )
+        orientation = str(kwargs.get("orientation", self.orientation)).lower()
+        _ = kwargs.get("shell_diameter")
+        if orientation == "vertical":
+            static_head = float(self.specs.get("condensate_density", 850.0)) * 9.81 * max(float(geometry.get("tube_length", 6.0)), 0.0)
+            if self.condensing_side == "tube":
+                tube_dp += static_head
+            else:
+                shell_dp += static_head
+        return tube_dp, shell_dp
 
-    # ==========================================================
-    # DESIGN
-    # ==========================================================
+    def _decorate_results(self, results: Dict[str, Any]) -> Dict[str, Any]:
+        results.update({
+            "hx_type": "condenser",
+            "service": self.condensation_mode + "_condenser",
+            "phase_change": True,
+            "orientation": self.orientation,
+            "condensing_side": self.condensing_side,
+            "convergence_status": results.get("status", "OK"),
+            "warnings": list(dict.fromkeys([*results.get("warnings", []), *self._warnings])),
+        })
+        return results
 
     def design(self):
-
-        results = super().design()
-
-        results["hx_type"] = "condenser"
-
-        results["service"] = "total_condenser"
-
-        results["phase_change"] = True
-
-        return results
-
-    # ==========================================================
-    # RATE
-    # ==========================================================
+        return self._decorate_results(super().design())
 
     def rate(self):
-
-        results = super().rate()
-
-        results["hx_type"] = "condenser"
-
-        results["service"] = "total_condenser"
-
-        results["phase_change"] = True
-
-        return results
+        return self._decorate_results(super().rate())

--- a/processpi/equipment/heatexchangers/double_pipe.py
+++ b/processpi/equipment/heatexchangers/double_pipe.py
@@ -179,32 +179,6 @@ class DoublePipeHX(HeatExchanger):
         )
 
         # ======================================================
-        # DEBUG
-        # ======================================================
-
-        print("\n" + "=" * 60)
-        print("DOUBLE PIPE HX — DESIGN MODE")
-        print("=" * 60)
-
-        print(f"Heat Duty          : {q:.4f} kW")
-        print(f"LMTD               : {lmtd:.4f} K")
-        print(f"U Assumed          : {u_assumed:.4f} W/m2.K")
-        print(f"Required Area      : {area_required:.4f} m2")
-        print(f"Actual Area        : {area:.4f} m2")
-
-        print("-" * 60)
-
-        print(f"Tube Velocity      : {tube_velocity:.4f} m/s")
-        print(f"Annulus Velocity   : {annulus_velocity:.4f} m/s")
-
-        print("-" * 60)
-
-        print(f"Tube DP            : {tube_dp:.2f} Pa")
-        print(f"Annulus DP         : {annulus_dp:.2f} Pa")
-
-        print("=" * 60)
-
-        # ======================================================
         # RESULTS
         # ======================================================
 
@@ -214,6 +188,8 @@ class DoublePipeHX(HeatExchanger):
             "Q": q,
             "Area": area,
             "U_assumed": u_assumed,
+            "U_clean": u_assumed,
+            "U_dirty": u_assumed,
             "U_calculated": u_assumed,
             "LMTD": lmtd,
             "tube_count": 1,
@@ -471,27 +447,13 @@ class DoublePipeHX(HeatExchanger):
         # DEBUG
         # ======================================================
 
-        print("\n" + "=" * 60)
-        print("DOUBLE PIPE HX — RATE MODE")
-        print("=" * 60)
 
-        print(f"UA                 : {UA:.4f}")
-        print(f"NTU                : {NTU:.4f}")
-        print(f"Effectiveness      : {effectiveness:.4f}")
 
-        print("-" * 60)
 
-        print(f"Actual Duty        : {q_actual/1000:.4f} kW")
 
-        print(f"Hot Outlet Temp    : {th_out:.2f} K")
-        print(f"Cold Outlet Temp   : {tc_out:.2f} K")
 
-        print("-" * 60)
 
-        print(f"Tube Velocity      : {tube_velocity:.4f} m/s")
-        print(f"Annulus Velocity   : {annulus_velocity:.4f} m/s")
 
-        print("=" * 60)
 
         # ======================================================
         # RESULTS

--- a/processpi/equipment/heatexchangers/engine.py
+++ b/processpi/equipment/heatexchangers/engine.py
@@ -17,19 +17,17 @@ from .shell_and_tube import ShellAndTubeHX
 class HeatExchangerResults:
     data: Dict[str, Any]
 
-    def summary(self):
-        print("\n=== Heat Exchanger Summary ===")
-        print(f"Type: {self.data['hx_type']}")
-        print(f"Q: {self.data['Q']:.2f} W")
-        print(f"Area: {self.data['Area']:.3f} m2")
-        print(f"U_assumed/U_calculated: {self.data['U_assumed']:.2f}/{self.data['U_calculated']:.2f} W/m2K")
-        print(f"Status: {self.data['status']}")
-        return self.data
+    def summary(self) -> str:
+        return (
+            f"Heat Exchanger Summary\n"
+            f"Type: {self.data.get('hx_type')}\n"
+            f"Q: {self.data.get('Q', 0.0):.2f} kW\n"
+            f"Area: {self.data.get('Area', 0.0):.3f} m2\n"
+            f"U_assumed/U_calculated: {self.data.get('U_assumed', 0.0):.2f}/{self.data.get('U_calculated', 0.0):.2f} W/m2K\n"
+            f"Status: {self.data.get('status', 'UNKNOWN')}"
+        )
 
-    def detailed_summary(self):
-        print("\n=== Heat Exchanger Detailed Summary ===")
-        for k, v in self.data.items():
-            print(f"- {k}: {v}")
+    def detailed_summary(self) -> Dict[str, Any]:
         return self.data
 
 
@@ -174,11 +172,6 @@ class HeatExchangerEngine:
             .lower()
         )
     
-        print("\n" + "=" * 60)
-        print(f"[DEBUG] Heat Exchanger Mode : {mode.upper()}")
-        print(f"[DEBUG] Heat Exchanger Type : {hx_type}")
-        print(f"[DEBUG] Design Method       : {self.method}")
-        print("=" * 60)
     
         # ======================================================
         # DESIGN MODE
@@ -235,7 +228,6 @@ class HeatExchangerEngine:
 
     def summary(self):
         if not self._results:
-            print("No results available for summary.")
             return None
         return self._results.summary()
     def results(self):

--- a/processpi/equipment/heatexchangers/evaporator.py
+++ b/processpi/equipment/heatexchangers/evaporator.py
@@ -1,245 +1,135 @@
 from __future__ import annotations
 
-import math
 from typing import Any, Dict
 
-from processpi.calculations.heat_transfer.hx_kern import (
-    BoilingHTC,
-    LatentDuty,
-)
+from processpi.calculations.heat_transfer.hx_kern import BoilingHTC, LatentDuty
 
 from .shell_and_tube import ShellAndTubeHX
 
 
 class EvaporatorHX(ShellAndTubeHX):
+    def __init__(self, *args: Any, method: str = "kern", **kwargs: Any):
+        super().__init__(*args, method=method, **kwargs)
+        self.service_type = "evaporator"
+        self.orientation = str(self.specs.get("orientation", "horizontal")).lower()
+        self.boiling_side = str(self.specs.get("boiling_side", "shell")).lower()
+        self.design_limits = {
+            "max_shell_diameter": float(self.specs.get("max_shell_diameter", 2.0)),
+            "max_tube_count": int(self.specs.get("max_tube_count", 5000)),
+            "min_tube_velocity": float(self.specs.get("min_tube_velocity", 0.3)),
+            "max_tube_velocity": float(self.specs.get("max_tube_velocity", 2.5)),
+            "min_shell_velocity": float(self.specs.get("min_shell_velocity", 0.2)),
+            "max_area": float(self.specs.get("max_area", 1000.0)),
+        }
 
-    """
-    Shell-and-tube evaporator.
+    def _calculate_heat_duty(self, hot: Dict[str, float], cold: Dict[str, float], **kwargs: Any):
+        latent_heat = self.specs.get("latent_heat")
+        if latent_heat is None:
+            raise ValueError("Evaporator requires latent_heat")
+        q_watts = LatentDuty(m_dot=cold["m_dot"], latent_heat=latent_heat).calculate().to("W").value
 
-    Architecture:
-    - Reuses ShellAndTubeHX geometry engine
-    - Reuses Bell/Kern framework
-    - Reuses pressure-drop framework
-    - Adds boiling-side heat transfer handling
-    """
+        q_max = hot["m_dot"] * hot["cp"] * 1000.0 * max(hot["t_k"] - cold["t_k"], 0.5)
+        if q_watts > 0.98 * q_max:
+            self._warn("Requested evaporator duty exceeds hot-side available sensible heat; clipping to feasible duty")
+            q_watts = 0.98 * q_max
 
-    def __init__(
+        th_out = hot["t_k"] - q_watts / max(hot["m_dot"] * hot["cp"] * 1000.0, 1e-12)
+        tc_out = cold["t_k"]  # near-isothermal boiling
+        return q_watts, th_out, tc_out
+
+    def _calculate_ft(self, *args: Any, **kwargs: Any) -> float:
+        return 1.0
+
+    def _calculate_boiling_htc(self, cold: Dict[str, float], q_flux: float) -> float:
+        pressure = max(cold.get("p_bar", 1.0), 0.5)
+        h_boil = BoilingHTC(heat_flux=max(q_flux, 1e3), pressure=pressure).calculate().to("W/m2K").value
+        orientation_factor = 1.1 if self.orientation == "vertical" else 1.0
+        return max(1500.0, min(h_boil * orientation_factor, 18000.0))
+
+    def _calculate_htc(self, dimless: Dict[str, float], geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float], **kwargs: Any):
+        h_tube, h_shell = super()._calculate_htc(dimless, geometry, hot, cold)
+        q_flux = max(float(self.specs.get("Q", 1e6)) / max(geometry.get("area", 1.0), 1e-9), 1e3)
+        h_boil = self._calculate_boiling_htc(cold, q_flux)
+
+        if self.boiling_side == "tube":
+            h_tube = h_boil
+        else:
+            h_shell = h_boil
+        return h_tube, h_shell
+
+    def _validate_design_constraints(self, results: Dict[str, Any]) -> None:
+        limits = self.design_limits
+        if results.get("Area", 0.0) > limits["max_area"]:
+            self._warn("Area exceeds configured evaporator design limit")
+        if results.get("tube_count", 0) > limits["max_tube_count"]:
+            self._warn("Tube count exceeds configured evaporator design limit")
+        if results.get("shell_diameter", 0.0) > limits["max_shell_diameter"]:
+            self._warn("Shell diameter exceeds configured evaporator design limit")
+        if results.get("tube_velocity", 0.0) < limits["min_tube_velocity"]:
+            self._warn("Tube velocity below recommended minimum; hydraulic collapse risk")
+        if results.get("tube_velocity", 0.0) > limits["max_tube_velocity"]:
+            self._warn("Tube velocity above recommended maximum")
+        if results.get("shell_velocity", 0.0) < limits["min_shell_velocity"]:
+            self._warn("Shell velocity below recommended minimum")
+
+    def _calculate_pressure_drop(
         self,
-        *args: Any,
-        method: str = "kern",
+        geometry: Dict[str, float],
+        hot: Dict[str, float],
+        cold: Dict[str, float],
+        shell_velocity: float | None = None,
+        tube_velocity: float | None = None,
         **kwargs: Any,
     ):
-
-        super().__init__(
-            *args,
-            method=method,
-            **kwargs,
+        shell_velocity = (
+            shell_velocity
+            if shell_velocity is not None
+            else float(kwargs.get("shell_velocity", 0.0))
         )
-
-        self.service_type = "evaporator"
-
-    # ==========================================================
-    # HEAT DUTY
-    # ==========================================================
-
-    def _calculate_heat_duty(
-        self,
-        hot: Dict[str, float],
-        cold: Dict[str, float],
-    ):
-
-        latent_heat = self.specs.get(
-            "latent_heat"
+        tube_velocity = (
+            tube_velocity
+            if tube_velocity is not None
+            else float(kwargs.get("tube_velocity", 0.0))
         )
+        shell_passes = int(kwargs.get("shell_passes", 1))
+        tube_passes = int(kwargs.get("tube_passes", 1))
+        _shell_diameter = kwargs.get("shell_diameter")
 
-        if latent_heat is None:
-
-            raise ValueError(
-                "Evaporator requires latent_heat."
-            )
-
-        # ======================================================
-        # DUTY
-        # ======================================================
-
-        q_watts = (
-            LatentDuty(
-                m_dot=cold["m_dot"],
-                latent_heat=latent_heat,
-            )
-            .calculate()
-            .to("W")
-            .value
+        tube_dp, shell_dp = super()._calculate_pressure_drop(
+            geometry=geometry,
+            hot=hot,
+            cold=cold,
+            shell_velocity=shell_velocity,
+            tube_velocity=tube_velocity,
+            shell_passes=shell_passes,
+            tube_passes=tube_passes,
         )
+        orientation = str(kwargs.get("orientation", self.orientation)).lower()
+        _ = kwargs.get("shell_diameter")
+        if orientation == "vertical":
+            rho = cold.get("density", 900.0) if self.boiling_side == "tube" else hot.get("density", 900.0)
+            static_head = rho * 9.81 * max(float(geometry.get("tube_length", 6.0)), 0.0)
+            if self.boiling_side == "tube":
+                tube_dp += static_head
+            else:
+                shell_dp += static_head
+        return tube_dp, shell_dp
 
-        q_max = (
-            hot["m_dot"]
-            * hot["cp"]
-            * 1000.0
-            * (
-                hot["t_k"]
-                - cold["t_k"]
-            )
-        )
-        
-        if q_watts > q_max:
-        
-            raise ValueError(
-                "Evaporator duty exceeds "
-                "available hot-side sensible heat."
-            )
-
-        # ======================================================
-        # HOT SIDE COOLING
-        # ======================================================
-
-        th_in = hot["t_k"]
-
-        th_out = (
-            th_in
-            - q_watts
-            / max(
-                hot["m_dot"]
-                * hot["cp"]
-                * 1000.0,
-                1e-12,
-            )
-        )
-
-        # ======================================================
-        # BOILING SIDE
-        # ======================================================
-
-        tc_in = cold["t_k"]
-
-        # boiling approx constant temperature
-        tc_out = tc_in
-
-        return (
-            q_watts,
-            th_out,
-            tc_out,
-        )
-
-    # ==========================================================
-    # BOILING HTC
-    # ==========================================================
-
-    def _calculate_boiling_htc(
-        self,
-        cold: Dict[str, float],
-        geometry: Dict[str, float],
-        q_flux: float,
-    ) -> float:
-
-        pressure = cold.get(
-            "p_bar",
-            1.0,
-        )
-
-        try:
-
-            h_boil = (
-                BoilingHTC(
-                    heat_flux=q_flux,
-                    pressure=pressure,
-                )
-                .calculate()
-                .to("W/m2K")
-                .value
-            )
-
-        except Exception:
-
-            # fallback engineering estimate
-            h_boil = 4000.0
-
-        return max(h_boil, 1500.0)
-
-    # ==========================================================
-    # HTC CALCULATION
-    # ==========================================================
-
-    def _calculate_htc(
-        self,
-        dimless: Dict[str, float],
-        geometry: Dict[str, float],
-        hot: Dict[str, float],
-        cold: Dict[str, float],
-    ):
-
-        # ======================================================
-        # NORMAL SINGLE-PHASE SIDE
-        # ======================================================
-
-        h_tube, h_shell = super()._calculate_htc(
-            dimless,
-            geometry,
-            hot,
-            cold,
-        )
-
-        # ======================================================
-        # HEAT FLUX
-        # ======================================================
-
-        area = max(
-            geometry["area"],
-            1e-9,
-        )
-
-        q_flux = (
-            self.specs.get("Q", 1e6)
-            / area
-        )
-
-        # ======================================================
-        # BOILING SIDE HTC
-        # ======================================================
-
-        h_boil = self._calculate_boiling_htc(
-            cold,
-            geometry,
-            q_flux,
-        )
-
-        # ======================================================
-        # ASSUME COLD SIDE BOILING
-        # ======================================================
-
-        return (
-            h_boil,
-            h_shell,
-        )
-
-    # ==========================================================
-    # DESIGN
-    # ==========================================================
+    def _decorate_results(self, results: Dict[str, Any]) -> Dict[str, Any]:
+        self._validate_design_constraints(results)
+        results.update({
+            "hx_type": "evaporator",
+            "service": "evaporator",
+            "phase_change": True,
+            "orientation": self.orientation,
+            "boiling_side": self.boiling_side,
+            "convergence_status": results.get("status", "OK"),
+            "warnings": list(dict.fromkeys([*results.get("warnings", []), *self._warnings])),
+        })
+        return results
 
     def design(self):
-
-        results = super().design()
-
-        results["hx_type"] = "evaporator"
-
-        results["service"] = "evaporator"
-
-        results["phase_change"] = True
-
-        return results
-
-    # ==========================================================
-    # RATE
-    # ==========================================================
+        return self._decorate_results(super().design())
 
     def rate(self):
-
-        results = super().rate()
-
-        results["hx_type"] = "evaporator"
-
-        results["service"] = "evaporator"
-
-        results["phase_change"] = True
-
-        return results
+        return self._decorate_results(super().rate())

--- a/processpi/equipment/heatexchangers/reboiler.py
+++ b/processpi/equipment/heatexchangers/reboiler.py
@@ -1,7 +1,79 @@
 from __future__ import annotations
 
-from .double_pipe import DoublePipeHX
+from typing import Any, Dict
+
+from .evaporator import EvaporatorHX
 
 
-class ReboilerHX(DoublePipeHX):
-    pass
+class ReboilerHX(EvaporatorHX):
+    """Shell-and-tube reboiler built from Evaporator phase-change architecture."""
+
+    def __init__(self, *args: Any, method: str = "kern", **kwargs: Any):
+        super().__init__(*args, method=method, **kwargs)
+        self.service_type = "reboiler"
+        self.reboiler_type = str(self.specs.get("reboiler_type", "kettle")).lower()
+        self.orientation = str(self.specs.get("orientation", "horizontal")).lower()
+
+    def _circulation_factor(self) -> float:
+        factors = {
+            "kettle": 1.00,
+            "horizontal_thermosyphon": 1.15,
+            "vertical_thermosyphon": 1.30,
+        }
+        return factors.get(self.reboiler_type, 1.00)
+
+    def _calculate_htc(self, dimless: Dict[str, float], geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float], **kwargs: Any):
+        h_tube, h_shell = super()._calculate_htc(dimless, geometry, hot, cold)
+        boost = self._circulation_factor()
+        if self.boiling_side == "tube":
+            h_tube *= boost
+        else:
+            h_shell *= boost
+        return h_tube, h_shell
+
+    def _calculate_pressure_drop(
+        self,
+        geometry: Dict[str, float],
+        hot: Dict[str, float],
+        cold: Dict[str, float],
+        shell_velocity: float | None = None,
+        tube_velocity: float | None = None,
+        **kwargs: Any,
+    ):
+        shell_velocity = (
+            shell_velocity
+            if shell_velocity is not None
+            else float(kwargs.get("shell_velocity", 0.0))
+        )
+        tube_velocity = (
+            tube_velocity
+            if tube_velocity is not None
+            else float(kwargs.get("tube_velocity", 0.0))
+        )
+        kwargs.setdefault("shell_passes", int(kwargs.get("shell_passes", 1)))
+        kwargs.setdefault("tube_passes", int(kwargs.get("tube_passes", 1)))
+        _shell_diameter = kwargs.get("shell_diameter")
+        return super()._calculate_pressure_drop(
+            geometry=geometry,
+            hot=hot,
+            cold=cold,
+            shell_velocity=shell_velocity,
+            tube_velocity=tube_velocity,
+            **kwargs,
+        )
+
+    def _decorate_results(self, results: Dict[str, Any]) -> Dict[str, Any]:
+        results = super()._decorate_results(results)
+        results.update({
+            "hx_type": "reboiler",
+            "service": "reboiler",
+            "reboiler_type": self.reboiler_type,
+            "circulation_factor": self._circulation_factor(),
+        })
+        return results
+
+    def design(self):
+        return self._decorate_results(super().design())
+
+    def rate(self):
+        return self._decorate_results(super().rate())

--- a/processpi/equipment/heatexchangers/shell_and_tube.py
+++ b/processpi/equipment/heatexchangers/shell_and_tube.py
@@ -40,11 +40,11 @@ class ShellAndTubeHX(HeatExchanger):
         hot_type = getattr(self.hot_in.component, "hx_type", "generic")
         cold_type = getattr(self.cold_in.component, "hx_type", "generic")
         service_type = getattr(self, "service_type", "heat_exchanger")
-        #print(hot_type, cold_type, service_type)
+        #self._debug(hot_type, cold_type, service_type)
         u_range = get_u_range("shell_and_tube", service_type, hot_type, cold_type)
         if u_range:
             u_min, u_max = u_range
-            #print(f"Assuming overall heat transfer coefficient U = {u_min}-{u_max} W/m2K based on service and fluids")
+            #self._debug(f"Assuming overall heat transfer coefficient U = {u_min}-{u_max} W/m2K based on service and fluids")
             return 0.5 * (u_min + u_max)
         return 300.0
 
@@ -54,7 +54,7 @@ class ShellAndTubeHX(HeatExchanger):
         for side_name, props in (("hot", hot), ("cold", cold)):
             for key in required:
                 val = props.get(key)
-                print(f"Side name {side_name}, {key} : {val}")
+                self._debug(f"Side name {side_name}, {key} : {val}")
                 if val is None or val <= 0:
                     
                     missing.append(f"{side_name}.{key}")
@@ -65,24 +65,24 @@ class ShellAndTubeHX(HeatExchanger):
         q_kw = self.heat_duty(hot, cold)
         th_in = hot["t_k"]
         tc_in = cold["t_k"]
-        #print(f"Hot Cp: {hot["cp"]} Cold Cp {cold["cp"]}")
+        #self._debug(f"Hot Cp: {hot["cp"]} Cold Cp {cold["cp"]}")
         if self.hot_out and self.hot_out.temperature and self.hot_out.temperature.to("C").value == 25 :
             th_out = self.hot_out.temperature.to("K").value
         else:
             th_out = th_in - (q_kw / max(hot["m_dot"] * hot["cp"], 1e-9))
 
         if self.cold_out and self.cold_out.temperature and self.cold_out.temperature.to("C").value == 25:
-            #print("Hello World")
+            #self._debug("Hello World")
             tc_out = self.cold_out.temperature.to("K").value
         else:
             tc_out = tc_in + (q_kw / max(cold["m_dot"] * cold["cp"], 1e-9))
-            #print(f"tc_out = {tc_in} + ({q_kw}/({cold["m_dot"]}*{cold["cp"]})")
-            #print(f"cold_rate: {max(cold["m_dot"] * cold["cp"], 1e-9)}")
-        #print(tc_out)
+            #self._debug(f"tc_out = {tc_in} + ({q_kw}/({cold["m_dot"]}*{cold["cp"]})")
+            #self._debug(f"cold_rate: {max(cold["m_dot"] * cold["cp"], 1e-9)}")
+        #self._debug(tc_out)
         return q_kw * 1000.0, th_out, tc_out
 
     def _calculate_lmtd(self, hot: Dict[str, float], cold: Dict[str, float], th_out: float, tc_out: float) -> float:
-        #print(f"Hot in: {hot["t_k"]} Hot out: {th_out} cold in: {cold["t_k"]} cold out: { tc_out}")
+        #self._debug(f"Hot in: {hot["t_k"]} Hot out: {th_out} cold in: {cold["t_k"]} cold out: { tc_out}")
         return self.lmtd(hot["t_k"], th_out, cold["t_k"], tc_out)
 
     def _safe_log_ratio(self, numerator: float, denominator: float) -> float:
@@ -134,7 +134,7 @@ class ShellAndTubeHX(HeatExchanger):
 
         r = (th_in - th_out) / max(tc_out - tc_in, 1e-12)
         s = (tc_out - tc_in) / max(th_in - tc_in, 1e-12)
-        print(f"R: {r} S: {s}")
+        self._debug(f"R: {r} S: {s}")
         if shell_passes == 1:
             return self._ft_1shell(r, s)
         if shell_passes == 2:
@@ -154,7 +154,7 @@ class ShellAndTubeHX(HeatExchanger):
         best_ft = 0.0
         for shell_passes, tube_passes in candidates:
             ft = self._calculate_ft(hot, cold, th_out, tc_out, shell_passes, tube_passes)
-            print(f"Passes (shell={shell_passes}, tube={tube_passes}) → Ft = {ft:.4f}")
+            self._debug(f"Passes (shell={shell_passes}, tube={tube_passes}) → Ft = {ft:.4f}")
 
             if ft > best_ft:
                 best_ft = ft
@@ -174,9 +174,6 @@ class ShellAndTubeHX(HeatExchanger):
 
     def _round_tube_count_to_passes(self, tube_count: int, tube_passes: int) -> int:
         return max(tube_passes, int(math.ceil(tube_count / max(tube_passes, 1)) * max(tube_passes, 1)))
-
-    def _debug(self, message: str) -> None:
-        print(f"[DEBUG] {message}")
 
     def _load_standard_tables(self) -> None:
         self._tube_count_tables = STANDARD_TUBE_COUNT_TABLES
@@ -415,9 +412,9 @@ class ShellAndTubeHX(HeatExchanger):
                 tube_count = 50
         else:
             area_per_tube = math.pi * tube_od * tube_length
-            print("Area Per Tube: ",area_per_tube)
+            self._debug("Area Per Tube: ",area_per_tube)
             tube_count = math.ceil(area_required / max(area_per_tube, 1e-12))
-            print("Tube Count: ",tube_count)
+            self._debug("Tube Count: ",tube_count)
 
         standard_geom = self._select_best_standard_geometry(area_required, tube_od, tube_length, tube_passes)
         std_tube_count = standard_geom.get("tube_count")
@@ -425,11 +422,11 @@ class ShellAndTubeHX(HeatExchanger):
             self._debug(f"Using standard tube count lookup >= required: {std_tube_count}")
             tube_count = std_tube_count
         tube_count = self._round_tube_count_to_passes(tube_count, tube_passes)
-        print("Tube Count Round: ",tube_count)
+        self._debug("Tube Count Round: ",tube_count)
         tube_pitch = float(self.specs.get("tube_pitch", 1.25 * tube_od))
-        print("Tube Pitch: ",tube_pitch)
+        self._debug("Tube Pitch: ",tube_pitch)
         area = tube_count * math.pi * tube_od * tube_length
-        print("Tubes Surface Area: ",area)
+        self._debug("Tubes Surface Area: ",area)
         return {
             "tube_od": tube_od,
             "tube_id": tube_id,
@@ -451,20 +448,20 @@ class ShellAndTubeHX(HeatExchanger):
 
     def _check_L_over_D(self, geometry: Dict[str, float], shell_diameter: float, tube_passes: int, base_required_area: float | None = None, hot: Dict[str, float] | None = None) -> Dict[str, float]:
         ld = geometry["tube_length"] / max(shell_diameter, 1e-9)
-        print("L/D: ",ld)
+        self._debug("L/D: ",ld)
         if 5.0 <= ld <= 10.0:
-            print("L/D is between 5 to 10")
+            self._debug("L/D is between 5 to 10")
             return geometry
         if ld > 10.0 or ld < 5.0:
-            print("L/D is not between 5 to 10")
+            self._debug("L/D is not between 5 to 10")
             geometry["tube_length"] = tube_length_select(geometry["tube_length"],ld)
-            print(f"geometry:{geometry}")
+            self._debug(f"geometry:{geometry}")
         #target_l = min(max(7.0 * shell_diameter, 0.5), 6.0)
         if self.specs.get("tube_length") is None:
             if base_required_area is not None:
                 geometry["tube_count"] = self._recalculate_required_tubes(base_required_area, geometry, tube_passes)
             geometry = self._regenerate_geometry(geometry, tube_passes, hot)
-            print("Geometry :",geometry)
+            self._debug("Geometry :",geometry)
         return geometry
 
     def _check_velocities(
@@ -587,7 +584,7 @@ class ShellAndTubeHX(HeatExchanger):
         ).calculate()
         pr_t = max(hot["cp"] * 1000 * hot["viscosity"] / max(hot["k"], 1e-12), 1e-12)
         nu_t = DittusBoelter(reynolds=max(re_t, 1.0), prandtl=pr_t, n=0.4).calculate()
-        print(f"Tube Side Rey:{re_t}, Pra:{pr_t}, Nuss:{nu_t}")
+        self._debug(f"Tube Side Rey:{re_t}, Pra:{pr_t}, Nuss:{nu_t}")
         de_shell = max(1.27 * (geometry["tube_pitch"] ** 2 - 0.785 * geometry["tube_od"] ** 2) / geometry["tube_od"], 1e-6)
         re_s = Reynolds(
             density=cold["density"],
@@ -597,7 +594,7 @@ class ShellAndTubeHX(HeatExchanger):
         ).calculate()
         pr_s = max(cold["cp"] * 1000 * cold["viscosity"] / max(cold["k"], 1e-12), 1e-12)
         nu_s = KernShellNu(reynolds=max(re_s, 1.0), prandtl=pr_s).calculate()
-        print(f"Shell Side Rey:{re_s}, Pra:{pr_s}, Nuss:{nu_s}")
+        self._debug(f"Shell Side Rey:{re_s}, Pra:{pr_s}, Nuss:{nu_s}")
         return {"re_t": re_t, "pr_t": pr_t, "nu_t": nu_t, "de_shell": de_shell, "re_s": re_s, "pr_s": pr_s, "nu_s": nu_s}
 
     def _calculate_htc(self, dimless: Dict[str, float], geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float]) -> Tuple[float, float]:
@@ -620,9 +617,9 @@ class ShellAndTubeHX(HeatExchanger):
         """
 
         tube_od = geometry.get("tube_od")
-        print(f"Tube_od:{tube_od}")
+        self._debug(f"Tube_od:{tube_od}")
         tube_id = geometry.get("tube_id")
-        print(f"Tube_id:{tube_id}")
+        self._debug(f"Tube_id:{tube_id}")
         if tube_od is None or tube_id is None:
             raise ValueError(
                 "Missing tube geometry required for "
@@ -735,20 +732,20 @@ class ShellAndTubeHX(HeatExchanger):
         # DEBUGGING
         # ======================================================
 
-        print("\n" + "="*40)
-        print("[DEBUG] OVERALL U CALCULATION SUMMARY")
-        print(f"[DEBUG] Convective -> R_tube: {R_tube:.8f}, R_shell: {R_shell:.8f}")
-        print(f"[DEBUG] Wall       -> R_wall: {R_wall:.8f}")
-        print(f"[DEBUG] Fouling    -> Rf_tube: {Rf_tube:.8f}, Rf_shell: {Rf_shell:.8f}")
-        print("-" * 40)
-        print(f"[DEBUG] R_total_clean: {R_total_clean:.8f} -> U_clean: {U_clean:.4f} W/m2.K")
-        print(f"[DEBUG] R_total_dirty: {R_total_dirty:.8f} -> U_dirty: {U_dirty:.4f} W/m2.K")
+        self._debug("\n" + "="*40)
+        self._debug("[DEBUG] OVERALL U CALCULATION SUMMARY")
+        self._debug(f"[DEBUG] Convective -> R_tube: {R_tube:.8f}, R_shell: {R_shell:.8f}")
+        self._debug(f"[DEBUG] Wall       -> R_wall: {R_wall:.8f}")
+        self._debug(f"[DEBUG] Fouling    -> Rf_tube: {Rf_tube:.8f}, Rf_shell: {Rf_shell:.8f}")
+        self._debug("-" * 40)
+        self._debug(f"[DEBUG] R_total_clean: {R_total_clean:.8f} -> U_clean: {U_clean:.4f} W/m2.K")
+        self._debug(f"[DEBUG] R_total_dirty: {R_total_dirty:.8f} -> U_dirty: {U_dirty:.4f} W/m2.K")
         
         if u_range:
             u_min, u_max = u_range
             status = "WITHIN" if u_min <= U_dirty <= u_max else "OUTSIDE"
-            print(f"[DEBUG] Range Check: {U_dirty:.2f} is {status} limits ({u_min}, {u_max})")
-        print("="*40 + "\n")
+            self._debug(f"[DEBUG] Range Check: {U_dirty:.2f} is {status} limits ({u_min}, {u_max})")
+        self._debug("="*40 + "\n")
 
         return {
             "U_clean": U_clean,
@@ -1055,19 +1052,19 @@ class ShellAndTubeHX(HeatExchanger):
                 ) * 100.0
             )
     
-            print("\n" + "=" * 60)
-            print(f"Iteration          : {i}")
-            print(f"U_assumed          : {u_old:.4f}")
-            print(f"U_dirty            : {u_dirty:.4f}")
-            print(f"U_clean            : {u_clean:.4f}")
-            print(f"Required Area      : {required_dirty_area:.4f} m2")
-            print(f"Actual Area        : {actual_area:.4f} m2")
-            print(f"Tube Velocity      : {v_tube:.4f} m/s")
-            print(f"Shell Velocity     : {v_shell:.4f} m/s")
-            print(f"Tube DP            : {tube_dp:.2f} Pa")
-            print(f"Shell DP           : {shell_dp:.2f} Pa")
-            print(f"U Error            : {convergence_error:.2f} %")
-            print("=" * 60)
+            self._debug("\n" + "=" * 60)
+            self._debug(f"Iteration          : {i}")
+            self._debug(f"U_assumed          : {u_old:.4f}")
+            self._debug(f"U_dirty            : {u_dirty:.4f}")
+            self._debug(f"U_clean            : {u_clean:.4f}")
+            self._debug(f"Required Area      : {required_dirty_area:.4f} m2")
+            self._debug(f"Actual Area        : {actual_area:.4f} m2")
+            self._debug(f"Tube Velocity      : {v_tube:.4f} m/s")
+            self._debug(f"Shell Velocity     : {v_shell:.4f} m/s")
+            self._debug(f"Tube DP            : {tube_dp:.2f} Pa")
+            self._debug(f"Shell DP           : {shell_dp:.2f} Pa")
+            self._debug(f"U Error            : {convergence_error:.2f} %")
+            self._debug("=" * 60)
     
             # ======================================================
             # UPDATE ASSUMED U
@@ -1108,17 +1105,23 @@ class ShellAndTubeHX(HeatExchanger):
       
     def _calculate_pressure_drop(
         self,
+        geometry: Dict[str, Any] | None,
         hot: Dict[str, float],
         cold: Dict[str, float],
-        shell_passes: int,
-        tube_passes: int,
-        shell_diameter: float,
-        tube_length: float,
-        tube_id: float,
-        v_tube: float,
-        v_shell: float,
-        geometry: Dict[str, Any] | None = None,
+        shell_velocity: float | None = None,
+        tube_velocity: float | None = None,
+        **kwargs: Any,
     ) -> Tuple[float, float]:
+        shell_velocity = shell_velocity if shell_velocity is not None else float(kwargs.get("shell_velocity", kwargs.get("v_shell", 0.0)))
+        tube_velocity = tube_velocity if tube_velocity is not None else float(kwargs.get("tube_velocity", kwargs.get("v_tube", 0.0)))
+        shell_passes = int(kwargs.get("shell_passes", 1))
+        tube_passes = int(kwargs.get("tube_passes", 1))
+        shell_diameter = float(kwargs.get("shell_diameter", 0.0) or 0.0)
+        orientation = str(kwargs.get("orientation", "horizontal")).lower()
+        tube_length = float(kwargs.get("tube_length", (geometry or {}).get("tube_length", 1.0)))
+        tube_id = float(kwargs.get("tube_id", (geometry or {}).get("tube_id", 0.016)))
+        v_tube = tube_velocity
+        v_shell = shell_velocity
     
         # ==========================================================
         # TUBE SIDE DP
@@ -1438,12 +1441,12 @@ class ShellAndTubeHX(HeatExchanger):
             self.service_type = "heater"
 
         q_watts, th_out, tc_out = self._calculate_heat_duty(hot, cold)
-        print(q_watts)
+        self._debug(q_watts)
         lmtd = self._calculate_lmtd(hot, cold, th_out, tc_out)
-        print(lmtd)
+        self._debug(lmtd)
 
         shell_passes, tube_passes, ft = self._adjust_passes(hot, cold, th_out, tc_out)
-        print(ft, shell_passes, tube_passes)
+        self._debug(ft, shell_passes, tube_passes)
         warnings: List[str] = list(getattr(self, "_warnings", []))
 
         n_units = 1
@@ -1454,10 +1457,10 @@ class ShellAndTubeHX(HeatExchanger):
             warnings.append(f"Using {n_units} exchangers in series to satisfy Ft requirement")
 
         cltd = max(ft * lmtd, 1e-9)
-        print(cltd)
+        self._debug(cltd)
 
         u_assumed = self._assume_u(hot, cold)
-        print(u_assumed)
+        self._debug(u_assumed)
         hot_hx = self.hot_in.component.hx_data() if hasattr(self.hot_in.component, "hx_data") else {"u_key": getattr(self.hot_in.component, "hx_type", "generic")}
         cold_hx = self.cold_in.component.hx_data() if hasattr(self.cold_in.component, "hx_data") else {"u_key": getattr(self.cold_in.component, "hx_type", "generic")}
         self._debug(f"Hot hx_data = {hot_hx}")
@@ -2144,10 +2147,10 @@ class ShellAndTubeHX(HeatExchanger):
             + q_actual / Cc
         )
         lmtd = self._calculate_lmtd(hot, cold, th_out, tc_out)
-        #print(lmtd)
+        #self._debug(lmtd)
 
         shell_passes, tube_passes, ft = self._adjust_passes(hot, cold, th_out, tc_out)
-        #print(ft, shell_passes, tube_passes)
+        #self._debug(ft, shell_passes, tube_passes)
         warnings: List[str] = list(getattr(self, "_warnings", []))
 
         n_units = 1
@@ -2195,37 +2198,37 @@ class ShellAndTubeHX(HeatExchanger):
         # DEBUG SUMMARY
         # ==========================================================
     
-        print("\n" + "=" * 60)
-        print("RATE MODE SUMMARY")
-        print("=" * 60)
+        self._debug("\n" + "=" * 60)
+        self._debug("RATE MODE SUMMARY")
+        self._debug("=" * 60)
     
-        print(f"UA                 : {UA:.4f}")
-        print(f"NTU                : {NTU:.4f}")
-        print(f"Effectiveness      : {effectiveness:.4f}")
+        self._debug(f"UA                 : {UA:.4f}")
+        self._debug(f"NTU                : {NTU:.4f}")
+        self._debug(f"Effectiveness      : {effectiveness:.4f}")
     
-        print("-" * 60)
+        self._debug("-" * 60)
     
-        print(f"Actual Duty        : {q_actual/1000:.4f} kW")
-        print(f"U Dirty            : {u_dirty:.4f} W/m2.K")
-        print(f"U Clean            : {u_clean:.4f} W/m2.K")
-        print(f"Area               : {actual_area:.4f} m2")
+        self._debug(f"Actual Duty        : {q_actual/1000:.4f} kW")
+        self._debug(f"U Dirty            : {u_dirty:.4f} W/m2.K")
+        self._debug(f"U Clean            : {u_clean:.4f} W/m2.K")
+        self._debug(f"Area               : {actual_area:.4f} m2")
     
-        print("-" * 60)
+        self._debug("-" * 60)
     
-        print(f"Tube Velocity      : {v_tube:.4f} m/s")
-        print(f"Shell Velocity     : {v_shell:.4f} m/s")
+        self._debug(f"Tube Velocity      : {v_tube:.4f} m/s")
+        self._debug(f"Shell Velocity     : {v_shell:.4f} m/s")
     
-        print("-" * 60)
+        self._debug("-" * 60)
     
-        print(f"Tube DP            : {tube_dp:.2f} Pa")
-        print(f"Shell DP           : {shell_dp:.2f} Pa")
+        self._debug(f"Tube DP            : {tube_dp:.2f} Pa")
+        self._debug(f"Shell DP           : {shell_dp:.2f} Pa")
     
-        print("-" * 60)
+        self._debug("-" * 60)
     
-        print(f"Hot Outlet Temp    : {th_out:.2f} K")
-        print(f"Cold Outlet Temp   : {tc_out:.2f} K")
+        self._debug(f"Hot Outlet Temp    : {th_out:.2f} K")
+        self._debug(f"Cold Outlet Temp   : {tc_out:.2f} K")
     
-        print("=" * 60)
+        self._debug("=" * 60)
     
         # ==========================================================
         # PAYLOAD

--- a/processpi/equipment/heatexchangers/standards.py
+++ b/processpi/equipment/heatexchangers/standards.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from typing import Optional, Tuple
+import logging
 import math
+
+logger = logging.getLogger("processpi.hx.standards")
 
 HX_U_STANDARDS = {
     "shell_and_tube": {
@@ -122,6 +125,8 @@ TUBE_DIAMETER_STANDARD = [
 
 
 import math
+
+logger = logging.getLogger("processpi.hx.standards")
 
 def select_tube_configuration(area_required, hot, cold):
     best = None
@@ -256,7 +261,7 @@ def tube_length_select(tube_length, ld):
     # Extract and sort standard lengths
     std_lengths = sorted([i["length"] for i in TUBE_LENGTH_STANDARD])
     
-    print(f"Current Length: {current_length}, L/D: {ld}")
+    logger.debug(f"Current Length: {current_length}, L/D: {ld}")
     
     # Case 1: L/D > 10 → select nearest LOWER standard length
     if ld > 10:
@@ -267,7 +272,7 @@ def tube_length_select(tube_length, ld):
         else:
             selected_length = min(std_lengths)  # fallback
         
-        print(f"[L/D > 10] Selected lower standard length: {selected_length}")
+        logger.debug(f"[L/D > 10] Selected lower standard length: {selected_length}")
         return selected_length
 
     # Case 2: L/D < 5 → select nearest HIGHER standard length
@@ -279,12 +284,12 @@ def tube_length_select(tube_length, ld):
         else:
             selected_length = max(std_lengths)  # fallback
         
-        print(f"[L/D < 5] Selected higher standard length: {selected_length}")
+        logger.debug(f"[L/D < 5] Selected higher standard length: {selected_length}")
         return selected_length
 
     # Case 3: Acceptable range → no change
     else:
-        print("[5 <= L/D <= 10] Length is acceptable. No change.")
+        logger.debug("[5 <= L/D <= 10] Length is acceptable. No change.")
         return current_length
 
 
@@ -440,7 +445,7 @@ def get_fouling_factor(
             entry = database[matched_key]
 
             if debug:
-                print(
+                logger.debug(
                     f"[DEBUG] Fouling key '{key}' "
                     f"not found. Using closest match "
                     f"'{matched_key}'"
@@ -453,7 +458,7 @@ def get_fouling_factor(
             # ==============================================
 
             if debug:
-                print(
+                logger.debug(
                     f"[DEBUG] Fouling key '{key}' "
                     f"not found. Using default fouling "
                     f"factor = {DEFAULT_FOULING}"
@@ -468,7 +473,7 @@ def get_fouling_factor(
     fouling = entry["base"]
 
     if debug:
-        print(f"[DEBUG] Base fouling factor = {fouling}")
+        logger.debug(f"[DEBUG] Base fouling factor = {fouling}")
 
     # ======================================================
     # VELOCITY CORRECTION
@@ -487,7 +492,7 @@ def get_fouling_factor(
                 fouling *= 1.30
 
                 if debug:
-                    print(
+                    logger.debug(
                         f"[DEBUG] Low velocity correction "
                         f"applied (v={velocity:.3f} m/s)"
                     )
@@ -496,7 +501,7 @@ def get_fouling_factor(
                 fouling *= 0.85
 
                 if debug:
-                    print(
+                    logger.debug(
                         f"[DEBUG] High velocity correction "
                         f"applied (v={velocity:.3f} m/s)"
                     )
@@ -518,7 +523,7 @@ def get_fouling_factor(
                 fouling *= 1.25
 
                 if debug:
-                    print(
+                    logger.debug(
                         f"[DEBUG] High temperature "
                         f"correction applied "
                         f"(T={temperature:.2f} °C)"
@@ -528,7 +533,7 @@ def get_fouling_factor(
                 fouling *= 0.95
 
                 if debug:
-                    print(
+                    logger.debug(
                         f"[DEBUG] Low temperature "
                         f"correction applied "
                         f"(T={temperature:.2f} °C)"
@@ -539,7 +544,7 @@ def get_fouling_factor(
     # ======================================================
 
     if debug:
-        print(
+        logger.debug(
             f"[DEBUG] Final fouling factor "
             f"for '{key}' = {fouling}"
         )


### PR DESCRIPTION
### Motivation
- Add first-class support for phase-change services (condenser, evaporator, reboiler) with orientation and side selection and to provide safer defaults and warnings for phase-change scenarios.
- Replace noisy stdout debugging with structured logging and a `verbose` toggle and collect runtime warnings on HX objects.
- Provide example usage for the new phase-change capabilities.

### Description
- Added `examples/phase_change_hx_examples.py` containing design/rate example functions for condenser, evaporator, and reboiler (horizontal/vertical variants).
- Introduced `HeatExchangerBaseMixin` to initialize `verbose`, `logger`, and `_warnings`, and added `_debug`/`_warn` helpers; wired this into `HeatExchanger` to centralize runtime logging behavior.
- Reworked `CondenserHX`, `EvaporatorHX`, and new `ReboilerHX` to handle latent-duty calculations, phase-change HTC calculations (`CondensationHTC`/`BoilingHTC` usage), orientation/static-head effects, duty clipping/warnings, and result decoration (including `phase_change`, `orientation`, and `warnings`).
- Replaced numerous `print` debug statements across `double_pipe.py`, `shell_and_tube.py`, `engine.py`, and `standards.py` with `_debug` or `logging` usage, removed side-effect printing from `HeatExchangerResults.summary()` and made it return a string, and populated additional result keys such as `U_clean`/`U_dirty` where relevant.
- Harmonized pressure-drop function signatures and argument handling across HX classes to accept `shell_velocity`/`tube_velocity`, `shell_passes`/`tube_passes`, and `orientation` via kwargs.

### Testing
- Ran the package test suite with `pytest`; core heat-exchanger unit tests completed successfully.
- Imported and exercised the new example flows in `examples.phase_change_hx_examples` to validate `HeatExchangerEngine.fit(...).run()` paths for design and rate modes without raising exceptions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0805dfb9ac83268ec1abd736b9f9d7)