### PR TITLE
Centralize numeric extraction in HX base and normalize HX internals with _get_value

### DIFF
--- a/processpi/equipment/heatexchangers/base.py
+++ b/processpi/equipment/heatexchangers/base.py
@@ -47,16 +47,39 @@ class HeatExchanger(HeatExchangerBaseMixin, ABC):
         self.specs = specs
         self._init_runtime()
 
+    @staticmethod
+    def _get_value(x, name):
+        """
+        Extract numeric value from floats or ProcessPI unit objects.
+        """
+        if hasattr(x, "value"):
+            return x.value
+        try:
+            return float(x)
+        except (TypeError, ValueError):
+            raise TypeError(f"Could not interpret {name} value: {x!r}")
+
+    def _safe_float(self, x: Any, name: str) -> float:
+        return float(self._get_value(x, name))
+
+    def _safe_positive(self, x: Any, name: str, minimum: float = 1e-12) -> float:
+        value = self._safe_float(x, name)
+        return max(value, minimum)
+
+    def _safe_nonzero(self, x: Any, name: str, eps: float = 1e-12) -> float:
+        value = self._safe_float(x, name)
+        return value if abs(value) > eps else eps
+
     def _stream_props(self, s: MaterialStream) -> Dict[str, float]:
         return {
-            "density": s.density.to("kg/m3").value,
-            "viscosity": s.component.viscosity().to("Pa·s").value if s.component and hasattr(s.component, "viscosity") else self.specs.get("viscosity", 1e-3),
-            "cp": s.specific_heat.to("J/kgK").value if s.specific_heat else self.specs.get("cp", 4180.0),
-            "k": s.component.thermal_conductivity().to("W/mK").value if s.component and hasattr(s.component, "thermal_conductivity") else self.specs.get("thermal_conductivity", 0.6),
-            "m_dot": s.mass_flow().to("kg/s").value if s.mass_flow() else self.specs.get("mass_flow_rate", 1.0),
-            "p_bar": s.pressure.to("bar").value if s.pressure else 1.0,
+            "density": self._safe_float(s.density.to("kg/m3"), "density"),
+            "viscosity": self._safe_float(s.component.viscosity().to("Pa·s"), "viscosity") if s.component and hasattr(s.component, "viscosity") else self._safe_float(self.specs.get("viscosity", 1e-3), "viscosity"),
+            "cp": self._safe_float(s.specific_heat.to("J/kgK"), "cp") if s.specific_heat else self._safe_float(self.specs.get("cp", 4180.0), "cp"),
+            "k": self._safe_float(s.component.thermal_conductivity().to("W/mK"), "k") if s.component and hasattr(s.component, "thermal_conductivity") else self._safe_float(self.specs.get("thermal_conductivity", 0.6), "k"),
+            "m_dot": self._safe_float(s.mass_flow().to("kg/s"), "m_dot") if s.mass_flow() else self._safe_float(self.specs.get("mass_flow_rate", 1.0), "m_dot"),
+            "p_bar": self._safe_float(s.pressure.to("bar"), "p_bar") if s.pressure else 1.0,
             "phase": (s.phase or "liquid").lower(),
-            "t_k": s.temperature.to("K").value if s.temperature else None,
+            "t_k": self._safe_float(s.temperature.to("K"), "t_k") if s.temperature else None,
         }
 
     def _to_float(self, value: Any, unit: str | None = None) -> float:
@@ -167,22 +190,24 @@ class HeatExchanger(HeatExchangerBaseMixin, ABC):
         if latent_heat is not None:
             latent_side = str(self.specs.get("latent_side", "hot")).lower()
             m_dot = hot["m_dot"] if latent_side == "hot" else cold["m_dot"]
-            return LatentDuty(m_dot=m_dot, latent_heat=latent_heat).calculate().to("W").value
+            return self._safe_float(LatentDuty(m_dot=m_dot, latent_heat=latent_heat).calculate().to("W"), "latent_duty")
         if self.hot_out and hot["t_k"] is not None and self.hot_out.temperature is not None:
-            return SensibleDuty(m_dot=hot["m_dot"], cp=hot["cp"], t_in=hot["t_k"], t_out=self.hot_out.temperature.to("K").value).calculate().to("W").value
+            t_out = self._safe_float(self.hot_out.temperature.to("K"), "hot_out_temperature")
+            return self._safe_float(SensibleDuty(m_dot=hot["m_dot"], cp=hot["cp"], t_in=hot["t_k"], t_out=t_out).calculate().to("W"), "sensible_duty_hot")
         if self.cold_out and cold["t_k"] is not None and self.cold_out.temperature is not None:
-            return SensibleDuty(m_dot=cold["m_dot"], cp=cold["cp"], t_in=self.cold_out.temperature.to("K").value, t_out=cold["t_k"]).calculate().to("W").value
+            t_in = self._safe_float(self.cold_out.temperature.to("K"), "cold_out_temperature")
+            return self._safe_float(SensibleDuty(m_dot=cold["m_dot"], cp=cold["cp"], t_in=t_in, t_out=cold["t_k"]).calculate().to("W"), "sensible_duty_cold")
         raise ValueError("Insufficient thermal specification. Provide one outlet stream or Q/latent_heat.")
 
     def lmtd(self, th_in: float, th_out: float, tc_in: float, tc_out: float) -> float:
         return LMTD(dT1=th_in - tc_out, dT2=th_out - tc_in).calculate()
 
     def area(self, q_w: float, u: float, dtlm: float) -> float:
-        return HeatExchangerArea(heat_duty=q_w, overall_heat_transfer_coeff=u, log_mean_temp_diff=dtlm).calculate().to("m2").value
+        return self._safe_float(HeatExchangerArea(heat_duty=q_w, overall_heat_transfer_coeff=u, log_mean_temp_diff=dtlm).calculate().to("m2"), "area")
 
     def overall_u(self, h_tube: float, h_shell: float, fouling_factor: float = 0.0) -> float:
         u = OverallHeatTransferCoefficient(resistances=[1.0 / h_tube, fouling_factor, 1.0 / h_shell]).calculate()
-        return u.to("W/m2K").value
+        return self._safe_float(u.to("W/m2K"), "overall_u")
 
     @abstractmethod
     def design(self) -> Dict[str, Any]:

--- a/processpi/equipment/heatexchangers/condenser.py
+++ b/processpi/equipment/heatexchangers/condenser.py
@@ -25,7 +25,7 @@ class CondenserHX(ShellAndTubeHX):
         vapor_fraction = float(self.specs.get("vapor_fraction_condensed", 1.0 if self.condensation_mode == "total" else 0.5))
         vapor_fraction = max(0.05, min(vapor_fraction, 1.0))
 
-        q_watts = LatentDuty(m_dot=hot["m_dot"] * vapor_fraction, latent_heat=latent_heat).calculate().to("W").value
+        q_watts = self._safe_float(LatentDuty(m_dot=hot["m_dot"] * vapor_fraction, latent_heat=latent_heat).calculate().to("W"), "q_watts")
         th_in = hot["t_k"]
         tc_in = cold["t_k"]
 
@@ -52,7 +52,7 @@ class CondenserHX(ShellAndTubeHX):
         delta_t = max(float(self.specs.get("condensation_dT", 5.0)), 0.5)
         length = max(float(geometry.get("tube_length", 6.0)), 0.5)
 
-        h_base = CondensationHTC(
+        h_base = self._safe_float(CondensationHTC(
             rho_l=liquid_density,
             rho_v=vapor_density,
             mu_l=liquid_viscosity,
@@ -60,7 +60,7 @@ class CondenserHX(ShellAndTubeHX):
             h_fg=latent_heat,
             delta_t=delta_t,
             length=length,
-        ).calculate().to("W/m2K").value
+        ).calculate().to("W/m2K"), "h_base")
 
         orientation_factor = 1.0 if self.orientation == "vertical" else 0.85
         side_factor = 0.9 if self.condensing_side == "tube" else 1.0

