### PR TITLE
Improve heat exchanger calculations: phase-change handling, tracing, hydraulics and geometry sizing

### DIFF
--- a/processpi/calculations/heat_transfer/lmtd.py
+++ b/processpi/calculations/heat_transfer/lmtd.py
@@ -14,9 +14,22 @@ class LMTD(CalculationBase):
                 raise ValueError(f"Missing required input: {key}")
 
     def calculate(self):
+        eps = 1e-6
 
         dT1 = self._get_value(self.inputs["dT1"], "temperature")
         dT2 = self._get_value(self.inputs["dT2"], "temperature")
 
-        dTlm = dT1 if dT1 == dT2 else (dT1 - dT2) / math.log(dT1 / dT2)
-        return dTlm
+        if dT1 <= 0 or dT2 <= 0:
+            raise ValueError("Invalid temperature approach in LMTD calculation.")
+
+        dT1 = max(dT1, eps)
+        dT2 = max(dT2, eps)
+
+        if abs(dT1 - dT2) < eps:
+            return dT1
+
+        ratio = dT1 / dT2
+        if ratio <= 0:
+            raise ValueError("Invalid temperature approach in LMTD calculation.")
+
+        return (dT1 - dT2) / math.log(ratio)

--- a/processpi/equipment/heatexchangers/base.py
+++ b/processpi/equipment/heatexchangers/base.py
@@ -14,6 +14,7 @@ class HeatExchangerBaseMixin:
         self.verbose = bool(self.specs.get("verbose", False))
         self.logger = self.specs.get("logger") or logging.getLogger(f"processpi.hx.{self.__class__.__name__.lower()}")
         self._warnings: list[str] = []
+        self._calculation_trace: list[dict[str, Any]] = []
 
     def _debug(self, *args: object) -> None:
         if self.verbose:
@@ -27,6 +28,12 @@ class HeatExchangerBaseMixin:
         tagged = f"[{category}] {message}"
         self._warnings.append(tagged)
         self.logger.warning(tagged)
+
+    def _trace_step(self, section: str, name: str, value: Any) -> None:
+        entry = {"section": section, "name": name, "value": value}
+        self._calculation_trace.append(entry)
+        if self.verbose:
+            self.logger.debug(f"[{section}] {name}: {value}")
 
 
 class HeatExchanger(HeatExchangerBaseMixin, ABC):
@@ -50,11 +57,85 @@ class HeatExchanger(HeatExchangerBaseMixin, ABC):
             "t_k": s.temperature.to("K").value if s.temperature else None,
         }
 
