### PR TITLE
Improve LMTD robustness, latent-heat resolution, and double-pipe hydraulics

### DIFF
--- a/processpi/calculations/heat_transfer/lmtd.py
+++ b/processpi/calculations/heat_transfer/lmtd.py
@@ -14,9 +14,22 @@ class LMTD(CalculationBase):
                 raise ValueError(f"Missing required input: {key}")
 
     def calculate(self):
+        eps = 1e-6
 
         dT1 = self._get_value(self.inputs["dT1"], "temperature")
         dT2 = self._get_value(self.inputs["dT2"], "temperature")
 
-        dTlm = dT1 if dT1 == dT2 else (dT1 - dT2) / math.log(dT1 / dT2)
-        return dTlm
+        if dT1 <= 0 or dT2 <= 0:
+            raise ValueError("Invalid temperature approach in LMTD calculation.")
+
+        dT1 = max(dT1, eps)
+        dT2 = max(dT2, eps)
+
+        if abs(dT1 - dT2) < eps:
+            return dT1
+
+        ratio = dT1 / dT2
+        if ratio <= 0:
+            raise ValueError("Invalid temperature approach in LMTD calculation.")
+
+        return (dT1 - dT2) / math.log(ratio)

--- a/processpi/equipment/heatexchangers/base.py
+++ b/processpi/equipment/heatexchangers/base.py
@@ -50,11 +50,60 @@ class HeatExchanger(HeatExchangerBaseMixin, ABC):
             "t_k": s.temperature.to("K").value if s.temperature else None,
         }
 
+    def _lookup_steam_latent_heat(self, pressure_bar: float) -> float:
+        """Approximate saturated steam latent heat [J/kg] using simple interpolation table."""
+        table = [
+            (1.0, 2257000.0),
+            (2.0, 2202000.0),
+            (3.0, 2163000.0),
+            (5.0, 2108000.0),
+            (8.0, 2048000.0),
+            (10.0, 2014000.0),
+            (15.0, 1944000.0),
+            (20.0, 1889000.0),
+        ]
+        p = max(float(pressure_bar), 0.5)
+        if p <= table[0][0]:
+            return table[0][1]
+        if p >= table[-1][0]:
+            return table[-1][1]
+        for (p1, h1), (p2, h2) in zip(table[:-1], table[1:]):
+            if p1 <= p <= p2:
+                ratio = (p - p1) / (p2 - p1)
+                return h1 + ratio * (h2 - h1)
+        return table[3][1]
+
+    def _resolve_phase_change_latent_heat(self, hot: Dict[str, float], cold: Dict[str, float]) -> float | None:
+        explicit_latent = self.specs.get("latent_heat")
+        if explicit_latent is not None:
+            return float(explicit_latent)
+
+        service = str(self.specs.get("service") or getattr(self, "service_type", "")).lower()
+        hot_in_phase = hot.get("phase", "liquid")
+        cold_in_phase = cold.get("phase", "liquid")
+        hot_out_phase = str(self.specs.get("hot_out_phase", hot_in_phase)).lower()
+        cold_out_phase = str(self.specs.get("cold_out_phase", cold_in_phase)).lower()
+
+        hot_condensing = hot_in_phase == "vapor" and hot_out_phase == "liquid"
+        cold_boiling = cold_in_phase == "liquid" and cold_out_phase == "vapor"
+        service_phase_change = service in {"condenser", "reboiler", "evaporator"}
+
+        if hot_condensing or service == "condenser":
+            return self._lookup_steam_latent_heat(hot.get("p_bar", 1.0))
+        if cold_boiling or service_phase_change:
+            if cold_in_phase == "steam" or getattr(self.cold_in.component, "name", "").lower() == "steam":
+                return self._lookup_steam_latent_heat(cold.get("p_bar", 1.0))
+            return 2257000.0
+        return None
+
     def heat_duty(self, hot: Dict[str, float], cold: Dict[str, float]) -> float:
         if self.specs.get("Q") is not None:
             return float(self.specs["Q"])
-        if self.specs.get("latent_heat") is not None:
-            return LatentDuty(m_dot=hot["m_dot"], latent_heat=self.specs["latent_heat"]).calculate().to("W").value
+        latent_heat = self._resolve_phase_change_latent_heat(hot, cold)
+        if latent_heat is not None:
+            latent_side = str(self.specs.get("latent_side", "hot")).lower()
+            m_dot = hot["m_dot"] if latent_side == "hot" else cold["m_dot"]
+            return LatentDuty(m_dot=m_dot, latent_heat=latent_heat).calculate().to("W").value
         if self.hot_out and hot["t_k"] is not None and self.hot_out.temperature is not None:
             return SensibleDuty(m_dot=hot["m_dot"], cp=hot["cp"], t_in=hot["t_k"], t_out=self.hot_out.temperature.to("K").value).calculate().to("W").value
         if self.cold_out and cold["t_k"] is not None and self.cold_out.temperature is not None:

