### PR TITLE
Add phase-change latent-duty handling and service-dependent hydraulic realism

### DIFF
--- a/processpi/equipment/heatexchangers/base.py
+++ b/processpi/equipment/heatexchangers/base.py
@@ -50,11 +50,60 @@ class HeatExchanger(HeatExchangerBaseMixin, ABC):
             "t_k": s.temperature.to("K").value if s.temperature else None,
         }
 
+    def _lookup_steam_latent_heat(self, pressure_bar: float) -> float:
+        """Approximate saturated steam latent heat [J/kg] using simple interpolation table."""
+        table = [
+            (1.0, 2257000.0),
+            (2.0, 2202000.0),
+            (3.0, 2163000.0),
+            (5.0, 2108000.0),
+            (8.0, 2048000.0),
+            (10.0, 2014000.0),
+            (15.0, 1944000.0),
+            (20.0, 1889000.0),
+        ]
+        p = max(float(pressure_bar), 0.5)
+        if p <= table[0][0]:
+            return table[0][1]
+        if p >= table[-1][0]:
+            return table[-1][1]
+        for (p1, h1), (p2, h2) in zip(table[:-1], table[1:]):
+            if p1 <= p <= p2:
+                ratio = (p - p1) / (p2 - p1)
+                return h1 + ratio * (h2 - h1)
+        return table[3][1]
+
+    def _resolve_phase_change_latent_heat(self, hot: Dict[str, float], cold: Dict[str, float]) -> float | None:
+        explicit_latent = self.specs.get("latent_heat")
+        if explicit_latent is not None:
+            return float(explicit_latent)
+
+        service = str(self.specs.get("service") or getattr(self, "service_type", "")).lower()
+        hot_in_phase = hot.get("phase", "liquid")
+        cold_in_phase = cold.get("phase", "liquid")
+        hot_out_phase = str(self.specs.get("hot_out_phase", hot_in_phase)).lower()
+        cold_out_phase = str(self.specs.get("cold_out_phase", cold_in_phase)).lower()
+
+        hot_condensing = hot_in_phase == "vapor" and hot_out_phase == "liquid"
+        cold_boiling = cold_in_phase == "liquid" and cold_out_phase == "vapor"
+        service_phase_change = service in {"condenser", "reboiler", "evaporator"}
+
+        if hot_condensing or service == "condenser":
+            return self._lookup_steam_latent_heat(hot.get("p_bar", 1.0))
+        if cold_boiling or service_phase_change:
+            if cold_in_phase == "steam" or getattr(self.cold_in.component, "name", "").lower() == "steam":
+                return self._lookup_steam_latent_heat(cold.get("p_bar", 1.0))
+            return 2257000.0
+        return None
+
     def heat_duty(self, hot: Dict[str, float], cold: Dict[str, float]) -> float:
         if self.specs.get("Q") is not None:
             return float(self.specs["Q"])
-        if self.specs.get("latent_heat") is not None:
-            return LatentDuty(m_dot=hot["m_dot"], latent_heat=self.specs["latent_heat"]).calculate().to("W").value
+        latent_heat = self._resolve_phase_change_latent_heat(hot, cold)
+        if latent_heat is not None:
+            latent_side = str(self.specs.get("latent_side", "hot")).lower()
+            m_dot = hot["m_dot"] if latent_side == "hot" else cold["m_dot"]
+            return LatentDuty(m_dot=m_dot, latent_heat=latent_heat).calculate().to("W").value
         if self.hot_out and hot["t_k"] is not None and self.hot_out.temperature is not None:
             return SensibleDuty(m_dot=hot["m_dot"], cp=hot["cp"], t_in=hot["t_k"], t_out=self.hot_out.temperature.to("K").value).calculate().to("W").value
         if self.cold_out and cold["t_k"] is not None and self.cold_out.temperature is not None:

--- a/processpi/equipment/heatexchangers/double_pipe.py
+++ b/processpi/equipment/heatexchangers/double_pipe.py
@@ -9,6 +9,20 @@ from .base import HeatExchanger
 
 class DoublePipeHX(HeatExchanger):
 
+    def _velocity_targets(self) -> dict[str, float]:
+        return {
+            "tube_min": float(self.specs.get("tube_velocity_min", 0.5)),
+            "tube_max": float(self.specs.get("tube_velocity_max", 2.5)),
+            "annulus_min": float(self.specs.get("annulus_velocity_min", 0.3)),
+            "annulus_max": float(self.specs.get("annulus_velocity_max", 2.0)),
+        }
+
+    def _compute_parallel_paths(self, tube_velocity: float, annulus_velocity: float) -> int:
+        limits = self._velocity_targets()
+        n_tube = max(1, math.ceil(tube_velocity / max(limits["tube_max"], 1e-6)))
+        n_annulus = max(1, math.ceil(annulus_velocity / max(limits["annulus_max"], 1e-6)))
+        return max(n_tube, n_annulus)
+
     # ==========================================================
     # DESIGN MODE
     # ==========================================================
@@ -146,7 +160,7 @@ class DoublePipeHX(HeatExchanger):
             / 4.0
         )
 