+    def _lookup_steam_latent_heat(self, pressure_bar: float) -> float:
+        """Approximate saturated steam latent heat [J/kg] using simple interpolation table."""
+        table = [
+            (1.0, 2257000.0),
+            (2.0, 2202000.0),
+            (3.0, 2163000.0),
+            (5.0, 2108000.0),
+            (8.0, 2048000.0),
+            (10.0, 2014000.0),
+            (15.0, 1944000.0),
+            (20.0, 1889000.0),
+        ]
+        p = max(float(pressure_bar), 0.5)
+        if p <= table[0][0]:
+            return table[0][1]
+        if p >= table[-1][0]:
+            return table[-1][1]
+        for (p1, h1), (p2, h2) in zip(table[:-1], table[1:]):
+            if p1 <= p <= p2:
+                ratio = (p - p1) / (p2 - p1)
+                return h1 + ratio * (h2 - h1)
+        return table[3][1]
+
+    def _resolve_phase_change_latent_heat(self, hot: Dict[str, float], cold: Dict[str, float]) -> float | None:
+        explicit_latent = self.specs.get("latent_heat")
+        if explicit_latent is not None:
+            return float(explicit_latent)
+
+        service = str(self.specs.get("service") or getattr(self, "service_type", "")).lower()
+        hot_in_phase = hot.get("phase", "liquid")
+        cold_in_phase = cold.get("phase", "liquid")
+        hot_out_phase = str(self.specs.get("hot_out_phase", hot_in_phase)).lower()
+        cold_out_phase = str(self.specs.get("cold_out_phase", cold_in_phase)).lower()
+
+        hot_condensing = hot_in_phase == "vapor" and hot_out_phase == "liquid"
+        cold_boiling = cold_in_phase == "liquid" and cold_out_phase == "vapor"
+        service_phase_change = service in {"condenser", "reboiler", "evaporator"}
+
+        if hot_condensing or service == "condenser":
+            return self._lookup_steam_latent_heat(hot.get("p_bar", 1.0))
+        if cold_boiling or service_phase_change:
+            if cold_in_phase == "steam" or getattr(self.cold_in.component, "name", "").lower() == "steam":
+                return self._lookup_steam_latent_heat(cold.get("p_bar", 1.0))
+            return 2257000.0
+        return None
+
+    def _is_phase_change_service(self) -> bool:
+        service = str(self.specs.get("service") or getattr(self, "service_type", "")).lower()
+        return service in {"condenser", "reboiler", "evaporator"}
+
+    def _get_stream_outlet_phase(self, side: str, default_phase: str) -> str:
+        if side == "hot":
+            stream = self.hot_out
+            spec_key = "hot_out_phase"
+        else:
+            stream = self.cold_out
+            spec_key = "cold_out_phase"
+        if stream is not None and getattr(stream, "phase", None):
+            return str(stream.phase).lower()
+        return str(self.specs.get(spec_key, default_phase)).lower()
+
+    def _available_thermal_capacity(self, side: str, inlet: Dict[str, float], other_inlet_tk: float) -> float:
+        in_phase = str(inlet.get("phase", "liquid")).lower()
+        out_phase = self._get_stream_outlet_phase(side, in_phase)
+        if in_phase != out_phase:
+            latent = self._resolve_phase_change_latent_heat(inlet if side == "hot" else {"phase":"liquid"}, inlet if side == "cold" else {"phase":"liquid"})
+            if latent is None:
+                latent = 2257000.0
+            return inlet["m_dot"] * latent
+        return inlet["m_dot"] * inlet["cp"] * 1000.0 * max(inlet["t_k"] - other_inlet_tk, 0.5)
+
     def heat_duty(self, hot: Dict[str, float], cold: Dict[str, float]) -> float:
         if self.specs.get("Q") is not None:
             return float(self.specs["Q"])
-        if self.specs.get("latent_heat") is not None:
-            return LatentDuty(m_dot=hot["m_dot"], latent_heat=self.specs["latent_heat"]).calculate().to("W").value
+        latent_heat = self._resolve_phase_change_latent_heat(hot, cold)
+        if latent_heat is not None:
+            latent_side = str(self.specs.get("latent_side", "hot")).lower()
+            m_dot = hot["m_dot"] if latent_side == "hot" else cold["m_dot"]
+            return LatentDuty(m_dot=m_dot, latent_heat=latent_heat).calculate().to("W").value
         if self.hot_out and hot["t_k"] is not None and self.hot_out.temperature is not None:
             return SensibleDuty(m_dot=hot["m_dot"], cp=hot["cp"], t_in=hot["t_k"], t_out=self.hot_out.temperature.to("K").value).calculate().to("W").value
         if self.cold_out and cold["t_k"] is not None and self.cold_out.temperature is not None:

--- a/processpi/equipment/heatexchangers/double_pipe.py
+++ b/processpi/equipment/heatexchangers/double_pipe.py
@@ -9,6 +9,20 @@ from .base import HeatExchanger
 
 class DoublePipeHX(HeatExchanger):
 
+    def _velocity_targets(self) -> dict[str, float]:
+        return {
+            "tube_min": float(self.specs.get("tube_velocity_min", 0.5)),
+            "tube_max": float(self.specs.get("tube_velocity_max", 2.5)),
+            "annulus_min": float(self.specs.get("annulus_velocity_min", 0.3)),
+            "annulus_max": float(self.specs.get("annulus_velocity_max", 2.0)),
+        }
+
+    def _compute_parallel_paths(self, tube_velocity: float, annulus_velocity: float) -> int:
+        limits = self._velocity_targets()
+        n_tube = max(1, math.ceil(tube_velocity / max(limits["tube_max"], 1e-6)))
+        n_annulus = max(1, math.ceil(annulus_velocity / max(limits["annulus_max"], 1e-6)))
+        return max(n_tube, n_annulus)
+
     # ==========================================================
     # DESIGN MODE
     # ==========================================================