--- a/processpi/equipment/heatexchangers/double_pipe.py
+++ b/processpi/equipment/heatexchangers/double_pipe.py
@@ -9,6 +9,20 @@ from .base import HeatExchanger
 
 class DoublePipeHX(HeatExchanger):
 
+    def _velocity_targets(self) -> dict[str, float]:
+        return {
+            "tube_min": float(self.specs.get("tube_velocity_min", 0.5)),
+            "tube_max": float(self.specs.get("tube_velocity_max", 2.5)),
+            "annulus_min": float(self.specs.get("annulus_velocity_min", 0.3)),
+            "annulus_max": float(self.specs.get("annulus_velocity_max", 2.0)),
+        }
+
+    def _compute_parallel_paths(self, tube_velocity: float, annulus_velocity: float) -> int:
+        limits = self._velocity_targets()
+        n_tube = max(1, math.ceil(tube_velocity / max(limits["tube_max"], 1e-6)))
+        n_annulus = max(1, math.ceil(annulus_velocity / max(limits["annulus_max"], 1e-6)))
+        return max(n_tube, n_annulus)
+
     # ==========================================================
     # DESIGN MODE
     # ==========================================================
@@ -146,7 +160,7 @@ class DoublePipeHX(HeatExchanger):
             / 4.0
         )
 