--- a/processpi/equipment/heatexchangers/double_pipe.py
+++ b/processpi/equipment/heatexchangers/double_pipe.py
@@ -39,7 +39,7 @@ class DoublePipeHX(HeatExchanger):
         # ======================================================
 
         th_out = (
-            self.hot_out.temperature.to("K").value
+            self._safe_float(self.hot_out.temperature.to("K"), "hot_out.temperature")
             if (
                 self.hot_out
                 and self.hot_out.temperature
@@ -55,7 +55,7 @@ class DoublePipeHX(HeatExchanger):
         )
 
         tc_out = (
-            self.cold_out.temperature.to("K").value
+            self._safe_float(self.cold_out.temperature.to("K"), "cold_out.temperature")
             if (
                 self.cold_out
                 and self.cold_out.temperature
@@ -85,12 +85,8 @@ class DoublePipeHX(HeatExchanger):
         # U
         # ======================================================
 
-        u_assumed = float(
-            self.specs.get(
-                "U",
-                350.0,
-            ).to("W/m2K").value
-        )
+        u_spec = self.specs.get("U", 350.0)
+        u_assumed = self._safe_float(u_spec.to("W/m2K"), "U") if hasattr(u_spec, "to") else self._safe_float(u_spec, "U")
 
         # ======================================================
         # AREA

--- a/processpi/equipment/heatexchangers/engine.py
+++ b/processpi/equipment/heatexchangers/engine.py
@@ -180,8 +180,8 @@ class HeatExchangerEngine:
         if cold_out and cold_out.phase == "vapor":
             return "reboiler"
 
-        hot_m = hot_in.mass_flow().to("kg/s").value if hot_in.mass_flow() else 0.0
-        cold_m = self.data["cold_in"].mass_flow().to("kg/s").value if self.data["cold_in"].mass_flow() else 0.0
+        hot_m = float(getattr(hot_in.mass_flow().to("kg/s"), "value", hot_in.mass_flow().to("kg/s"))) if hot_in.mass_flow() else 0.0
+        cold_m = float(getattr(self.data["cold_in"].mass_flow().to("kg/s"), "value", self.data["cold_in"].mass_flow().to("kg/s"))) if self.data["cold_in"].mass_flow() else 0.0
         if max(hot_m, cold_m) <= 1.0:
             return "double_pipe"
         return "shell_and_tube"

--- a/processpi/equipment/heatexchangers/evaporator.py
+++ b/processpi/equipment/heatexchangers/evaporator.py
@@ -28,7 +28,7 @@ class EvaporatorHX(ShellAndTubeHX):
         latent_heat = self.specs.get("latent_heat") or self._resolve_phase_change_latent_heat(hot, cold)
         if latent_heat is None:
             raise ValueError("Evaporator requires latent_heat or detectable phase-change service")
-        q_watts = LatentDuty(m_dot=cold["m_dot"], latent_heat=latent_heat).calculate().to("W").value
+        q_watts = self._safe_float(LatentDuty(m_dot=cold["m_dot"], latent_heat=latent_heat).calculate().to("W"), "q_watts")
 
         hot_out_phase = self._get_stream_outlet_phase("hot", str(hot.get("phase", "liquid")))
         if hot_out_phase != str(hot.get("phase", "liquid")):
@@ -49,7 +49,7 @@ class EvaporatorHX(ShellAndTubeHX):
 
     def _calculate_boiling_htc(self, cold: Dict[str, float], q_flux: float) -> float:
         pressure = max(cold.get("p_bar", 1.0), 0.5)
-        h_boil = BoilingHTC(heat_flux=max(q_flux, 1e3), pressure=pressure).calculate().to("W/m2K").value
+        h_boil = self._safe_float(BoilingHTC(heat_flux=max(q_flux, 1e3), pressure=pressure).calculate().to("W/m2K"), "h_boil")
         orientation_factor = 1.1 if self.orientation == "vertical" else 1.0
         return max(1500.0, min(h_boil * orientation_factor, 18000.0))
 

--- a/processpi/equipment/heatexchangers/shell_and_tube.py
+++ b/processpi/equipment/heatexchangers/shell_and_tube.py
@@ -45,7 +45,7 @@ class ShellAndTubeHX(HeatExchanger):
 
     def _assume_u(self, hot: Dict[str, float], cold: Dict[str, float]) -> float:
         if self.specs.get("U") is not None:
-            return float(self.specs["U"].to("W/m2K").value)
+            return self._safe_float(self.specs["U"].to("W/m2K"), "U")
         hot_type = getattr(self.hot_in.component, "hx_type", "generic")
         cold_type = getattr(self.cold_in.component, "hx_type", "generic")
         service_type = getattr(self, "service_type", "heat_exchanger")
@@ -75,14 +75,14 @@ class ShellAndTubeHX(HeatExchanger):
         th_in = hot["t_k"]
         tc_in = cold["t_k"]
         #self._debug(f"Hot Cp: {hot["cp"]} Cold Cp {cold["cp"]}")
-        if self.hot_out and self.hot_out.temperature and self.hot_out.temperature.to("C").value == 25 :
-            th_out = self.hot_out.temperature.to("K").value
+        if self.hot_out and self.hot_out.temperature and self._safe_float(self.hot_out.temperature.to("C"), "hot_out.temperature") == 25 :
+            th_out = self._safe_float(self.hot_out.temperature.to("K"), "hot_out.temperature")
         else:
             th_out = th_in - (q_kw / max(hot["m_dot"] * hot["cp"], 1e-9))
 
-        if self.cold_out and self.cold_out.temperature and self.cold_out.temperature.to("C").value == 25:
+        if self.cold_out and self.cold_out.temperature and self._safe_float(self.cold_out.temperature.to("C"), "cold_out.temperature") == 25:
             #self._debug("Hello World")
-            tc_out = self.cold_out.temperature.to("K").value
+            tc_out = self._safe_float(self.cold_out.temperature.to("K"), "cold_out.temperature")
         else:
             tc_out = tc_in + (q_kw / max(cold["m_dot"] * cold["cp"], 1e-9))
             #self._debug(f"tc_out = {tc_in} + ({q_kw}/({cold["m_dot"]}*{cold["cp"]})")
@@ -683,8 +683,8 @@ class ShellAndTubeHX(HeatExchanger):
         return {"re_t": re_t, "pr_t": pr_t, "nu_t": nu_t, "de_shell": de_shell, "re_s": re_s, "pr_s": pr_s, "nu_s": nu_s}
 
     def _calculate_htc(self, dimless: Dict[str, float], geometry: Dict[str, float], hot: Dict[str, float], cold: Dict[str, float]) -> Tuple[float, float]:
-        h_t = ConvectiveH(nusselt=dimless["nu_t"], k=hot["k"], diameter=geometry["tube_id"]).calculate().to("W/m2K").value
-        h_s = ConvectiveH(nusselt=dimless["nu_s"], k=cold["k"], diameter=dimless["de_shell"]).calculate().to("W/m2K").value
+        h_t = self._safe_float(ConvectiveH(nusselt=dimless["nu_t"], k=hot["k"], diameter=geometry["tube_id"]).calculate().to("W/m2K"), "h_t")
+        h_s = self._safe_float(ConvectiveH(nusselt=dimless["nu_s"], k=cold["k"], diameter=dimless["de_shell"]).calculate().to("W/m2K"), "h_s")
         return h_t, h_s
 
     def _calculate_overall_U(
@@ -715,7 +715,9 @@ class ShellAndTubeHX(HeatExchanger):
         # TUBE WALL RESISTANCE
         # ======================================================
 
-        tube_wall_thickness = (tube_od.value - tube_id) / 2
+        tube_od = self._safe_float(tube_od, "tube_od")
+        tube_id = self._safe_float(tube_id, "tube_id")
+        tube_wall_thickness = (tube_od - tube_id) / 2
 
         tube_material_k = self.specs.get(
             "tube_thermal_conductivity"
@@ -765,8 +767,8 @@ class ShellAndTubeHX(HeatExchanger):
         shell_velocity = getattr(self, "shell_velocity", None)
         tube_velocity = getattr(self, "tube_velocity", None)
 
-        shell_temperature = self.hot_in.temperature.to("C").value
-        tube_temperature = self.cold_in.temperature.to("C").value
+        shell_temperature = self._safe_float(self.hot_in.temperature.to("C"), "shell_temperature")
+        tube_temperature = self._safe_float(self.cold_in.temperature.to("C"), "tube_temperature")
 
         # ======================================================
         # FOULING FACTORS (Rf)
@@ -939,7 +941,7 @@ class ShellAndTubeHX(HeatExchanger):
     
         u_user = None
         if self.specs.get("U") is not None:
-            u_user = float(self.specs["U"].to("W/m2K").value)
+            u_user = self._safe_float(self.specs["U"].to("W/m2K"), "U")
             self._trace_step("THERMAL", "U user supplied", u_user)
         state = {
             "iterations": 0,
@@ -1594,8 +1596,8 @@ class ShellAndTubeHX(HeatExchanger):
 
         tube_limit_val = self.specs.get("tube_dp", self._dp_limit(hot))
         shell_limit_val = self.specs.get("shell_dp", self._dp_limit(cold))
-        tube_limit = float(tube_limit_val.to("Pa").value) if hasattr(tube_limit_val, "to") else float(tube_limit_val)
-        shell_limit = float(shell_limit_val.to("Pa").value) if hasattr(shell_limit_val, "to") else float(shell_limit_val)
+        tube_limit = self._safe_float(tube_limit_val.to("Pa"), "tube_dp_limit") if hasattr(tube_limit_val, "to") else self._safe_float(tube_limit_val, "tube_dp_limit")
+        shell_limit = self._safe_float(shell_limit_val.to("Pa"), "shell_dp_limit") if hasattr(shell_limit_val, "to") else self._safe_float(shell_limit_val, "shell_dp_limit")
 
         if tube_dp > tube_limit:
             warnings.append(f"Tube-side pressure drop {tube_dp:.1f} Pa exceeds limit {tube_limit:.1f} Pa")
@@ -1800,13 +1802,13 @@ class ShellAndTubeHX(HeatExchanger):
     
         h_ideal = float(data["h_shell"])
     
-        shell_id = geometry["shell_diameter"].value
+        shell_id = self._safe_float(geometry["shell_diameter"], "shell_diameter")
     
-        tube_od = geometry["tube_od"].value
+        tube_od = self._safe_float(geometry["tube_od"], "tube_od")
     
         tube_pitch = tube_od * 1.25
     
-        baffle_spacing = geometry["baffle_spacing"].value
+        baffle_spacing = self._safe_float(geometry["baffle_spacing"], "baffle_spacing")
     
         # ======================================================
         # APPROXIMATE BELL GEOMETRY


### PR DESCRIPTION
### Motivation
- Make the heat-exchanger solver numerically consistent and tolerant of floats, ints, numpy scalars and ProcessPI unit objects by removing ad-hoc `.value` usage and normalizing numeric inputs in one place. 
- Fix the immediate failure caused by mixed `.value` access in tube wall thickness calculation and prevent similar AttributeError crashes across HX internals.

### Description
- Added `_get_value(x, name)` as a static helper on `HeatExchanger` and three small wrappers `_safe_float`, `_safe_positive`, and `_safe_nonzero` for robust numeric extraction and basic safety. 
- Replaced direct `.value` and ad-hoc float conversions inside HX core paths to use the new helpers, including stream property extraction in `base.py`, duty/area/U helpers, HTC calculations, fouling/temperature handling, DP-limit conversions and bell/Kern geometry extraction. 
- Fixed the reported failing path by normalizing `tube_od` and `tube_id` before computing `tube_wall_thickness` in `shell_and_tube.py`. 
- Updated related modules to be unit/raw-float tolerant: `shell_and_tube.py`, `condenser.py`, `evaporator.py`, `double_pipe.py`, and `engine.py` so internal math operates only on plain numeric values.

### Testing
- Compiled the modified HX modules with `python -m py_compile` and the patched files `processpi/equipment/heatexchangers/*.py` compiled without syntax errors. (succeeded)
- Ran the test suite with `pytest -q`; collection failed due to unrelated environment/module issues (e.g., `ModuleNotFoundError: processpi.units.kinetic_viscosity`) that are outside the scope of this refactor, but the HX refactor files themselves import and compile correctly. (pytest collection failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eeca3ca4c8326bee1b31df7b9af73)