@@ -146,7 +160,7 @@ class DoublePipeHX(HeatExchanger):
             / 4.0
         )
 
-        tube_velocity = (
+        tube_velocity_single = (
             cold["m_dot"]
             / (
                 cold["density"]
@@ -154,7 +168,7 @@ class DoublePipeHX(HeatExchanger):
             )
         )
 
-        annulus_velocity = (
+        annulus_velocity_single = (
             hot["m_dot"]
             / (
                 hot["density"]
@@ -162,21 +176,20 @@ class DoublePipeHX(HeatExchanger):
             )
         )
 
+        parallel_paths = self._compute_parallel_paths(tube_velocity_single, annulus_velocity_single)
+        tube_velocity = tube_velocity_single / parallel_paths
+        annulus_velocity = annulus_velocity_single / parallel_paths
+
         # ======================================================
         # PRESSURE DROP
         # ======================================================
 
-        tube_dp = (
-            0.5
-            * cold["density"]
-            * tube_velocity**2
-        )
+        friction_factor_tube = float(self.specs.get("tube_friction_factor", 0.02))
+        friction_factor_annulus = float(self.specs.get("annulus_friction_factor", 0.03))
+        tube_dp = friction_factor_tube * (tube_length / max(tube_id, 1e-6)) * (cold["density"] * tube_velocity**2 / 2.0)
 
-        annulus_dp = (
-            0.5
-            * hot["density"]
-            * annulus_velocity**2
-        )
+        hydraulic_diameter = max(annulus_diameter - tube_od, 1e-6)
+        annulus_dp = friction_factor_annulus * (tube_length / hydraulic_diameter) * (hot["density"] * annulus_velocity**2 / 2.0)
 
         # ======================================================
         # RESULTS
@@ -192,7 +205,8 @@ class DoublePipeHX(HeatExchanger):
             "U_dirty": u_assumed,
             "U_calculated": u_assumed,
             "LMTD": lmtd,
-            "tube_count": 1,
+            "tube_count": parallel_paths,
+            "parallel_paths": parallel_paths,
             "tube_od": tube_od,
             "tube_id": tube_id,
             "tube_length": tube_length,
@@ -203,8 +217,21 @@ class DoublePipeHX(HeatExchanger):
             "shell_dp": annulus_dp,
             "iterations": 1,
             "status": "OK",
-            "warnings": [],
+            "warnings": self._double_pipe_warnings(tube_velocity, annulus_velocity),
         }
+
+    def _double_pipe_warnings(self, tube_velocity: float, annulus_velocity: float) -> list[str]:
+        limits = self._velocity_targets()
+        warnings: list[str] = []
+        if tube_velocity < limits["tube_min"]:
+            warnings.append("[HYDRAULIC_WARNING] Tube velocity below recommended range for double-pipe exchanger")
+        elif tube_velocity > limits["tube_max"]:
+            warnings.append("[HYDRAULIC_WARNING] Tube velocity above recommended range for double-pipe exchanger")
+        if annulus_velocity < limits["annulus_min"]:
+            warnings.append("[HYDRAULIC_WARNING] Annulus velocity below recommended range for double-pipe exchanger")
+        elif annulus_velocity > limits["annulus_max"]:
+            warnings.append("[HYDRAULIC_WARNING] Annulus velocity above recommended range for double-pipe exchanger")
+        return warnings
 
     # ==========================================================
     # RATE MODE
@@ -262,7 +289,7 @@ class DoublePipeHX(HeatExchanger):
         # VELOCITIES
         # ======================================================
 
-        tube_velocity = (
+        tube_velocity_single = (
             cold["m_dot"]
             / (
                 cold["density"]
@@ -270,13 +297,16 @@ class DoublePipeHX(HeatExchanger):
             )
         )
 
-        annulus_velocity = (
+        annulus_velocity_single = (
             hot["m_dot"]
             / (
                 hot["density"]
                 * annulus_area
             )
         )
+        parallel_paths = int(self.specs.get("parallel_paths", self._compute_parallel_paths(tube_velocity_single, annulus_velocity_single)))
+        tube_velocity = tube_velocity_single / parallel_paths
+        annulus_velocity = annulus_velocity_single / parallel_paths
 
         # ======================================================
         # HEAT TRANSFER COEFFICIENTS
@@ -431,17 +461,10 @@ class DoublePipeHX(HeatExchanger):
         # PRESSURE DROP
         # ======================================================
 
-        tube_dp = (
-            0.5
-            * cold["density"]
-            * tube_velocity**2
-        )
-
-        annulus_dp = (
-            0.5
-            * hot["density"]
-            * annulus_velocity**2
-        )
+        friction_factor_tube = float(self.specs.get("tube_friction_factor", 0.02))
+        friction_factor_annulus = float(self.specs.get("annulus_friction_factor", 0.03))
+        tube_dp = friction_factor_tube * (tube_length / max(tube_id, 1e-6)) * (cold["density"] * tube_velocity**2 / 2.0)
+        annulus_dp = friction_factor_annulus * (tube_length / max(hydraulic_diameter, 1e-6)) * (hot["density"] * annulus_velocity**2 / 2.0)
 
         # ======================================================
         # DEBUG
@@ -467,7 +490,8 @@ class DoublePipeHX(HeatExchanger):
             "U_assumed": u_dirty,
             "U_calculated": u_dirty,
             "LMTD": None,
-            "tube_count": 1,
+            "tube_count": parallel_paths,
+            "parallel_paths": parallel_paths,
             "tube_od": tube_od,
             "tube_id": tube_id,
             "tube_length": tube_length,
@@ -478,7 +502,7 @@ class DoublePipeHX(HeatExchanger):
             "shell_dp": annulus_dp,
             "iterations": 1,
             "status": "OK",
-            "warnings": [],
+            "warnings": self._double_pipe_warnings(tube_velocity, annulus_velocity),
             "NTU": NTU,
             "effectiveness": effectiveness,
         }

--- a/processpi/equipment/heatexchangers/engine.py
+++ b/processpi/equipment/heatexchangers/engine.py
@@ -30,6 +30,23 @@ class HeatExchangerResults:
     def detailed_summary(self) -> Dict[str, Any]:
         return self.data
 
+    def trace(self) -> str:
+        trace_entries = self.data.get("calculation_trace", [])
+        grouped: Dict[str, list[dict[str, Any]]] = {}
+        for entry in trace_entries:
+            grouped.setdefault(entry.get("section", "GENERAL"), []).append(entry)
+        lines: list[str] = []
+        for section in ["THERMAL", "GEOMETRY", "HYDRAULICS", "DIMENSIONLESS", "PHASE_CHANGE", "GENERAL"]:
+            rows = grouped.get(section, [])
+            if not rows:
+                continue
+            lines.append("=" * 48)
+            lines.append(section)
+            lines.append("=" * len(section))
+            for row in rows:
+                lines.append(f"{row.get('name','item'):<24}: {row.get('value')}")
+        return "\n".join(lines) if lines else "No engineering trace available."
+
 
 class HeatExchangerEngine:
     _map: Dict[str, Type[HeatExchanger]] = {

--- a/processpi/equipment/heatexchangers/evaporator.py
+++ b/processpi/equipment/heatexchangers/evaporator.py
@@ -25,14 +25,19 @@ class EvaporatorHX(ShellAndTubeHX):
         }
 
     def _calculate_heat_duty(self, hot: Dict[str, float], cold: Dict[str, float], **kwargs: Any):
-        latent_heat = self.specs.get("latent_heat")
+        latent_heat = self.specs.get("latent_heat") or self._resolve_phase_change_latent_heat(hot, cold)
         if latent_heat is None:
-            raise ValueError("Evaporator requires latent_heat")
+            raise ValueError("Evaporator requires latent_heat or detectable phase-change service")
         q_watts = LatentDuty(m_dot=cold["m_dot"], latent_heat=latent_heat).calculate().to("W").value
 
-        q_max = hot["m_dot"] * hot["cp"] * 1000.0 * max(hot["t_k"] - cold["t_k"], 0.5)
+        hot_out_phase = self._get_stream_outlet_phase("hot", str(hot.get("phase", "liquid")))
+        if hot_out_phase != str(hot.get("phase", "liquid")):
+            hot_latent = self._resolve_phase_change_latent_heat(hot, cold) or self._lookup_steam_latent_heat(hot.get("p_bar", 1.0))
+            q_max = hot["m_dot"] * hot_latent
+        else:
+            q_max = hot["m_dot"] * hot["cp"] * 1000.0 * max(hot["t_k"] - cold["t_k"], 0.5)
         if q_watts > 0.98 * q_max:
-            self._warn_with_category("FEASIBILITY_WARNING", "Requested evaporator duty exceeds hot-side available sensible heat; clipping to feasible duty")
+            self._warn_with_category("FEASIBILITY_WARNING", "Requested evaporator duty exceeds hot-side available thermal capacity (latent/sensible); clipping to feasible duty")
             q_watts = 0.98 * q_max
 
         th_out = hot["t_k"] - q_watts / max(hot["m_dot"] * hot["cp"] * 1000.0, 1e-12)

--- a/processpi/equipment/heatexchangers/shell_and_tube.py
+++ b/processpi/equipment/heatexchangers/shell_and_tube.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 from typing import Any, Dict, List, Tuple
 
+from processpi.calculations.heat_transfer import LMTD
 from processpi.calculations.heat_transfer.hx_kern import (
     ConvectiveH,
     DarcyDrop,
@@ -82,7 +83,23 @@ class ShellAndTubeHX(HeatExchanger):
         return q_kw * 1000.0, th_out, tc_out
 
     def _calculate_lmtd(self, hot: Dict[str, float], cold: Dict[str, float], th_out: float, tc_out: float) -> float:
-        #self._debug(f"Hot in: {hot["t_k"]} Hot out: {th_out} cold in: {cold["t_k"]} cold out: { tc_out}")
+        eps = 1e-3
+        dt1 = hot["t_k"] - tc_out
+        dt2 = th_out - cold["t_k"]
+        phase_change_service = str(getattr(self, "service_type", "")).lower() in {"condenser", "reboiler", "evaporator"}
+
+        if phase_change_service:
+            if dt1 <= eps:
+                self._warn_with_category("FEASIBILITY_WARNING", "Phase-change LMTD stabilization applied on terminal dT1")
+                dt1 = eps
+            if dt2 <= eps:
+                self._warn_with_category("FEASIBILITY_WARNING", "Phase-change LMTD stabilization applied on terminal dT2")
+                dt2 = eps
+            if abs(dt1 - dt2) < eps:
+                self._warn_with_category("FEASIBILITY_WARNING", "Near-isothermal phase-change exchanger stabilized")
+                return 0.5 * (dt1 + dt2)
+            return LMTD(dT1=dt1, dT2=dt2).calculate()
+
         return self.lmtd(hot["t_k"], th_out, cold["t_k"], tc_out)
 
     def _safe_log_ratio(self, numerator: float, denominator: float) -> float:
@@ -249,6 +266,13 @@ class ShellAndTubeHX(HeatExchanger):
         - exchanger side
         """
     
+        service = str(getattr(self, "service_type", self.specs.get("service", "heat_exchanger"))).lower()
+
+        if service in {"condenser", "reboiler"}:
+            return (0.6, 2.0) if side == "tube" else (0.3, 1.0)
+        if service in {"evaporator"}:
+            return (0.8, 2.0) if side == "tube" else (0.3, 1.0)
+
         if hasattr(component, "hx_data"):
             data = component.hx_data()
         elif isinstance(component, dict):
@@ -276,9 +300,9 @@ class ShellAndTubeHX(HeatExchanger):
                 if "water" in family:
                     return (1.5, 2.5)
     
-                return (1.0, 2.0)
-    
-            return (0.3, 1.0)
+                return (1.0, 2.5)
+
+            return (0.5, 1.5)
     
         # ==========================================================
         # VAPORS / GASES
@@ -416,11 +440,31 @@ class ShellAndTubeHX(HeatExchanger):
             tube_count = math.ceil(area_required / max(area_per_tube, 1e-12))
             self._debug("Tube Count: ",tube_count)
 
-        standard_geom = self._select_best_standard_geometry(area_required, tube_od, tube_length, tube_passes)
+        # Thermo-hydraulic tube count target: satisfy area and avoid tube-side velocity collapse.
+        area_per_tube = math.pi * tube_od * tube_length
+        tube_flow_per_tube = math.pi * tube_id**2 / 4.0
+        required_count = math.ceil(area_required / max(area_per_tube, 1e-12))
+        required_count = self._round_tube_count_to_passes(required_count, tube_passes)
+        vmin, vmax = self._get_velocity_limits("tube", self.hot_in.component)
+        q_vol_hot = hot["m_dot"] / max(hot["density"], 1e-12)
+        low_v_count = int(math.floor((q_vol_hot * tube_passes) / max(vmin * tube_flow_per_tube, 1e-12)))
+        high_v_count = int(math.ceil((q_vol_hot * tube_passes) / max(vmax * tube_flow_per_tube, 1e-12)))
+        if high_v_count > 0:
+            required_count = max(required_count, self._round_tube_count_to_passes(high_v_count, tube_passes))
+        if low_v_count > 0 and required_count > low_v_count:
+            self._warn_with_category("HYDRAULIC_WARNING", "Thermal area pushes tube count above hydraulic velocity target; using capped thermo-hydraulic count")
+            required_count = self._round_tube_count_to_passes(low_v_count, tube_passes)
+
+        standard_geom = self._select_best_standard_geometry(max(area_required, required_count * area_per_tube), tube_od, tube_length, tube_passes)
         std_tube_count = standard_geom.get("tube_count")
         if std_tube_count and std_tube_count >= tube_count:
             self._debug(f"Using standard tube count lookup >= required: {std_tube_count}")
             tube_count = std_tube_count
+        tube_count = max(tube_count, required_count)
+        tube_count_max = int(self.specs.get("tube_count_max", 1200))
+        if tube_count > tube_count_max:
+            self._warn_with_category("GEOMETRY_WARNING", f"Tube count clipped to practical maximum ({tube_count_max})")
+            tube_count = tube_count_max
         tube_count = self._round_tube_count_to_passes(tube_count, tube_passes)
         self._debug("Tube Count Round: ",tube_count)
         tube_pitch = float(self.specs.get("tube_pitch", 1.25 * tube_od))
@@ -852,9 +896,14 @@ class ShellAndTubeHX(HeatExchanger):
         u_range: Tuple[float, float] | None,
     ) -> Dict[str, Any]:
     
+        u_user = None
+        if self.specs.get("U") is not None:
+            u_user = float(self.specs["U"].to("W/m2K").value)
+            self._trace_step("THERMAL", "U user supplied", u_user)
         state = {
             "iterations": 0,
             "u_assumed": u_assumed,
+            "u_user": u_user,
         }
     
         max_iter = 15
@@ -871,6 +920,8 @@ class ShellAndTubeHX(HeatExchanger):
                 state["u_assumed"],
                 cltd,
             )
+            self._trace_step("THERMAL", "U iteration", i)
+            self._trace_step("THERMAL", "Area required", area_required)
     
             # ======================================================
             # GEOMETRY
@@ -888,6 +939,8 @@ class ShellAndTubeHX(HeatExchanger):
                 tube_passes,
                 hot,
             )
+            self._trace_step("GEOMETRY", "Tube count", geometry["tube_count"])
+            self._trace_step("GEOMETRY", "Tube length", geometry["tube_length"])
     
             bundle_diameter = self._calculate_bundle_diameter(
                 geometry["tube_count"],
@@ -924,6 +977,8 @@ class ShellAndTubeHX(HeatExchanger):
                 shell_passes,
                 shell_diameter,
             )
+            self._trace_step("HYDRAULICS", "Tube velocity", v_tube)
+            self._trace_step("HYDRAULICS", "Shell velocity", v_shell)
     
             geometry["tube_count"] = tube_count
     
@@ -944,6 +999,8 @@ class ShellAndTubeHX(HeatExchanger):
                 v_tube,
                 v_shell,
             )
+            self._trace_step("DIMENSIONLESS", "Re_tube", dimless["re_t"])
+            self._trace_step("DIMENSIONLESS", "Nu_tube", dimless["nu_t"])
     
             h_t, h_s = self._calculate_htc(
                 dimless,
@@ -965,6 +1022,10 @@ class ShellAndTubeHX(HeatExchanger):
     
             u_dirty = u_results["U_dirty"]
             u_clean = u_results["U_clean"]
+            self._trace_step("THERMAL", "U clean", u_clean)
+            self._trace_step("THERMAL", "U calculated", u_dirty)
+            if u_user is not None:
+                self._trace_step("THERMAL", "U calc vs U user", f"{u_dirty:.2f} vs {u_user:.2f}")
     
             # ======================================================
             # DIRTY AREA
@@ -1022,6 +1083,8 @@ class ShellAndTubeHX(HeatExchanger):
     
             state["tube_dp"] = tube_dp
             state["shell_dp"] = shell_dp
+            self._trace_step("HYDRAULICS", "Tube pressure drop", tube_dp)
+            self._trace_step("HYDRAULICS", "Shell pressure drop", shell_dp)
     
             # ======================================================
             # VALIDATION
@@ -1051,6 +1114,7 @@ class ShellAndTubeHX(HeatExchanger):
                     / max(u_old, 1e-12)
                 ) * 100.0
             )
+            self._trace_step("THERMAL", "U convergence error %", convergence_error)
     
             self._debug("\n" + "=" * 60)
             self._debug(f"Iteration          : {i}")
@@ -1083,6 +1147,15 @@ class ShellAndTubeHX(HeatExchanger):
                 existing.extend(soft_warnings)
     
                 state["warnings"] = list(dict.fromkeys(existing))
+
+            if "tube_velocity" in hard_violations or "shell_velocity" in hard_violations:
+                self._trace_step("GEOMETRY", "Geometry rejected", f"hydraulic violation {hard_violations}")
+                if self.specs.get("tube_length") is None:
+                    geometry["tube_length"] = min(12.0, geometry["tube_length"] * 1.15)
+                    self._trace_step("GEOMETRY", "Tube length adjusted", geometry["tube_length"])
+                tube_passes = min(8, max(tube_passes, 2) * 2 if tube_passes < 8 else 8)
+                self._trace_step("GEOMETRY", "Tube passes adjusted", tube_passes)
+                continue
     
             # ======================================================
             # CONVERGENCE CHECK
@@ -1400,6 +1473,7 @@ class ShellAndTubeHX(HeatExchanger):
             "Q": payload["q_watts_original"] / 1000.0,
             "Area": payload["area"],
             "U_assumed": payload["u_assumed"],
+            "U_user": payload.get("u_user"),
             "U_calculated": payload["u_calculated"],
             "LMTD": payload["lmtd"],
             "tube_count": payload["geometry"]["tube_count"],
@@ -1422,6 +1496,7 @@ class ShellAndTubeHX(HeatExchanger):
             "shell_side_fluid": payload.get("assignment", {}).get("shell_side_fluid"),
             "assignment_reason": payload.get("assignment", {}).get("assignment_reason", []),
             "assignment": payload.get("assignment", {}),
+            "calculation_trace": list(self._calculation_trace),
         }
 
     def _design_kern(self) -> Dict[str, Any]:
@@ -1441,12 +1516,14 @@ class ShellAndTubeHX(HeatExchanger):
             self.service_type = "heater"
 
         q_watts, th_out, tc_out = self._calculate_heat_duty(hot, cold)
-        self._debug(q_watts)
+        self._trace_step("THERMAL", "Heat duty (W)", q_watts)
         lmtd = self._calculate_lmtd(hot, cold, th_out, tc_out)
-        self._debug(lmtd)
+        self._trace_step("THERMAL", "LMTD", lmtd)
 
         shell_passes, tube_passes, ft = self._adjust_passes(hot, cold, th_out, tc_out)
-        self._debug(ft, shell_passes, tube_passes)
+        self._trace_step("THERMAL", "Ft", ft)
+        self._trace_step("GEOMETRY", "Shell passes", shell_passes)
+        self._trace_step("GEOMETRY", "Tube passes", tube_passes)
         warnings: List[str] = list(getattr(self, "_warnings", []))
 
         n_units = 1
@@ -1460,7 +1537,7 @@ class ShellAndTubeHX(HeatExchanger):
         self._debug(cltd)
 
         u_assumed = self._assume_u(hot, cold)
-        self._debug(u_assumed)
+        self._trace_step("THERMAL", "U assumed initial", u_assumed)
         hot_hx = self.hot_in.component.hx_data() if hasattr(self.hot_in.component, "hx_data") else {"u_key": getattr(self.hot_in.component, "hx_type", "generic")}
         cold_hx = self.cold_in.component.hx_data() if hasattr(self.cold_in.component, "hx_data") else {"u_key": getattr(self.cold_in.component, "hx_type", "generic")}
         self._debug(f"Hot hx_data = {hot_hx}")
@@ -1523,6 +1600,7 @@ class ShellAndTubeHX(HeatExchanger):
             "area": state["geometry"]["area"],
             "u_assumed": state["u_assumed"],
             "u_calculated": state["u_calculated"],
+            "u_user": state.get("u_user"),
             "re_shell": state["re_shell"],
         }
         return self._finalize_results(payload)
@@ -2274,4 +2352,3 @@ class ShellAndTubeHX(HeatExchanger):
         }
     
         return self._finalize_results(payload)
-


### PR DESCRIPTION
### Motivation
- Stabilize and harden LMTD and heat-duty calculations for near-isothermal and phase-change cases to avoid numerical issues and incorrect sizing. 
- Capture an engineering calculation trace for debugging and to expose intermediate thermal/hydraulic state. 
- Improve hydraulic/velocity logic and geometry selection to support parallel paths, realistic pressure-drop estimates and better tube-count selection. 

### Description
- Hardened `LMTD.calculate` to guard against zero/negative approaches, near-equal dTs and added a small `eps` tolerance to avoid divide-by-zero. 
- Added calculation tracing to `HeatExchangerBaseMixin` (`_calculation_trace` and `_trace_step`) and surfaced the trace in `HeatExchangerResults.trace` and final results under `calculation_trace`. 
- Implemented steam latent-heat lookup (`_lookup_steam_latent_heat`) and a phase-change resolver (`_resolve_phase_change_latent_heat`) so `heat_duty` auto-detects condensers/evaporators and selects appropriate latent heat and side (`latent_side`). 
- Enhanced `DoublePipeHX` to compute recommended velocity targets, derive `parallel_paths` from single-path velocities, divide flows across parallel paths, use friction-factor based pressure-drop formulas, and emit hydraulic warnings via `_double_pipe_warnings`. 
- Improved `EvaporatorHX` and `ShellAndTubeHX` to use the new latent-heat resolution, apply LMTD stabilization for phase-change exchangers, update Ft/LMTD handling and velocity limits for different services, and adjust tube-count selection to consider thermo-hydraulic targets and clip to a configurable maximum. 
- Added many `_trace_step` calls across `_iterate_U`, geometry selection, HTC calculations and pressure-drop computations to record important intermediate values such as `Area required`, `Tube count`, `U calculated`, velocity and pressure-drop diagnostics. 

### Testing
- Ran unit tests for the heat-exchanger module using `pytest tests/equipment/test_heatexchangers.py`; all tests passed. 
- Executed the project's full test suite via `pytest` to validate integrations; no failures were reported. 
- Verified that new tracing fields appear in `HeatExchangerResults.detailed_summary()` outputs and that numeric edge-cases for LMTD/latent duty are handled without exceptions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c053912088326ad2d2b2ef7785a47)