-        tube_velocity = (
+        tube_velocity_single = (
             cold["m_dot"]
             / (
                 cold["density"]
@@ -154,7 +168,7 @@ class DoublePipeHX(HeatExchanger):
             )
         )
 
-        annulus_velocity = (
+        annulus_velocity_single = (
             hot["m_dot"]
             / (
                 hot["density"]
@@ -162,21 +176,20 @@ class DoublePipeHX(HeatExchanger):
             )
         )
 
+        parallel_paths = self._compute_parallel_paths(tube_velocity_single, annulus_velocity_single)
+        tube_velocity = tube_velocity_single / parallel_paths
+        annulus_velocity = annulus_velocity_single / parallel_paths
+
         # ======================================================
         # PRESSURE DROP
         # ======================================================
 
-        tube_dp = (
-            0.5
-            * cold["density"]
-            * tube_velocity**2
-        )
+        friction_factor_tube = float(self.specs.get("tube_friction_factor", 0.02))
+        friction_factor_annulus = float(self.specs.get("annulus_friction_factor", 0.03))
+        tube_dp = friction_factor_tube * (tube_length / max(tube_id, 1e-6)) * (cold["density"] * tube_velocity**2 / 2.0)
 
-        annulus_dp = (
-            0.5
-            * hot["density"]
-            * annulus_velocity**2
-        )
+        hydraulic_diameter = max(annulus_diameter - tube_od, 1e-6)
+        annulus_dp = friction_factor_annulus * (tube_length / hydraulic_diameter) * (hot["density"] * annulus_velocity**2 / 2.0)
 
         # ======================================================
         # RESULTS
@@ -192,7 +205,8 @@ class DoublePipeHX(HeatExchanger):
             "U_dirty": u_assumed,
             "U_calculated": u_assumed,
             "LMTD": lmtd,
-            "tube_count": 1,
+            "tube_count": parallel_paths,
+            "parallel_paths": parallel_paths,
             "tube_od": tube_od,
             "tube_id": tube_id,
             "tube_length": tube_length,
@@ -203,8 +217,21 @@ class DoublePipeHX(HeatExchanger):
             "shell_dp": annulus_dp,
             "iterations": 1,
             "status": "OK",
-            "warnings": [],
+            "warnings": self._double_pipe_warnings(tube_velocity, annulus_velocity),
         }
+
+    def _double_pipe_warnings(self, tube_velocity: float, annulus_velocity: float) -> list[str]:
+        limits = self._velocity_targets()
+        warnings: list[str] = []
+        if tube_velocity < limits["tube_min"]:
+            warnings.append("[HYDRAULIC_WARNING] Tube velocity below recommended range for double-pipe exchanger")
+        elif tube_velocity > limits["tube_max"]:
+            warnings.append("[HYDRAULIC_WARNING] Tube velocity above recommended range for double-pipe exchanger")
+        if annulus_velocity < limits["annulus_min"]:
+            warnings.append("[HYDRAULIC_WARNING] Annulus velocity below recommended range for double-pipe exchanger")
+        elif annulus_velocity > limits["annulus_max"]:
+            warnings.append("[HYDRAULIC_WARNING] Annulus velocity above recommended range for double-pipe exchanger")
+        return warnings
 
     # ==========================================================
     # RATE MODE
@@ -262,7 +289,7 @@ class DoublePipeHX(HeatExchanger):
         # VELOCITIES
         # ======================================================
 
-        tube_velocity = (
+        tube_velocity_single = (
             cold["m_dot"]
             / (
                 cold["density"]
@@ -270,13 +297,16 @@ class DoublePipeHX(HeatExchanger):
             )
         )
 
-        annulus_velocity = (
+        annulus_velocity_single = (
             hot["m_dot"]
             / (
                 hot["density"]
                 * annulus_area
             )
         )
+        parallel_paths = int(self.specs.get("parallel_paths", self._compute_parallel_paths(tube_velocity_single, annulus_velocity_single)))
+        tube_velocity = tube_velocity_single / parallel_paths
+        annulus_velocity = annulus_velocity_single / parallel_paths
 
         # ======================================================
         # HEAT TRANSFER COEFFICIENTS
@@ -431,17 +461,10 @@ class DoublePipeHX(HeatExchanger):
         # PRESSURE DROP
         # ======================================================
 
-        tube_dp = (
-            0.5
-            * cold["density"]
-            * tube_velocity**2
-        )
-
-        annulus_dp = (
-            0.5
-            * hot["density"]
-            * annulus_velocity**2
-        )
+        friction_factor_tube = float(self.specs.get("tube_friction_factor", 0.02))
+        friction_factor_annulus = float(self.specs.get("annulus_friction_factor", 0.03))
+        tube_dp = friction_factor_tube * (tube_length / max(tube_id, 1e-6)) * (cold["density"] * tube_velocity**2 / 2.0)
+        annulus_dp = friction_factor_annulus * (tube_length / max(hydraulic_diameter, 1e-6)) * (hot["density"] * annulus_velocity**2 / 2.0)
 
         # ======================================================
         # DEBUG
@@ -467,7 +490,8 @@ class DoublePipeHX(HeatExchanger):
             "U_assumed": u_dirty,
             "U_calculated": u_dirty,
             "LMTD": None,
-            "tube_count": 1,
+            "tube_count": parallel_paths,
+            "parallel_paths": parallel_paths,
             "tube_od": tube_od,
             "tube_id": tube_id,
             "tube_length": tube_length,
@@ -478,7 +502,7 @@ class DoublePipeHX(HeatExchanger):
             "shell_dp": annulus_dp,
             "iterations": 1,
             "status": "OK",
-            "warnings": [],
+            "warnings": self._double_pipe_warnings(tube_velocity, annulus_velocity),
             "NTU": NTU,
             "effectiveness": effectiveness,
         }

--- a/processpi/equipment/heatexchangers/evaporator.py
+++ b/processpi/equipment/heatexchangers/evaporator.py
@@ -25,14 +25,18 @@ class EvaporatorHX(ShellAndTubeHX):
         }
 
     def _calculate_heat_duty(self, hot: Dict[str, float], cold: Dict[str, float], **kwargs: Any):
-        latent_heat = self.specs.get("latent_heat")
+        latent_heat = self.specs.get("latent_heat") or self._resolve_phase_change_latent_heat(hot, cold)
         if latent_heat is None:
-            raise ValueError("Evaporator requires latent_heat")
+            raise ValueError("Evaporator requires latent_heat or detectable phase-change service")
         q_watts = LatentDuty(m_dot=cold["m_dot"], latent_heat=latent_heat).calculate().to("W").value
 
-        q_max = hot["m_dot"] * hot["cp"] * 1000.0 * max(hot["t_k"] - cold["t_k"], 0.5)
+        hot_latent = self._resolve_phase_change_latent_heat(hot, cold) if hot.get("phase") in {"vapor", "steam"} else None
+        if hot_latent is not None:
+            q_max = hot["m_dot"] * hot_latent
+        else:
+            q_max = hot["m_dot"] * hot["cp"] * 1000.0 * max(hot["t_k"] - cold["t_k"], 0.5)
         if q_watts > 0.98 * q_max:
-            self._warn_with_category("FEASIBILITY_WARNING", "Requested evaporator duty exceeds hot-side available sensible heat; clipping to feasible duty")
+            self._warn_with_category("FEASIBILITY_WARNING", "Requested evaporator duty exceeds hot-side available thermal capacity (latent/sensible); clipping to feasible duty")
             q_watts = 0.98 * q_max
 
         th_out = hot["t_k"] - q_watts / max(hot["m_dot"] * hot["cp"] * 1000.0, 1e-12)

--- a/processpi/equipment/heatexchangers/shell_and_tube.py
+++ b/processpi/equipment/heatexchangers/shell_and_tube.py
@@ -82,7 +82,18 @@ class ShellAndTubeHX(HeatExchanger):
         return q_kw * 1000.0, th_out, tc_out
 
     def _calculate_lmtd(self, hot: Dict[str, float], cold: Dict[str, float], th_out: float, tc_out: float) -> float:
-        #self._debug(f"Hot in: {hot["t_k"]} Hot out: {th_out} cold in: {cold["t_k"]} cold out: { tc_out}")
+        dt1 = hot["t_k"] - tc_out
+        dt2 = th_out - cold["t_k"]
+        phase_change_service = str(getattr(self, "service_type", "")).lower() in {"condenser", "reboiler", "evaporator"}
+
+        if phase_change_service and (dt1 <= 0 or dt2 <= 0):
+            self._warn_with_category("FEASIBILITY_WARNING", "Temperature crossing/zero approach detected for phase-change service")
+            raise ValueError("Invalid temperature approach for phase-change exchanger service")
+
+        # Phase-change stabilization: avoid near-singularity in isothermal-side services.
+        if phase_change_service and abs(dt1 - dt2) < 1e-6:
+            return max(dt1, 1e-6)
+
         return self.lmtd(hot["t_k"], th_out, cold["t_k"], tc_out)
 
     def _safe_log_ratio(self, numerator: float, denominator: float) -> float:
@@ -249,6 +260,13 @@ class ShellAndTubeHX(HeatExchanger):
         - exchanger side
         """
     
+        service = str(getattr(self, "service_type", self.specs.get("service", "heat_exchanger"))).lower()
+
+        if service in {"condenser", "reboiler", "evaporator"}:
+            if side == "tube":
+                return (0.6, 1.5)
+            return (0.3, 1.2)
+
         if hasattr(component, "hx_data"):
             data = component.hx_data()
         elif isinstance(component, dict):
@@ -2274,4 +2292,3 @@ class ShellAndTubeHX(HeatExchanger):
         }
     
         return self._finalize_results(payload)
-


### PR DESCRIPTION
### Motivation

- Fix numerical issues and invalid inputs in the LMTD calculation to avoid log singularities and zero/negative approaches.
- Automatically detect or look up latent heat for phase-change services (condenser/reboiler/evaporator) so heat duty can be computed when `latent_heat` is not explicitly provided.
- Improve double-pipe hydraulic sizing to support multiple parallel paths, realistic pressure-drop estimates, and velocity warninging for safer designs.

### Description

- Hardened `LMTD.calculate` by adding an `eps` tolerance, rejecting non-positive approaches, handling near-equal temperatures without division by zero, and validating the log ratio before computing the log-mean temperature difference.
- Added `_lookup_steam_latent_heat` and `_resolve_phase_change_latent_heat` to `HeatExchanger` to approximate saturated-steam latent heat from pressure and to decide when latent heat should be used; updated `heat_duty` to use the resolved latent heat and a `latent_side` spec to pick the correct mass flow.
- Extended `DoublePipeHX` with `_velocity_targets`, `_compute_parallel_paths`, and logic to compute `parallel_paths` (auto or from `specs`), derive per-path velocities, compute pressure drop with friction-factor and hydraulic diameter, and emit hydraulic warnings; results now include `tube_count`, `parallel_paths`, and `warnings`.
- Updated `EvaporatorHX` to fall back to the latent-heat resolver, compute `q_max` from hot-side latent if applicable, and improve the feasibility warning wording when clipping duty.
- Improved `ShellAndTubeHX._calculate_lmtd` to detect invalid or crossing temperature approaches for phase-change services (raising a `ValueError` and emitting a `FEASIBILITY_WARNING`), and to stabilize nearly-isothermal phase-change cases; updated `_get_velocity_limits` to provide conservative defaults for condensers/reboilers/evaporators.

### Testing

- Ran unit tests for LMTD and heat exchanger modules including `tests.calculations.test_lmtd`, `tests.equipment.test_double_pipe`, `tests.equipment.test_evaporator`, and `tests.equipment.test_shell_and_tube` using `pytest -q`.
- All exercised tests completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c053912088326ad2d2b2ef7785a47)