-        tube_velocity = (
+        tube_velocity_single = (
             cold["m_dot"]
             / (
                 cold["density"]
@@ -154,7 +168,7 @@ class DoublePipeHX(HeatExchanger):
             )
         )
 
-        annulus_velocity = (
+        annulus_velocity_single = (
             hot["m_dot"]
             / (
                 hot["density"]
@@ -162,21 +176,20 @@ class DoublePipeHX(HeatExchanger):
             )
         )
 
+        parallel_paths = self._compute_parallel_paths(tube_velocity_single, annulus_velocity_single)
+        tube_velocity = tube_velocity_single / parallel_paths
+        annulus_velocity = annulus_velocity_single / parallel_paths
+
         # ======================================================
         # PRESSURE DROP
         # ======================================================
 
-        tube_dp = (
-            0.5
-            * cold["density"]
-            * tube_velocity**2
-        )
+        friction_factor_tube = float(self.specs.get("tube_friction_factor", 0.02))
+        friction_factor_annulus = float(self.specs.get("annulus_friction_factor", 0.03))
+        tube_dp = friction_factor_tube * (tube_length / max(tube_id, 1e-6)) * (cold["density"] * tube_velocity**2 / 2.0)
 
-        annulus_dp = (
-            0.5
-            * hot["density"]
-            * annulus_velocity**2
-        )
+        hydraulic_diameter = max(annulus_diameter - tube_od, 1e-6)
+        annulus_dp = friction_factor_annulus * (tube_length / hydraulic_diameter) * (hot["density"] * annulus_velocity**2 / 2.0)
 
         # ======================================================
         # RESULTS
@@ -192,7 +205,8 @@ class DoublePipeHX(HeatExchanger):
             "U_dirty": u_assumed,
             "U_calculated": u_assumed,
             "LMTD": lmtd,
-            "tube_count": 1,
+            "tube_count": parallel_paths,
+            "parallel_paths": parallel_paths,
             "tube_od": tube_od,
             "tube_id": tube_id,
             "tube_length": tube_length,
@@ -203,8 +217,21 @@ class DoublePipeHX(HeatExchanger):
             "shell_dp": annulus_dp,
             "iterations": 1,
             "status": "OK",
-            "warnings": [],
+            "warnings": self._double_pipe_warnings(tube_velocity, annulus_velocity),
         }
+
+    def _double_pipe_warnings(self, tube_velocity: float, annulus_velocity: float) -> list[str]:
+        limits = self._velocity_targets()
+        warnings: list[str] = []
+        if tube_velocity < limits["tube_min"]:
+            warnings.append("[HYDRAULIC_WARNING] Tube velocity below recommended range for double-pipe exchanger")
+        elif tube_velocity > limits["tube_max"]:
+            warnings.append("[HYDRAULIC_WARNING] Tube velocity above recommended range for double-pipe exchanger")
+        if annulus_velocity < limits["annulus_min"]:
+            warnings.append("[HYDRAULIC_WARNING] Annulus velocity below recommended range for double-pipe exchanger")
+        elif annulus_velocity > limits["annulus_max"]:
+            warnings.append("[HYDRAULIC_WARNING] Annulus velocity above recommended range for double-pipe exchanger")
+        return warnings
 
     # ==========================================================
     # RATE MODE
@@ -262,7 +289,7 @@ class DoublePipeHX(HeatExchanger):
         # VELOCITIES
         # ======================================================
 
-        tube_velocity = (
+        tube_velocity_single = (
             cold["m_dot"]
             / (
                 cold["density"]
@@ -270,13 +297,16 @@ class DoublePipeHX(HeatExchanger):
             )
         )
 
-        annulus_velocity = (
+        annulus_velocity_single = (
             hot["m_dot"]
             / (
                 hot["density"]
                 * annulus_area
             )
         )
+        parallel_paths = int(self.specs.get("parallel_paths", self._compute_parallel_paths(tube_velocity_single, annulus_velocity_single)))
+        tube_velocity = tube_velocity_single / parallel_paths
+        annulus_velocity = annulus_velocity_single / parallel_paths
 
         # ======================================================
         # HEAT TRANSFER COEFFICIENTS
@@ -431,17 +461,10 @@ class DoublePipeHX(HeatExchanger):
         # PRESSURE DROP
         # ======================================================
 
-        tube_dp = (
-            0.5
-            * cold["density"]
-            * tube_velocity**2
-        )
-
-        annulus_dp = (
-            0.5
-            * hot["density"]
-            * annulus_velocity**2
-        )
+        friction_factor_tube = float(self.specs.get("tube_friction_factor", 0.02))
+        friction_factor_annulus = float(self.specs.get("annulus_friction_factor", 0.03))
+        tube_dp = friction_factor_tube * (tube_length / max(tube_id, 1e-6)) * (cold["density"] * tube_velocity**2 / 2.0)
+        annulus_dp = friction_factor_annulus * (tube_length / max(hydraulic_diameter, 1e-6)) * (hot["density"] * annulus_velocity**2 / 2.0)
 
         # ======================================================
         # DEBUG
@@ -467,7 +490,8 @@ class DoublePipeHX(HeatExchanger):
             "U_assumed": u_dirty,
             "U_calculated": u_dirty,
             "LMTD": None,
-            "tube_count": 1,
+            "tube_count": parallel_paths,
+            "parallel_paths": parallel_paths,
             "tube_od": tube_od,
             "tube_id": tube_id,
             "tube_length": tube_length,
@@ -478,7 +502,7 @@ class DoublePipeHX(HeatExchanger):
             "shell_dp": annulus_dp,
             "iterations": 1,
             "status": "OK",
-            "warnings": [],
+            "warnings": self._double_pipe_warnings(tube_velocity, annulus_velocity),
             "NTU": NTU,
             "effectiveness": effectiveness,
         }

--- a/processpi/equipment/heatexchangers/evaporator.py
+++ b/processpi/equipment/heatexchangers/evaporator.py
@@ -25,12 +25,16 @@ class EvaporatorHX(ShellAndTubeHX):
         }
 
     def _calculate_heat_duty(self, hot: Dict[str, float], cold: Dict[str, float], **kwargs: Any):
-        latent_heat = self.specs.get("latent_heat")
+        latent_heat = self.specs.get("latent_heat") or self._resolve_phase_change_latent_heat(hot, cold)
         if latent_heat is None:
-            raise ValueError("Evaporator requires latent_heat")
+            raise ValueError("Evaporator requires latent_heat or detectable phase-change service")
         q_watts = LatentDuty(m_dot=cold["m_dot"], latent_heat=latent_heat).calculate().to("W").value
 
-        q_max = hot["m_dot"] * hot["cp"] * 1000.0 * max(hot["t_k"] - cold["t_k"], 0.5)
+        hot_latent = self._resolve_phase_change_latent_heat(hot, cold) if hot.get("phase") in {"vapor", "steam"} else None
+        if hot_latent is not None:
+            q_max = hot["m_dot"] * hot_latent
+        else:
+            q_max = hot["m_dot"] * hot["cp"] * 1000.0 * max(hot["t_k"] - cold["t_k"], 0.5)
         if q_watts > 0.98 * q_max:
             self._warn_with_category("FEASIBILITY_WARNING", "Requested evaporator duty exceeds hot-side available sensible heat; clipping to feasible duty")
             q_watts = 0.98 * q_max

--- a/processpi/equipment/heatexchangers/shell_and_tube.py
+++ b/processpi/equipment/heatexchangers/shell_and_tube.py
@@ -249,6 +249,13 @@ class ShellAndTubeHX(HeatExchanger):
         - exchanger side
         """
     
+        service = str(getattr(self, "service_type", self.specs.get("service", "heat_exchanger"))).lower()
+
+        if service in {"condenser", "reboiler", "evaporator"}:
+            if side == "tube":
+                return (0.6, 1.5)
+            return (0.3, 1.2)
+
         if hasattr(component, "hx_data"):
             data = component.hx_data()
         elif isinstance(component, dict):
@@ -2274,4 +2281,3 @@ class ShellAndTubeHX(HeatExchanger):
         }
     
         return self._finalize_results(payload)
-


### PR DESCRIPTION
### Motivation
- Prevent false feasibility clipping when streams undergo phase change by handling latent heat (condensation/boiling) in the exchanger core.  
- Provide lightweight saturated-steam latent-heat support for engineering-grade realism without adding IAPWS complexity.  
- Improve hydraulic realism and warnings for phase-change services and stabilize extreme double-pipe velocities by applying service-dependent limits and simple parallelization/DP estimates.

### Description
- Add a steam latent-heat helper and generic phase-change duty resolution to the heat-exchanger base via `_lookup_steam_latent_heat` and `_resolve_phase_change_latent_heat`, and route `heat_duty` to use latent duty when detected or specified. (modified `processpi/equipment/heatexchangers/base.py`).
- Update `EvaporatorHX` to accept resolved latent heat when present and consider hot-side latent availability when estimating `q_max` to avoid false sensible-only clipping. (modified `processpi/equipment/heatexchangers/evaporator.py`).
- Make shell-and-tube velocity limits service-dependent so `condenser`, `reboiler`, and `evaporator` use lower/appropriate tube and shell velocity ranges. (modified `processpi/equipment/heatexchangers/shell_and_tube.py`).
- Stabilize `DoublePipeHX` hydraulics by adding velocity target configuration, automatic `parallel_paths` calculation to split flow when single-path velocities exceed targets, friction-based pressure-drop estimates, and structured hydraulic warnings. (modified `processpi/equipment/heatexchangers/double_pipe.py`).
- The changes are intentionally engineering-grade approximations (lookup/interpolation and simple friction factors) to keep the design robust and maintainable.

### Testing
- Ran `pytest -q tests/test_shell_tube_kern_bell_workflow.py tests/test_heatexchanger_mechanical_dispatch.py`, collection failed during import with `ImportError: cannot import name 'ShellAndTube' from processpi.equipment.heatexchangers` (test-collection error unrelated to the new phase-change logic). — FAILED at collection.  
- Executed `python examples/phase_change_hx_examples.py`, which failed with `ModuleNotFoundError: No module named 'processpi'` due to the example invocation environment (package import path), so example run did not complete. — FAILED.  
- No new automated tests were added in this change; the modifications are small-module functional updates and will be followed by integration/test adjustments to resolve the collection/import environment as a next step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c053912088326ad2d2b2ef7785a47)