### PR TITLE
Modernize documentation: generated API inventory, heat-exchanger guides, CLI & navigation updates

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -2,6 +2,16 @@
 
 <div class="grid cards" markdown style="grid-template-columns: 1fr; gap: 1.5rem;">
 
+-   :material-book-open-page-variant: **v0.2.0.4 – Documentation Modernization (2026-06-06)**  
+    Documentation was audited against the implementation inventory generated from the `processpi/` package.  
+    **Highlights:**  
+    - Added generated API inventory pages for calculations, components, equipment, pipelines, streams, units, integration, and CLI  
+    - Added heat-exchanger engineering theory, sizing/rating workflows, condenser and reboiler-style examples, and pressure-drop guidance  
+    - Added component/property/stream documentation with units, validation notes, and mixture examples  
+    - Added CLI documentation aligned with the packaged `processpi` entry point  
+    - Added documentation audit report identifying renamed/missing top-level package names and remaining gaps  
+
+
 -   :material-rocket-launch: **v0.2.0 – Initial Public Release (2025-09-15)**  
     Welcome to the first public release of **ProcessPI**! This release introduces core pipeline, network, and calculation functionalities.  
     **Highlights:**  

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -51,3 +51,15 @@ This roadmap highlights upcoming features, improvements, and long-term vision.
     Community-driven libraries, templates for standard chemical processes, and verified industry case studies.
 
 </div>
+
+---
+
+## Documentation Alignment Priorities
+
+The current documentation now tracks the implemented package layout. Future documentation work should focus on:
+
+- Adding source docstrings with parameter units and correlation validity ranges for every public calculation class.
+- Migrating the static source inventory to `mkdocstrings` once documentation dependencies are standardized.
+- Adding tested examples for every heat-transfer, thermodynamics, mass-transfer, reaction-engineering, and pipeline calculation primitive.
+- Documenting component correlation sources and valid temperature/pressure ranges in a structured database.
+- Clarifying the distinction between preliminary heat-exchanger screening, rating, and vendor/mechanical design.

--- a/docs/api/__init__.md
+++ b/docs/api/__init__.md
@@ -1,0 +1,22 @@
+# `processpi.__init__` API
+
+## Overview
+
+ProcessPI module.
+
+### Design assumptions and limitations
+
+- Calculations generally expect engineering quantities in the units documented by the corresponding class constructor or module examples.
+- Unit wrapper objects expose `.to("unit")`; many higher-level models accept either ProcessPI unit objects or numeric SI values depending on context.
+- Validation is implemented in each class through `validate_inputs()` or constructor checks where available; invalid or missing inputs generally raise `ValueError`, `TypeError`, or `NotImplementedError`.
+- The API reference below is generated from source signatures and public names. If a class has limited source docstrings, consult its examples and calculation result keys for engineering interpretation.
+
+## Public modules
+
+### `processpi.__init__`
+
+**Source:** `processpi/__init__.py`
+
+**Purpose:** ProcessPI: Chemical & Process Engineering Tools ============================================== A Python library for process engineers to: - Perform fluid mechanics and hydraulic calculations - Simulate and visualize pipeline networks - Manage chemical and physical properties - Handle engineering units and conversions
+
+No public classes or functions discovered in this module.

--- a/docs/api/calculations.md
+++ b/docs/api/calculations.md
@@ -1,0 +1,1538 @@
+# `processpi.calculations` API
+
+## Overview
+
+Calculation framework module.
+
+### Design assumptions and limitations
+
+- Calculations generally expect engineering quantities in the units documented by the corresponding class constructor or module examples.
+- Unit wrapper objects expose `.to("unit")`; many higher-level models accept either ProcessPI unit objects or numeric SI values depending on context.
+- Validation is implemented in each class through `validate_inputs()` or constructor checks where available; invalid or missing inputs generally raise `ValueError`, `TypeError`, or `NotImplementedError`.
+- The API reference below is generated from source signatures and public names. If a class has limited source docstrings, consult its examples and calculation result keys for engineering interpretation.
+
+## Public modules
+
+### `processpi.calculations.__init__`
+
+**Source:** `processpi/calculations/__init__.py`
+
+**Purpose:** ProcessPI Calculations Module ============================= This module provides core calculation classes and dynamically loads all available calculation submodules under `processpi.calculations`. Example: import processpi.calculations as calc engine = calc.CalculationEngine() water_dp = calc.fluids.PressureDropDarcy(...)
+
+No public classes or functions discovered in this module.
+
+### `processpi.calculations.base`
+
+**Source:** `processpi/calculations/base.py`
+
+**Purpose:** Calculation framework module.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `CalculationBase` | `CalculationBase(self, **kwargs)` | Abstract base class for all calculation modules in the processpi library. This class defines a standard interface and common utility methods for all calculation classes, ensuring they have a consistent structure for input validation, calculation execution, and result handling. All specific calculation classes (e.g., `PressureDropDarcy`, `ReynoldsNumber`) must inherit from this class. | `validate_inputs()`, `calculate()`, `get_inputs()`, `to_dict()` |
+
+##### `CalculationBase`
+
+Abstract base class for all calculation modules in the processpi library. This class defines a standard interface and common utility methods for all calculation classes, ensuring they have a consistent structure for input validation, calculation execution, and result handling. All specific calculation classes (e.g., `PressureDropDarcy`, `ReynoldsNumber`) must inherit from this class.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | Abstract method to validate the inputs. Subclasses must implement this method to check for the presence and validity of required inputs. It should raise a `ValueError` if any input is missing or invalid. |
+| `calculate` | `calculate(self)` | Abstract method to perform the calculation. Subclasses must implement this method to execute the core calculation logic. The method should return the results, typically as a dictionary or a specific unit object. |
+| `get_inputs` | `get_inputs(self)` | Returns the original inputs provided during initialization. Returns: dict: A dictionary of the input parameters. |
+| `to_dict` | `to_dict(self)` | Performs the calculation and returns a dictionary with both inputs and results. This method combines the inputs and the output of the `calculate()` method into a single, comprehensive dictionary. Returns: dict: A dictionary containing two keys: "inputs" and "results". |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.engine`
+
+**Source:** `processpi/calculations/engine.py`
+
+**Purpose:** This module acts as the central engine for performing calculations in the ProcessPI library. The `CalculationEngine` class serves as a central hub, providing a registry for all available calculation classes. This design allows users to execute calculations by name without needing to directly import or instantiate each class.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `CalculationEngine` | `CalculationEngine(self)` | The central hub for all ProcessPI calculations. The engine maintains a registry of calculation classes and provides a single, consistent method to execute any registered calculation by its name. This decouples the calling code from the specific implementation details of each calculation. | `register_calculation()`, `calculate()` |
+
+##### `CalculationEngine`
+
+The central hub for all ProcessPI calculations. The engine maintains a registry of calculation classes and provides a single, consistent method to execute any registered calculation by its name. This decouples the calling code from the specific implementation details of each calculation.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `register_calculation` | `register_calculation(self, name: str, calc_class: Type)` | Dynamically registers a new calculation class with the engine. This method allows for extending the engine's capabilities at runtime without modifying the source code. Args: name (str): The string name to be used for the calculation. calc_class (Type): The calculation class to register. |
+| `calculate` | `calculate(self, name: str, **kwargs)` | Executes a calculation by its registered name. The method looks up the calculation class in the registry, instantiates it with the provided keyword arguments, and then runs its `calculate` method. Args: name (str): The name of the calculation to execute. **kwargs: Arbitrary keyword arguments to be passed as inputs to the calculation class. Returns: Any: The result of the calculation, as returned by the `calculate` method of the specific class. Raises: ValueError: If the specified calculation name is not found in the registry. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.fluids.__init__`
+
+**Source:** `processpi/calculations/fluids/__init__.py`
+
+**Purpose:** ProcessPI Fluid Mechanics Calculations ====================================== This module loads all calculation classes for fluid mechanics automatically. Available calculations: - PressureDropDarcy - PressureDropFanning - PumpPower - ReynoldsNumber - OptimumPipeDiameter - FluidVelocity - ColebrookWhite - PressureDropHazenWilliams - TypeOfFlow
+
+No public classes or functions discovered in this module.
+
+### `processpi.calculations.fluids.flow_type`
+
+**Source:** `processpi/calculations/fluids/flow_type.py`
+
+**Purpose:** Fluid-mechanics calculation primitive for velocity, Reynolds number, friction, pressure drop, pump power, or flow classification.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `TypeOfFlow` | `TypeOfFlow(...)` | A class to determine the type of fluid flow based on the Reynolds number. This class serves as a calculation engine for classifying flow regimes as Laminar, Transitional, or Turbulent according to standard engineering criteria. It inherits from `CalculationBase` to ensure a standardized input/output structure. **Flow Regime Criteria:** * Laminar Flow: Occurs when the fluid moves in smooth, parallel layers, with little to no mixing. This regime is defined by a Reynolds number (Re) less than 2000. * Transitional Flow: An unstable regime where the flow can fluctuate between laminar and turbulent characteristics. It is defined by a Reynolds number between 2000 and 4000 (inclusive). * Turbulent Flow: Characterized by chaotic, unpredictable fluid motion with significant mixing. This regime is defined by a Reynolds number greater than 4000. **Inputs:** * `reynolds_number` (Re): A dimensionless quantity representing the ratio of inertial forces to viscous forces. **Output:** * A `StringUnit` containing the determined flow type ("Laminar", "Transitional", or "Turbulent"). | `validate_inputs()`, `calculate()` |
+
+##### `TypeOfFlow`
+
+A class to determine the type of fluid flow based on the Reynolds number. This class serves as a calculation engine for classifying flow regimes as Laminar, Transitional, or Turbulent according to standard engineering criteria. It inherits from `CalculationBase` to ensure a standardized input/output structure. **Flow Regime Criteria:** * Laminar Flow: Occurs when the fluid moves in smooth, parallel layers, with little to no mixing. This regime is defined by a Reynolds number (Re) less than 2000. * Transitional Flow: An unstable regime where the flow can fluctuate between laminar and turbulent characteristics. It is defined by a Reynolds number between 2000 and 4000 (inclusive). * Turbulent Flow: Characterized by chaotic, unpredictable fluid motion with significant mixing. This regime is defined by a Reynolds number greater than 4000. **Inputs:** * `reynolds_number` (Re): A dimensionless quantity representing the ratio of inertial forces to viscous forces. **Output:** * A `StringUnit` containing the determined flow type ("Laminar", "Transitional", or "Turbulent").
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | Validates the required inputs for the calculation. Ensures that the 'reynolds_number' key is present in the inputs dictionary. Raises a ValueError if the key is missing. |
+| `calculate` | `calculate(self)` | Performs the calculation to determine the flow type. Retrieves the Reynolds number from the inputs and applies the flow regime criteria to classify the flow. Returns: StringUnit: An object containing the flow type as a string. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.fluids.friction_factor_colebrookwhite`
+
+**Source:** `processpi/calculations/fluids/friction_factor_colebrookwhite.py`
+
+**Purpose:** Fluid-mechanics calculation primitive for velocity, Reynolds number, friction, pressure drop, pump power, or flow classification.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ColebrookWhite` | `ColebrookWhite(...)` | A class to calculate the Darcy friction factor using the Colebrook–White equation. The Colebrook-White equation is an empirical formula used to determine the Darcy friction factor (f) for fluid flow in pipes, particularly for turbulent flow. Because the equation is implicit, the friction factor must be solved for iteratively. **Formula (Implicit):** $ rac{1}{\sqrt{f}} = -2.0 \cdot \log_{10} \left( rac{\epsilon/D}{3.7} + rac{2.51}{Re \cdot \sqrt{f}} ight) $ **Inputs:** * `reynolds_number` (Re): A dimensionless quantity. * `diameter` (D): The internal diameter of the pipe. * `roughness` (ε): The absolute roughness of the pipe surface. **Output:** * A `Dimensionless` object containing the calculated friction factor (f). | `validate_inputs()`, `calculate()` |
+
+##### `ColebrookWhite`
+
+A class to calculate the Darcy friction factor using the Colebrook–White equation. The Colebrook-White equation is an empirical formula used to determine the Darcy friction factor (f) for fluid flow in pipes, particularly for turbulent flow. Because the equation is implicit, the friction factor must be solved for iteratively. **Formula (Implicit):** $ rac{1}{\sqrt{f}} = -2.0 \cdot \log_{10} \left( rac{\epsilon/D}{3.7} + rac{2.51}{Re \cdot \sqrt{f}} ight) $ **Inputs:** * `reynolds_number` (Re): A dimensionless quantity. * `diameter` (D): The internal diameter of the pipe. * `roughness` (ε): The absolute roughness of the pipe surface. **Output:** * A `Dimensionless` object containing the calculated friction factor (f).
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | Validates the required inputs for the calculation. Ensures that 'reynolds_number', 'diameter', and 'roughness' are present in the inputs dictionary. Raises a ValueError if any key is missing. |
+| `calculate` | `calculate(self)` | Calculates the Darcy friction factor. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.fluids.optimium_pipe_dia`
+
+**Source:** `processpi/calculations/fluids/optimium_pipe_dia.py`
+
+**Purpose:** Fluid-mechanics calculation primitive for velocity, Reynolds number, friction, pressure drop, pump power, or flow classification.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `OptimumPipeDiameter` | `OptimumPipeDiameter(...)` | A class to calculate the optimum pipe diameter using an empirical formula. This class provides a method for calculating the most efficient pipe diameter for a given set of fluid properties and flow rate, based on an empirical correlation. The calculated optimum diameter is then mapped to the nearest available standard pipe size. **Empirical Formula:** $D_{opt} = 293 \cdot Q_{mass}^{0.53} \cdot ho^{-0.37}$ Where: * $D_{opt}$ = Optimum diameter [mm] * $Q_{mass}$ = Mass flow rate [kg/s] * $ ho$ = Fluid density [kg/m³] **Inputs:** * `flow_rate` (Q): The volumetric flow rate of the fluid. * `density` ($ ho$): The density of the fluid. **Output:** * The nearest standard pipe diameter as a `Diameter` object in millimeters. | `validate_inputs()`, `calculate()` |
+
+##### `OptimumPipeDiameter`
+
+A class to calculate the optimum pipe diameter using an empirical formula. This class provides a method for calculating the most efficient pipe diameter for a given set of fluid properties and flow rate, based on an empirical correlation. The calculated optimum diameter is then mapped to the nearest available standard pipe size. **Empirical Formula:** $D_{opt} = 293 \cdot Q_{mass}^{0.53} \cdot ho^{-0.37}$ Where: * $D_{opt}$ = Optimum diameter [mm] * $Q_{mass}$ = Mass flow rate [kg/s] * $ ho$ = Fluid density [kg/m³] **Inputs:** * `flow_rate` (Q): The volumetric flow rate of the fluid. * `density` ($ ho$): The density of the fluid. **Output:** * The nearest standard pipe diameter as a `Diameter` object in millimeters.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | Validates the required inputs for the calculation. This method ensures that the 'flow_rate' and 'density' keys are present in the inputs dictionary, raising a ValueError if any required input is missing. |
+| `calculate` | `calculate(self)` | Performs the calculation to find the optimum and nearest standard pipe diameter. The method first calculates the mass flow rate from the volumetric flow rate and density. It then applies the empirical formula to find the optimum diameter. Finally, it uses an external utility function to find the closest standard pipe size and returns it. Returns: Diameter: The nearest standard pipe diameter. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.fluids.pressure_drop_darcy`
+
+**Source:** `processpi/calculations/fluids/pressure_drop_darcy.py`
+
+**Purpose:** Fluid-mechanics calculation primitive for velocity, Reynolds number, friction, pressure drop, pump power, or flow classification.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `PressureDropDarcy` | `PressureDropDarcy(...)` | A class to calculate the pressure drop in a pipe using the Darcy–Weisbach equation. This formula is a widely used tool in fluid dynamics to calculate the loss of pressure due to friction along a given length of pipe. It is applicable for both laminar and turbulent flow regimes. **Formula:** $ \Delta P = f \cdot rac{L}{D} \cdot rac{ ho \cdot v^2}{2} $ Where: * $ \Delta P $ = Pressure drop [Pa] * $ f $ = Darcy friction factor [dimensionless] * $ L $ = Pipe length [m] * $ D $ = Pipe diameter [m] * $ ho $ = Fluid density [kg/m³] * $ v $ = Fluid velocity [m/s] **Inputs:** * `friction_factor`: The friction factor of the pipe. * `length`: The length of the pipe. * `diameter`: The internal diameter of the pipe. * `density`: The density of the fluid. * `velocity`: The velocity of the fluid. **Output:** * A `Pressure` object containing the calculated pressure drop in Pascals (Pa). | `validate_inputs()`, `calculate()` |
+
+##### `PressureDropDarcy`
+
+A class to calculate the pressure drop in a pipe using the Darcy–Weisbach equation. This formula is a widely used tool in fluid dynamics to calculate the loss of pressure due to friction along a given length of pipe. It is applicable for both laminar and turbulent flow regimes. **Formula:** $ \Delta P = f \cdot rac{L}{D} \cdot rac{ ho \cdot v^2}{2} $ Where: * $ \Delta P $ = Pressure drop [Pa] * $ f $ = Darcy friction factor [dimensionless] * $ L $ = Pipe length [m] * $ D $ = Pipe diameter [m] * $ ho $ = Fluid density [kg/m³] * $ v $ = Fluid velocity [m/s] **Inputs:** * `friction_factor`: The friction factor of the pipe. * `length`: The length of the pipe. * `diameter`: The internal diameter of the pipe. * `density`: The density of the fluid. * `velocity`: The velocity of the fluid. **Output:** * A `Pressure` object containing the calculated pressure drop in Pascals (Pa).
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | Validates the required inputs for the calculation. This method checks for the presence of all necessary keys in the inputs dictionary and raises a ValueError if any are missing. |
+| `calculate` | `calculate(self)` | Performs the pressure drop calculation using the Darcy–Weisbach equation. Retrieves all required input values and applies the formula to compute the pressure drop. The result is returned as a `Pressure` object. Returns: Pressure: The calculated pressure drop in Pascals. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.fluids.pressure_drop_fanning`
+
+**Source:** `processpi/calculations/fluids/pressure_drop_fanning.py`
+
+**Purpose:** Fluid-mechanics calculation primitive for velocity, Reynolds number, friction, pressure drop, pump power, or flow classification.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `PressureDropFanning` | `PressureDropFanning(...)` | A class to calculate the pressure drop in a pipe using the Fanning equation. The Fanning friction factor is a dimensionless number that relates the shear stress at the pipe wall to the kinetic energy of the fluid. The Fanning equation is widely used in chemical and process engineering for pressure drop calculations. **Formula:** $ \Delta P = 4 \cdot f_F \cdot rac{L}{D} \cdot rac{ ho \cdot v^2}{2} $ Where: * $ \Delta P $ = Pressure drop [Pa] * $ f_F $ = Fanning friction factor [dimensionless] * $ L $ = Pipe length [m] * $ D $ = Pipe diameter [m] * $ ho $ = Fluid density [kg/m³] * $ v $ = Fluid velocity [m/s] **Inputs:** * `friction_factor`: The Fanning friction factor of the pipe. * `length`: The length of the pipe. * `diameter`: The internal diameter of the pipe. * `density`: The density of the fluid. * `velocity`: The velocity of the fluid. **Output:** * A `Pressure` object containing the calculated pressure drop in Pascals (Pa). | `validate_inputs()`, `calculate()` |
+
+##### `PressureDropFanning`
+
+A class to calculate the pressure drop in a pipe using the Fanning equation. The Fanning friction factor is a dimensionless number that relates the shear stress at the pipe wall to the kinetic energy of the fluid. The Fanning equation is widely used in chemical and process engineering for pressure drop calculations. **Formula:** $ \Delta P = 4 \cdot f_F \cdot rac{L}{D} \cdot rac{ ho \cdot v^2}{2} $ Where: * $ \Delta P $ = Pressure drop [Pa] * $ f_F $ = Fanning friction factor [dimensionless] * $ L $ = Pipe length [m] * $ D $ = Pipe diameter [m] * $ ho $ = Fluid density [kg/m³] * $ v $ = Fluid velocity [m/s] **Inputs:** * `friction_factor`: The Fanning friction factor of the pipe. * `length`: The length of the pipe. * `diameter`: The internal diameter of the pipe. * `density`: The density of the fluid. * `velocity`: The velocity of the fluid. **Output:** * A `Pressure` object containing the calculated pressure drop in Pascals (Pa).
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | Validates the required inputs for the calculation. This method ensures all necessary keys are present in the inputs dictionary, raising a ValueError if any are missing. |
+| `calculate` | `calculate(self)` | Performs the pressure drop calculation using the Fanning equation. Retrieves all required input values and applies the formula to compute the pressure drop. The result is returned as a `Pressure` object. Returns: Pressure: The calculated pressure drop in Pascals. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.fluids.pressure_drop_hazen_williams`
+
+**Source:** `processpi/calculations/fluids/pressure_drop_hazen_williams.py`
+
+**Purpose:** Fluid-mechanics calculation primitive for velocity, Reynolds number, friction, pressure drop, pump power, or flow classification.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `PressureDropHazenWilliams` | `PressureDropHazenWilliams(...)` | A class to calculate the pressure drop in a pipe using the Hazen–Williams equation. The Hazen–Williams equation is an empirical formula for calculating head loss in a pipe due to friction. It is primarily used for water systems and is simpler than the Darcy-Weisbach equation as it does not require an iterative solution for the friction factor. **Formula (SI units):** $ h_f = 10.67 \cdot L \cdot Q^{1.852} / (C^{1.852} \cdot D^{4.87}) $ **Where:** * $ h_f $ = head loss [m] * $ L $ = pipe length [m] * $ Q $ = volumetric flow rate [m³/s] * $ C $ = Hazen-Williams roughness coefficient [dimensionless] * $ D $ = pipe diameter [m] The pressure drop ($\Delta P$) is then calculated from the head loss ($h_f$) using the following relationship: $ \Delta P = \rho \cdot g \cdot h_f $ **Inputs:** * `length`: The length of the pipe. * `flow_rate`: The volumetric flow rate of the fluid. * `coefficient`: The Hazen-Williams roughness coefficient. * `diameter`: The internal diameter of the pipe. * `density`: The density of the fluid. **Output:** * A `Pressure` object containing the calculated pressure drop in Pascals (Pa). | `validate_inputs()`, `calculate()` |
+
+##### `PressureDropHazenWilliams`
+
+A class to calculate the pressure drop in a pipe using the Hazen–Williams equation. The Hazen–Williams equation is an empirical formula for calculating head loss in a pipe due to friction. It is primarily used for water systems and is simpler than the Darcy-Weisbach equation as it does not require an iterative solution for the friction factor. **Formula (SI units):** $ h_f = 10.67 \cdot L \cdot Q^{1.852} / (C^{1.852} \cdot D^{4.87}) $ **Where:** * $ h_f $ = head loss [m] * $ L $ = pipe length [m] * $ Q $ = volumetric flow rate [m³/s] * $ C $ = Hazen-Williams roughness coefficient [dimensionless] * $ D $ = pipe diameter [m] The pressure drop ($\Delta P$) is then calculated from the head loss ($h_f$) using the following relationship: $ \Delta P = \rho \cdot g \cdot h_f $ **Inputs:** * `length`: The length of the pipe. * `flow_rate`: The volumetric flow rate of the fluid. * `coefficient`: The Hazen-Williams roughness coefficient. * `diameter`: The internal diameter of the pipe. * `density`: The density of the fluid. **Output:** * A `Pressure` object containing the calculated pressure drop in Pascals (Pa).
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | Validates the required inputs for the calculation. This method checks for the presence of all necessary keys in the inputs dictionary and raises a ValueError if any are missing. |
+| `calculate` | `calculate(self)` | Performs the pressure drop calculation using the Hazen-Williams equation. The method first computes the head loss using the Hazen-Williams formula and then converts the head loss to pressure drop. The result is returned as a `Pressure` object. Returns: Pressure: The calculated pressure drop in Pascals. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.fluids.pump_power`
+
+**Source:** `processpi/calculations/fluids/pump_power.py`
+
+**Purpose:** Fluid-mechanics calculation primitive for velocity, Reynolds number, friction, pressure drop, pump power, or flow classification.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `PumpPower` | `PumpPower(...)` | A class to calculate the required pump power for a fluid system. This class computes both the hydraulic power (the power imparted to the fluid) and the shaft power (the power required at the pump's shaft, accounting for efficiency). The calculation is based on the fluid's flow rate, head, density, and the pump's mechanical efficiency. **Formulas:** * Hydraulic Power ($P_{hydraulic}$) = $ ho \cdot g \cdot Q \cdot H $ * Shaft Power ($P_{shaft}$) = $ P_{hydraulic} / \eta $ Where: * $P_{hydraulic}$ = Hydraulic (water) power [W] * $P_{shaft}$ = Shaft power [W] * $ ho $ = Fluid density [kg/m³] * $ g $ = Acceleration due to gravity (9.81 m/s²) * $ Q $ = Volumetric flow rate [m³/s] * $ H $ = Total dynamic head [m] * $ \eta $ = Pump efficiency [decimal] **Inputs:** * `flow_rate` (Q): The volumetric flow rate. * `head` (H): The total dynamic head. * `density` ($ ho$): The fluid's density. * `efficiency` ($\eta$): The pump's efficiency as a decimal (0 to 1). **Outputs:** * A dictionary containing two power values: * "hydraulic_power_W": The calculated hydraulic power in Watts. * "shaft_power_W": The calculated shaft power in Watts. | `validate_inputs()`, `calculate()` |
+
+##### `PumpPower`
+
+A class to calculate the required pump power for a fluid system. This class computes both the hydraulic power (the power imparted to the fluid) and the shaft power (the power required at the pump's shaft, accounting for efficiency). The calculation is based on the fluid's flow rate, head, density, and the pump's mechanical efficiency. **Formulas:** * Hydraulic Power ($P_{hydraulic}$) = $ ho \cdot g \cdot Q \cdot H $ * Shaft Power ($P_{shaft}$) = $ P_{hydraulic} / \eta $ Where: * $P_{hydraulic}$ = Hydraulic (water) power [W] * $P_{shaft}$ = Shaft power [W] * $ ho $ = Fluid density [kg/m³] * $ g $ = Acceleration due to gravity (9.81 m/s²) * $ Q $ = Volumetric flow rate [m³/s] * $ H $ = Total dynamic head [m] * $ \eta $ = Pump efficiency [decimal] **Inputs:** * `flow_rate` (Q): The volumetric flow rate. * `head` (H): The total dynamic head. * `density` ($ ho$): The fluid's density. * `efficiency` ($\eta$): The pump's efficiency as a decimal (0 to 1). **Outputs:** * A dictionary containing two power values: * "hydraulic_power_W": The calculated hydraulic power in Watts. * "shaft_power_W": The calculated shaft power in Watts.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | Validates the required inputs for the calculation. This method checks for the presence of all necessary keys in the inputs dictionary and ensures that the efficiency is a valid value between 0 and 1. |
+| `calculate` | `calculate(self)` | Performs the pump power calculation. The method first calculates the hydraulic power and then the shaft power, accounting for the pump's efficiency. Returns: dict: A dictionary with the calculated hydraulic and shaft power. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.fluids.reynolds_number`
+
+**Source:** `processpi/calculations/fluids/reynolds_number.py`
+
+**Purpose:** Fluid-mechanics calculation primitive for velocity, Reynolds number, friction, pressure drop, pump power, or flow classification.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ReynoldsNumber` | `ReynoldsNumber(...)` | A class to calculate the Reynolds number for fluid flow in a pipe. The Reynolds number (Re) is a dimensionless quantity that helps predict the flow patterns in a fluid. It represents the ratio of inertial forces to viscous forces. A low Reynolds number indicates laminar flow, while a high Reynolds number indicates turbulent flow. **Formulas:** * Using dynamic viscosity ($\mu$): $ Re = rac{ ho \cdot v \cdot D}{\mu} $ * Using kinematic viscosity ($ u$): $ Re = rac{v \cdot D}{ u} $ **Where:** * $ ho $ = Fluid density [kg/m³] * $ v $ = Fluid velocity [m/s] * $ D $ = Pipe diameter [m] * $ \mu $ = Dynamic viscosity [Pa·s] * $ u $ = Kinematic viscosity [m²/s] **Inputs:** * `density`: The fluid's density. * `velocity`: The fluid's velocity. * `diameter`: The internal diameter of the pipe. * `viscosity`: The fluid's viscosity (can be dynamic or kinematic). **Output:** * A `Dimensionless` object containing the calculated Reynolds number. | `validate_inputs()`, `calculate()` |
+
+##### `ReynoldsNumber`
+
+A class to calculate the Reynolds number for fluid flow in a pipe. The Reynolds number (Re) is a dimensionless quantity that helps predict the flow patterns in a fluid. It represents the ratio of inertial forces to viscous forces. A low Reynolds number indicates laminar flow, while a high Reynolds number indicates turbulent flow. **Formulas:** * Using dynamic viscosity ($\mu$): $ Re = rac{ ho \cdot v \cdot D}{\mu} $ * Using kinematic viscosity ($ u$): $ Re = rac{v \cdot D}{ u} $ **Where:** * $ ho $ = Fluid density [kg/m³] * $ v $ = Fluid velocity [m/s] * $ D $ = Pipe diameter [m] * $ \mu $ = Dynamic viscosity [Pa·s] * $ u $ = Kinematic viscosity [m²/s] **Inputs:** * `density`: The fluid's density. * `velocity`: The fluid's velocity. * `diameter`: The internal diameter of the pipe. * `viscosity`: The fluid's viscosity (can be dynamic or kinematic). **Output:** * A `Dimensionless` object containing the calculated Reynolds number.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | Validates the required inputs for the calculation. This method checks for the presence of all necessary keys in the inputs dictionary, raising a ValueError if any are missing. |
+| `calculate` | `calculate(self)` | Performs the Reynolds number calculation based on the type of viscosity provided. The method first retrieves all required input values. It then determines whether the input viscosity is dynamic or kinematic and applies the appropriate formula to calculate the Reynolds number. Returns: Dimensionless: The calculated Reynolds number. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.fluids.velocity`
+
+**Source:** `processpi/calculations/fluids/velocity.py`
+
+**Purpose:** Fluid-mechanics calculation primitive for velocity, Reynolds number, friction, pressure drop, pump power, or flow classification.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `FluidVelocity` | `FluidVelocity(...)` | A class to calculate the average fluid velocity in a circular pipe. This calculation is fundamental in fluid dynamics and is used to determine how quickly a fluid is moving through a pipe based on its volumetric flow rate and the pipe's cross-sectional area. **Formula:** $ v = rac{Q}{A} = rac{4 \cdot Q}{\pi \cdot D^2} $ Where: * $ v $ = Fluid velocity [m/s] * $ Q $ = Volumetric flow rate [m³/s] * $ A $ = Cross-sectional area [m²] * $ D $ = Pipe diameter [m] **Inputs:** * `volumetric_flow_rate` (Q): The rate at which the fluid is flowing. * `diameter` (D): The internal diameter of the pipe. **Output:** * A `Velocity` object containing the calculated fluid velocity in meters per second (m/s). | `validate_inputs()`, `calculate()` |
+
+##### `FluidVelocity`
+
+A class to calculate the average fluid velocity in a circular pipe. This calculation is fundamental in fluid dynamics and is used to determine how quickly a fluid is moving through a pipe based on its volumetric flow rate and the pipe's cross-sectional area. **Formula:** $ v = rac{Q}{A} = rac{4 \cdot Q}{\pi \cdot D^2} $ Where: * $ v $ = Fluid velocity [m/s] * $ Q $ = Volumetric flow rate [m³/s] * $ A $ = Cross-sectional area [m²] * $ D $ = Pipe diameter [m] **Inputs:** * `volumetric_flow_rate` (Q): The rate at which the fluid is flowing. * `diameter` (D): The internal diameter of the pipe. **Output:** * A `Velocity` object containing the calculated fluid velocity in meters per second (m/s).
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | Validates the required inputs for the calculation. This method checks for the presence of all necessary keys in the inputs dictionary, raising a ValueError if any are missing. |
+| `calculate` | `calculate(self)` | Performs the fluid velocity calculation. The method retrieves the volumetric flow rate and pipe diameter, calculates the cross-sectional area of the pipe, and then applies the formula to determine the fluid velocity. Returns: Velocity: The calculated fluid velocity in m/s. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.__init__`
+
+**Source:** `processpi/calculations/heat_transfer/__init__.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+No public classes or functions discovered in this module.
+
+### `processpi.calculations.heat_transfer.biot`
+
+**Source:** `processpi/calculations/heat_transfer/biot.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `BiotNumber` | `BiotNumber(...)` | Biot number. **Formula:** Bi = h * Lc / k | `validate_inputs()`, `calculate()` |
+
+##### `BiotNumber`
+
+Biot number. **Formula:** Bi = h * Lc / k
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.boiling_chen`
+
+**Source:** `processpi/calculations/heat_transfer/boiling_chen.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ChenBoiling` | `ChenBoiling(...)` | Chen correlation for **flow boiling heat transfer**. **Formula (simplified):** h_total = S * h_pool + F * h_conv **Where:** * h_total = overall heat transfer coefficient [W/m²·K] * h_pool = pool boiling coefficient (from Rohsenow or others) * h_conv = forced convection coefficient (from Dittus-Boelter or similar) * S = suppression factor (empirical, function of Re, Boiling number, etc.) * F = enhancement factor (empirical, function of flow parameters) **Inputs:** * h_pool * h_conv * S * F **Output:** * HeatTransferCoefficient [W/m²·K] | `validate_inputs()`, `calculate()` |
+
+##### `ChenBoiling`
+
+Chen correlation for **flow boiling heat transfer**. **Formula (simplified):** h_total = S * h_pool + F * h_conv **Where:** * h_total = overall heat transfer coefficient [W/m²·K] * h_pool = pool boiling coefficient (from Rohsenow or others) * h_conv = forced convection coefficient (from Dittus-Boelter or similar) * S = suppression factor (empirical, function of Re, Boiling number, etc.) * F = enhancement factor (empirical, function of flow parameters) **Inputs:** * h_pool * h_conv * S * F **Output:** * HeatTransferCoefficient [W/m²·K]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.combined_modes`
+
+**Source:** `processpi/calculations/heat_transfer/combined_modes.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ConductionConvectionCombined` | `ConductionConvectionCombined(...)` | Heat transfer with conduction resistance + convection resistance. **Formula:** Q = (Ts - T∞) / (R_cond + R_conv) Where: R_cond = dx / (k * A) R_conv = 1 / (h * A) **Inputs:** * `thickness`: Conduction thickness [m] * `k`: Thermal conductivity [W/m·K] * `h`: Convective coefficient [W/m²·K] * `area`: Heat transfer area [m²] * `T_surface`: Surface temperature [K] * `T_fluid`: Bulk fluid temperature [K] **Output:** * HeatFlow [W] | `validate_inputs()`, `calculate()` |
+
+##### `ConductionConvectionCombined`
+
+Heat transfer with conduction resistance + convection resistance. **Formula:** Q = (Ts - T∞) / (R_cond + R_conv) Where: R_cond = dx / (k * A) R_conv = 1 / (h * A) **Inputs:** * `thickness`: Conduction thickness [m] * `k`: Thermal conductivity [W/m·K] * `h`: Convective coefficient [W/m²·K] * `area`: Heat transfer area [m²] * `T_surface`: Surface temperature [K] * `T_fluid`: Bulk fluid temperature [K] **Output:** * HeatFlow [W]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.condensation`
+
+**Source:** `processpi/calculations/heat_transfer/condensation.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `CondensingVapourFilm` | `CondensingVapourFilm(...)` | Heat transfer from condensing vapours on a vertical plate (Nusselt’s theory). **Formula:** h = 0.943 * [ (ρ_l * (ρ_l - ρ_v) * g * h_fg * k_l^3) / (μ_l * L * ΔT) ]^(1/4) Then: Q = h * A * ΔT **Inputs:** * `rho_l`: Liquid density [kg/m³] * `rho_v`: Vapour density [kg/m³] * `g`: Gravity [m/s²] * `h_fg`: Latent heat [J/kg] * `k_l`: Liquid thermal conductivity [W/m·K] * `mu_l`: Liquid viscosity [Pa·s] * `L`: Plate length [m] * `A`: Area [m²] * `deltaT`: Temperature difference [K] | `validate_inputs()`, `calculate()` |
+
+##### `CondensingVapourFilm`
+
+Heat transfer from condensing vapours on a vertical plate (Nusselt’s theory). **Formula:** h = 0.943 * [ (ρ_l * (ρ_l - ρ_v) * g * h_fg * k_l^3) / (μ_l * L * ΔT) ]^(1/4) Then: Q = h * A * ΔT **Inputs:** * `rho_l`: Liquid density [kg/m³] * `rho_v`: Vapour density [kg/m³] * `g`: Gravity [m/s²] * `h_fg`: Latent heat [J/kg] * `k_l`: Liquid thermal conductivity [W/m·K] * `mu_l`: Liquid viscosity [Pa·s] * `L`: Plate length [m] * `A`: Area [m²] * `deltaT`: Temperature difference [K]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.condensation_dropwise`
+
+**Source:** `processpi/calculations/heat_transfer/condensation_dropwise.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `DropwiseCondensation` | `DropwiseCondensation(...)` | Empirical correlations for **dropwise condensation**. Dropwise condensation has much higher heat transfer coefficients than filmwise (often 5–10× larger). **Simple empirical model:** h_dw = C * h_fw **Where:** * h_dw = dropwise condensation heat transfer coefficient [W/m²·K] * h_fw = filmwise condensation coefficient [W/m²·K] (from Nusselt theory) * C = enhancement factor (typically 5–10, depending on surface treatment) **Inputs:** * h_fw – filmwise coefficient [W/m²·K] * C – enhancement factor (default: 7) **Output:** * HeatTransferCoefficient [W/m²·K] | `validate_inputs()`, `calculate()` |
+
+##### `DropwiseCondensation`
+
+Empirical correlations for **dropwise condensation**. Dropwise condensation has much higher heat transfer coefficients than filmwise (often 5–10× larger). **Simple empirical model:** h_dw = C * h_fw **Where:** * h_dw = dropwise condensation heat transfer coefficient [W/m²·K] * h_fw = filmwise condensation coefficient [W/m²·K] (from Nusselt theory) * C = enhancement factor (typically 5–10, depending on surface treatment) **Inputs:** * h_fw – filmwise coefficient [W/m²·K] * C – enhancement factor (default: 7) **Output:** * HeatTransferCoefficient [W/m²·K]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.condensation_nusselt`
+
+**Source:** `processpi/calculations/heat_transfer/condensation_nusselt.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `NusseltCondensation` | `NusseltCondensation(...)` | Filmwise condensation heat transfer coefficient based on **Nusselt’s theory** (laminar film condensation on vertical surface). **Formula (vertical plate/tube):** h = 0.943 * [ (k_l^3 * rho_l^2 * g * h_fg) / (mu_l * L * ΔT) ]^(1/4) **Where:** * h = average heat transfer coefficient [W/m²·K] * k_l = liquid thermal conductivity [W/m·K] * rho_l = liquid density [kg/m³] * g = gravity [m/s²] * h_fg = latent heat of vaporization [J/kg] * mu_l = liquid viscosity [Pa·s] * L = characteristic length (plate height or tube length) [m] * ΔT = (T_wall – T_sat) [K] **Inputs:** * k_l * rho_l * g * h_fg * mu_l * L * dT **Output:** * HeatTransferCoefficient [W/m²·K] | `validate_inputs()`, `calculate()` |
+
+##### `NusseltCondensation`
+
+Filmwise condensation heat transfer coefficient based on **Nusselt’s theory** (laminar film condensation on vertical surface). **Formula (vertical plate/tube):** h = 0.943 * [ (k_l^3 * rho_l^2 * g * h_fg) / (mu_l * L * ΔT) ]^(1/4) **Where:** * h = average heat transfer coefficient [W/m²·K] * k_l = liquid thermal conductivity [W/m·K] * rho_l = liquid density [kg/m³] * g = gravity [m/s²] * h_fg = latent heat of vaporization [J/kg] * mu_l = liquid viscosity [Pa·s] * L = characteristic length (plate height or tube length) [m] * ΔT = (T_wall – T_sat) [K] **Inputs:** * k_l * rho_l * g * h_fg * mu_l * L * dT **Output:** * HeatTransferCoefficient [W/m²·K]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.conduction_heat_loss`
+
+**Source:** `processpi/calculations/heat_transfer/conduction_heat_loss.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ConductionHeatLoss` | `ConductionHeatLoss(...)` | Calculate steady-state conduction heat loss through a wall. Formula: Q = k * A * ΔT / L | `validate_inputs()`, `calculate()` |
+
+##### `ConductionHeatLoss`
+
+Calculate steady-state conduction heat loss through a wall. Formula: Q = k * A * ΔT / L
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.convection_heat_loss`
+
+**Source:** `processpi/calculations/heat_transfer/convection_heat_loss.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ConvectionHeatLoss` | `ConvectionHeatLoss(...)` | Calculate convection heat loss. Formula: Q = h * A * ΔT | `validate_inputs()`, `calculate()` |
+
+##### `ConvectionHeatLoss`
+
+Calculate convection heat loss. Formula: Q = h * A * ΔT
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.crossflow_tube`
+
+**Source:** `processpi/calculations/heat_transfer/crossflow_tube.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `CrossFlowSingleTube` | `CrossFlowSingleTube(...)` | Heat transfer to/from fluid flowing normal to a single tube. **Formula:** Q = h * A * (T_surface - T_fluid) **Inputs:** * `h`: Convective heat transfer coefficient [W/m²·K] * `diameter`: Tube outer diameter [m] * `length`: Tube length [m] * `T_surface`: Tube surface temperature [K] * `T_fluid`: Bulk fluid temperature [K] | `validate_inputs()`, `calculate()` |
+
+##### `CrossFlowSingleTube`
+
+Heat transfer to/from fluid flowing normal to a single tube. **Formula:** Q = h * A * (T_surface - T_fluid) **Inputs:** * `h`: Convective heat transfer coefficient [W/m²·K] * `diameter`: Tube outer diameter [m] * `length`: Tube length [m] * `T_surface`: Tube surface temperature [K] * `T_fluid`: Bulk fluid temperature [K]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.fourier`
+
+**Source:** `processpi/calculations/heat_transfer/fourier.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `FourierNumber` | `FourierNumber(...)` | Fourier number (transient conduction). **Formula:** Fo = α * t / L² | `validate_inputs()`, `calculate()` |
+
+##### `FourierNumber`
+
+Fourier number (transient conduction). **Formula:** Fo = α * t / L²
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.fourierlaw`
+
+**Source:** `processpi/calculations/heat_transfer/fourierlaw.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `FourierLaw` | `FourierLaw(...)` | Heat transfer rate by conduction (Fourier's Law). **Formula:** q = k * A * (ΔT / dx) **Where:** * k = Thermal conductivity [W/m·K] * A = Cross-sectional area [m²] * ΔT = Temperature difference [K] * dx = Thickness of material [m] **Inputs:** * `conductivity`: Thermal conductivity (k). * `area`: Heat transfer area (A). * `deltaT`: Temperature difference (ΔT). * `thickness`: Material thickness (dx). **Output:** * HeatFlow [W] | `validate_inputs()`, `calculate()` |
+
+##### `FourierLaw`
+
+Heat transfer rate by conduction (Fourier's Law). **Formula:** q = k * A * (ΔT / dx) **Where:** * k = Thermal conductivity [W/m·K] * A = Cross-sectional area [m²] * ΔT = Temperature difference [K] * dx = Thickness of material [m] **Inputs:** * `conductivity`: Thermal conductivity (k). * `area`: Heat transfer area (A). * `deltaT`: Temperature difference (ΔT). * `thickness`: Material thickness (dx). **Output:** * HeatFlow [W]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.grashof`
+
+**Source:** `processpi/calculations/heat_transfer/grashof.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `GrashofNumber` | `GrashofNumber(...)` | Grashof number (buoyancy vs. viscous forces in natural convection). **Formula:** Gr = g * β * ΔT * L³ / ν² | `validate_inputs()`, `calculate()` |
+
+##### `GrashofNumber`
+
+Grashof number (buoyancy vs. viscous forces in natural convection). **Formula:** Gr = g * β * ΔT * L³ / ν²
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.heat_exchanger`
+
+**Source:** `processpi/calculations/heat_transfer/heat_exchanger.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `SensibleHeatDuty` | `SensibleHeatDuty(...)` | Q = m * Cp * (Tin - Tout). | `validate_inputs()`, `calculate()` |
+| `LatentHeatDuty` | `LatentHeatDuty(...)` | Q = m * lambda. | `validate_inputs()`, `calculate()` |
+| `KernNusselt` | `KernNusselt(...)` | Nu = 0.023 * Re^0.8 * Pr^n. | `validate_inputs()`, `calculate()` |
+| `ConvectiveCoefficient` | `ConvectiveCoefficient(...)` | h = Nu * k / D. | `validate_inputs()`, `calculate()` |
+| `DarcyPressureDrop` | `DarcyPressureDrop(...)` | dP = f * (L / D) * (rho * v^2 / 2). | `validate_inputs()`, `calculate()` |
+| `ReynoldsFromProperties` | `ReynoldsFromProperties(...)` | Re = rho * v * D / mu. | `validate_inputs()`, `calculate()` |
+
+##### `SensibleHeatDuty`
+
+Q = m * Cp * (Tin - Tout).
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `LatentHeatDuty`
+
+Q = m * lambda.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `KernNusselt`
+
+Nu = 0.023 * Re^0.8 * Pr^n.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `ConvectiveCoefficient`
+
+h = Nu * k / D.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `DarcyPressureDrop`
+
+dP = f * (L / D) * (rho * v^2 / 2).
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `ReynoldsFromProperties`
+
+Re = rho * v * D / mu.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.heat_exchanger_area`
+
+**Source:** `processpi/calculations/heat_transfer/heat_exchanger_area.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `HeatExchangerArea` | `HeatExchangerArea(...)` | Calculate required heat exchanger area. Formula: Q = U * A * ΔTlm => A = Q / (U * ΔTlm) | `validate_inputs()`, `calculate()` |
+
+##### `HeatExchangerArea`
+
+Calculate required heat exchanger area. Formula: Q = U * A * ΔTlm => A = Q / (U * ΔTlm)
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.hx_kern`
+
+**Source:** `processpi/calculations/heat_transfer/hx_kern.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `SensibleDuty` | `SensibleDuty(...)` | No source docstring provided. See module purpose and examples. | `validate_inputs()`, `calculate()` |
+| `LatentDuty` | `LatentDuty(...)` | No source docstring provided. See module purpose and examples. | `validate_inputs()`, `calculate()` |
+| `Reynolds` | `Reynolds(...)` | No source docstring provided. See module purpose and examples. | `validate_inputs()`, `calculate()` |
+| `DittusBoelter` | `DittusBoelter(...)` | No source docstring provided. See module purpose and examples. | `validate_inputs()`, `calculate()` |
+| `KernShellNu` | `KernShellNu(...)` | No source docstring provided. See module purpose and examples. | `validate_inputs()`, `calculate()` |
+| `ConvectiveH` | `ConvectiveH(...)` | No source docstring provided. See module purpose and examples. | `validate_inputs()`, `calculate()` |
+| `TubeCountFromArea` | `TubeCountFromArea(...)` | No source docstring provided. See module purpose and examples. | `validate_inputs()`, `calculate()` |
+| `ShellDiameterEstimate` | `ShellDiameterEstimate(...)` | No source docstring provided. See module purpose and examples. | `validate_inputs()`, `calculate()` |
+| `DarcyDrop` | `DarcyDrop(...)` | No source docstring provided. See module purpose and examples. | `validate_inputs()`, `calculate()` |
+| `CondensationHTC` | `CondensationHTC(...)` | Nusselt film condensation correlation for vertical tube condensation. Preliminary engineering approximation. | `validate_inputs()`, `calculate()` |
+| `BoilingHTC` | `BoilingHTC(...)` | Simplified boiling heat-transfer coefficient. Preliminary engineering approximation. | `validate_inputs()`, `calculate()` |
+
+##### `SensibleDuty`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `LatentDuty`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `Reynolds`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `DittusBoelter`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `KernShellNu`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `ConvectiveH`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `TubeCountFromArea`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `ShellDiameterEstimate`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `DarcyDrop`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `CondensationHTC`
+
+Nusselt film condensation correlation for vertical tube condensation. Preliminary engineering approximation.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `BoilingHTC`
+
+Simplified boiling heat-transfer coefficient. Preliminary engineering approximation.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.lmtd`
+
+**Source:** `processpi/calculations/heat_transfer/lmtd.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `LMTD` | `LMTD(...)` | Heat Exchanger using LMTD method. Q = U * A * ΔTlm | `validate_inputs()`, `calculate()` |
+
+##### `LMTD`
+
+Heat Exchanger using LMTD method. Q = U * A * ΔTlm
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.newton_cooling`
+
+**Source:** `processpi/calculations/heat_transfer/newton_cooling.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `NewtonCooling` | `NewtonCooling(...)` | Convective heat transfer (Newton’s Law of Cooling). **Formula:** q = h * A * (Ts - T∞) **Where:** * h = Heat transfer coefficient [W/m²·K] * A = Surface area [m²] * Ts = Surface temperature [K] * T∞ = Bulk fluid temperature [K] **Inputs:** * `h`: Heat transfer coefficient. * `area`: Surface area. * `T_surface`: Surface temperature. * `T_fluid`: Bulk fluid temperature. **Output:** * HeatFlow [W] | `validate_inputs()`, `calculate()` |
+
+##### `NewtonCooling`
+
+Convective heat transfer (Newton’s Law of Cooling). **Formula:** q = h * A * (Ts - T∞) **Where:** * h = Heat transfer coefficient [W/m²·K] * A = Surface area [m²] * Ts = Surface temperature [K] * T∞ = Bulk fluid temperature [K] **Inputs:** * `h`: Heat transfer coefficient. * `area`: Surface area. * `T_surface`: Surface temperature. * `T_fluid`: Bulk fluid temperature. **Output:** * HeatFlow [W]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.ntu`
+
+**Source:** `processpi/calculations/heat_transfer/ntu.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `NTUHeatExchanger` | `NTUHeatExchanger(...)` | Heat Exchanger using Effectiveness-NTU method. Q = ε * C_min * (T_hot,in - T_cold,in) | `validate_inputs()`, `calculate()` |
+
+##### `NTUHeatExchanger`
+
+Heat Exchanger using Effectiveness-NTU method. Q = ε * C_min * (T_hot,in - T_cold,in)
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.nusselt`
+
+**Source:** `processpi/calculations/heat_transfer/nusselt.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `NusseltNumber` | `NusseltNumber(...)` | Nusselt number (dimensionless heat transfer coefficient). **Formula:** Nu = h * L / k | `validate_inputs()`, `calculate()` |
+
+##### `NusseltNumber`
+
+Nusselt number (dimensionless heat transfer coefficient). **Formula:** Nu = h * L / k
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.overall_u`
+
+**Source:** `processpi/calculations/heat_transfer/overall_u.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `OverallHeatTransferCoefficient` | `OverallHeatTransferCoefficient(...)` | Overall heat transfer coefficient for a composite wall. U = 1 / ΣR | `validate_inputs()`, `calculate()` |
+
+##### `OverallHeatTransferCoefficient`
+
+Overall heat transfer coefficient for a composite wall. U = 1 / ΣR
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.peclet`
+
+**Source:** `processpi/calculations/heat_transfer/peclet.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `PecletNumber` | `PecletNumber(...)` | Peclet number (convection vs. conduction in fluid flow). **Formula:** Pe = Re * Pr = (ρ * v * L / μ) * (μ * Cp / k) = ρ * v * L * Cp / k | `validate_inputs()`, `calculate()` |
+
+##### `PecletNumber`
+
+Peclet number (convection vs. conduction in fluid flow). **Formula:** Pe = Re * Pr = (ρ * v * L / μ) * (μ * Cp / k) = ρ * v * L * Cp / k
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.prandtl`
+
+**Source:** `processpi/calculations/heat_transfer/prandtl.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `PrandtlNumber` | `PrandtlNumber(...)` | Prandtl number. **Formula:** Pr = μ * Cp / k | `validate_inputs()`, `calculate()` |
+
+##### `PrandtlNumber`
+
+Prandtl number. **Formula:** Pr = μ * Cp / k
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.radial_cylinder`
+
+**Source:** `processpi/calculations/heat_transfer/radial_cylinder.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `RadialHeatFlowCylinder` | `RadialHeatFlowCylinder(...)` | Radial heat conduction through a hollow cylinder. **Formula:** Q = (2 * π * k * L * (T1 - T2)) / ln(r2/r1) **Inputs:** * `k`: Thermal conductivity [W/m·K] * `length`: Cylinder length [m] * `r_inner`: Inner radius [m] * `r_outer`: Outer radius [m] * `T_inner`: Temperature at inner surface [K] * `T_outer`: Temperature at outer surface [K] **Output:** * HeatFlow [W] | `validate_inputs()`, `calculate()` |
+
+##### `RadialHeatFlowCylinder`
+
+Radial heat conduction through a hollow cylinder. **Formula:** Q = (2 * π * k * L * (T1 - T2)) / ln(r2/r1) **Inputs:** * `k`: Thermal conductivity [W/m·K] * `length`: Cylinder length [m] * `r_inner`: Inner radius [m] * `r_outer`: Outer radius [m] * `T_inner`: Temperature at inner surface [K] * `T_outer`: Temperature at outer surface [K] **Output:** * HeatFlow [W]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.radiation_blackbody`
+
+**Source:** `processpi/calculations/heat_transfer/radiation_blackbody.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `BlackbodyRadiation` | `BlackbodyRadiation(...)` | Stefan–Boltzmann law for blackbody radiation. **Formula:** q = σ * T^4 **Where:** * q = radiative flux [W/m²] * σ = Stefan–Boltzmann constant (5.670374419e-8 W/m²·K⁴) * T = absolute temperature [K] **Inputs:** * T – surface temperature [K] **Output:** * HeatFlux [W/m²] | `validate_inputs()`, `calculate()` |
+
+##### `BlackbodyRadiation`
+
+Stefan–Boltzmann law for blackbody radiation. **Formula:** q = σ * T^4 **Where:** * q = radiative flux [W/m²] * σ = Stefan–Boltzmann constant (5.670374419e-8 W/m²·K⁴) * T = absolute temperature [K] **Inputs:** * T – surface temperature [K] **Output:** * HeatFlux [W/m²]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.radiation_exchange`
+
+**Source:** `processpi/calculations/heat_transfer/radiation_exchange.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `RadiationExchange` | `RadiationExchange(...)` | Net radiative heat exchange between two diffuse gray surfaces. **Formula:** q = σ * (T1^4 – T2^4) / ( (1/ε1) + (1/ε2) – 1 ) **Where:** * T1, T2 = absolute temperatures [K] * ε1, ε2 = emissivities * q = net flux [W/m²] **Inputs:** * T1 * T2 * epsilon1 * epsilon2 **Output:** * HeatFlux [W/m²] | `validate_inputs()`, `calculate()` |
+
+##### `RadiationExchange`
+
+Net radiative heat exchange between two diffuse gray surfaces. **Formula:** q = σ * (T1^4 – T2^4) / ( (1/ε1) + (1/ε2) – 1 ) **Where:** * T1, T2 = absolute temperatures [K] * ε1, ε2 = emissivities * q = net flux [W/m²] **Inputs:** * T1 * T2 * epsilon1 * epsilon2 **Output:** * HeatFlux [W/m²]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.radiation_greybody`
+
+**Source:** `processpi/calculations/heat_transfer/radiation_greybody.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `GreybodyRadiation` | `GreybodyRadiation(...)` | Greybody radiation with emissivity factor. **Formula:** q = ε * σ * T^4 **Where:** * ε = emissivity (0 < ε ≤ 1) * q = radiative flux [W/m²] * T = absolute temperature [K] **Inputs:** * T – surface temperature [K] * ε – emissivity (dimensionless) **Output:** * HeatFlux [W/m²] | `validate_inputs()`, `calculate()` |
+
+##### `GreybodyRadiation`
+
+Greybody radiation with emissivity factor. **Formula:** q = ε * σ * T^4 **Where:** * ε = emissivity (0 < ε ≤ 1) * q = radiative flux [W/m²] * T = absolute temperature [K] **Inputs:** * T – surface temperature [K] * ε – emissivity (dimensionless) **Output:** * HeatFlux [W/m²]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.radiation_viewfactor`
+
+**Source:** `processpi/calculations/heat_transfer/radiation_viewfactor.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `RadiationWithViewFactor` | `RadiationWithViewFactor(...)` | Radiation exchange between two surfaces with a given view factor. **Formula:** Q = σ * A1 * F12 * (T1^4 – T2^4) **Where:** * A1 = area of surface 1 [m²] * F12 = view factor from surface 1 to 2 * T1, T2 = temperatures [K] * Q = net heat transfer [W] **Inputs:** * A1 * F12 * T1 * T2 **Output:** * HeatFlow [W] | `validate_inputs()`, `calculate()` |
+
+##### `RadiationWithViewFactor`
+
+Radiation exchange between two surfaces with a given view factor. **Formula:** Q = σ * A1 * F12 * (T1^4 – T2^4) **Where:** * A1 = area of surface 1 [m²] * F12 = view factor from surface 1 to 2 * T1, T2 = temperatures [K] * Q = net heat transfer [W] **Inputs:** * A1 * F12 * T1 * T2 **Output:** * HeatFlow [W]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.resistance`
+
+**Source:** `processpi/calculations/heat_transfer/resistance.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ThermalResistanceSeries` | `ThermalResistanceSeries(...)` | Equivalent thermal resistance for series layers. R_total = Σ Ri | `validate_inputs()`, `calculate()` |
+| `ThermalResistanceParallel` | `ThermalResistanceParallel(...)` | Equivalent thermal resistance for parallel layers. 1/R_total = Σ (1/Ri) | `validate_inputs()`, `calculate()` |
+
+##### `ThermalResistanceSeries`
+
+Equivalent thermal resistance for series layers. R_total = Σ Ri
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `ThermalResistanceParallel`
+
+Equivalent thermal resistance for parallel layers. 1/R_total = Σ (1/Ri)
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.reyleigh`
+
+**Source:** `processpi/calculations/heat_transfer/reyleigh.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `RayleighNumber` | `RayleighNumber(...)` | Rayleigh number (convection onset parameter). **Formula:** Ra = Gr * Pr | `validate_inputs()`, `calculate()` |
+
+##### `RayleighNumber`
+
+Rayleigh number (convection onset parameter). **Formula:** Ra = Gr * Pr
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.rohsenow_boiling`
+
+**Source:** `processpi/calculations/heat_transfer/rohsenow_boiling.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `RohsenowBoiling` | `RohsenowBoiling(...)` | Rohsenow correlation for **pool boiling heat transfer**. **Formula:** q'' = μ_l * h_fg * [ (g * (ρ_l - ρ_v) / σ)^(1/2) ] * [ Cp_l * (ΔT / (h_fg * Pr_l^n)) ]^3 **Where:** * q'' = Heat flux [W/m²] * μ_l = Liquid viscosity [Pa·s] * h_fg = Latent heat of vaporization [J/kg] * g = Gravity [m/s²] * ρ_l, ρ_v = Liquid and vapor densities [kg/m³] * σ = Surface tension [N/m] * Cp_l = Specific heat of liquid [J/kg·K] * ΔT = (T_wall – T_sat) [K] * Pr_l = Prandtl number of liquid * n = empirical constant (usually 1.0 for water, 1.7 for other fluids) **Inputs:** * mu_l * h_fg * g * rho_l * rho_v * sigma * Cp_l * dT * Pr_l * n (default: 1.0) **Output:** * HeatFlux [W/m²] | `validate_inputs()`, `calculate()` |
+
+##### `RohsenowBoiling`
+
+Rohsenow correlation for **pool boiling heat transfer**. **Formula:** q'' = μ_l * h_fg * [ (g * (ρ_l - ρ_v) / σ)^(1/2) ] * [ Cp_l * (ΔT / (h_fg * Pr_l^n)) ]^3 **Where:** * q'' = Heat flux [W/m²] * μ_l = Liquid viscosity [Pa·s] * h_fg = Latent heat of vaporization [J/kg] * g = Gravity [m/s²] * ρ_l, ρ_v = Liquid and vapor densities [kg/m³] * σ = Surface tension [N/m] * Cp_l = Specific heat of liquid [J/kg·K] * ΔT = (T_wall – T_sat) [K] * Pr_l = Prandtl number of liquid * n = empirical constant (usually 1.0 for water, 1.7 for other fluids) **Inputs:** * mu_l * h_fg * g * rho_l * rho_v * sigma * Cp_l * dT * Pr_l * n (default: 1.0) **Output:** * HeatFlux [W/m²]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.heat_transfer.stefan_boltzmann`
+
+**Source:** `processpi/calculations/heat_transfer/stefan_boltzmann.py`
+
+**Purpose:** Reusable heat-transfer calculation primitive used by exchanger and engineering workflows.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `StefanBoltzmann` | `StefanBoltzmann(...)` | Radiative heat transfer (Stefan–Boltzmann Law). **Formula:** q = εσA(Ts⁴ - Tsur⁴) **Where:** * ε = Surface emissivity [-] * σ = Stefan–Boltzmann constant [5.67e-8 W/m²·K⁴] * A = Surface area [m²] * Ts = Surface temperature [K] * Tsur = Surrounding temperature [K] **Inputs:** * `emissivity`: Surface emissivity. * `area`: Surface area. * `T_surface`: Surface temperature. * `T_surround`: Surrounding temperature. **Output:** * HeatFlow [W] | `validate_inputs()`, `calculate()` |
+
+##### `StefanBoltzmann`
+
+Radiative heat transfer (Stefan–Boltzmann Law). **Formula:** q = εσA(Ts⁴ - Tsur⁴) **Where:** * ε = Surface emissivity [-] * σ = Stefan–Boltzmann constant [5.67e-8 W/m²·K⁴] * A = Surface area [m²] * Ts = Surface temperature [K] * Tsur = Surrounding temperature [K] **Inputs:** * `emissivity`: Surface emissivity. * `area`: Surface area. * `T_surface`: Surface temperature. * `T_surround`: Surrounding temperature. **Output:** * HeatFlow [W]
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.mass_transfer.__init__`
+
+**Source:** `processpi/calculations/mass_transfer/__init__.py`
+
+**Purpose:** Mass-transfer calculation primitive.
+
+No public classes or functions discovered in this module.
+
+### `processpi.calculations.mass_transfer.distillation_stage_count`
+
+**Source:** `processpi/calculations/mass_transfer/distillation_stage_count.py`
+
+**Purpose:** Mass-transfer calculation primitive.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `DistillationStageCount` | `DistillationStageCount(...)` | Detailed distillation stage calculations. Supports two workflows: 1) Fenske minimum stages (binary): - Inputs: alpha_avg: float # Average relative volatility (LK relative to HK), alpha > 1 xD: float # LK mole fraction in distillate xB: float # LK mole fraction in bottoms - Output: {"Nmin_theoretical": float} 2) McCabe–Thiele graphical stepping (binary): - Inputs: xD: float # LK in distillate xB: float # LK in bottoms zF: float # LK in feed R: float # Reflux ratio (L/D) q: float # Feed thermal condition (q-line slope param) eq_curve: List[Tuple[float,float]] or callable x->y_eq # Equilibrium data: y = f(x). You can pass: # - list of (x,y) pairs (monotonic in x), OR # - a callable y_eq(x) total_condenser: bool = True # If True, add total condenser stage partial_reboiler: bool = True # If True, count reboiler as a stage max_stages: int = 300 # Safety limit for stepping tol: float = 1e-6 # Numeric tolerance - Assumptions: * Binary system (LK/HK). * Constant molar overflow (straight rectifying/stripping lines). * Feed plate determined by q-line intersection. - Output: { "N_theoretical": int, "rectifying_stages": int, "stripping_stages": int, "includes_total_condenser": bool, "includes_partial_reboiler": bool } Notes ----- * The McCabe–Thiele stepper uses piecewise linear interpolation of eq data if provided as (x,y) pairs. * Rectifying operating line: y = (R/(R+1)) x + xD/(R+1) * q-line (feed): y = (q/(q-1)) x - zF/(q-1) (q != 1 case) Special cases: - q = 1 (saturated liquid): vertical line at x = zF - q = 0 (saturated vapor): line slope 0 through y = zF * Stripping line is constructed through feed intersection and (xB, xB) pinch. | `validate_inputs()`, `calculate()` |
+
+##### `DistillationStageCount`
+
+Detailed distillation stage calculations. Supports two workflows: 1) Fenske minimum stages (binary): - Inputs: alpha_avg: float # Average relative volatility (LK relative to HK), alpha > 1 xD: float # LK mole fraction in distillate xB: float # LK mole fraction in bottoms - Output: {"Nmin_theoretical": float} 2) McCabe–Thiele graphical stepping (binary): - Inputs: xD: float # LK in distillate xB: float # LK in bottoms zF: float # LK in feed R: float # Reflux ratio (L/D) q: float # Feed thermal condition (q-line slope param) eq_curve: List[Tuple[float,float]] or callable x->y_eq # Equilibrium data: y = f(x). You can pass: # - list of (x,y) pairs (monotonic in x), OR # - a callable y_eq(x) total_condenser: bool = True # If True, add total condenser stage partial_reboiler: bool = True # If True, count reboiler as a stage max_stages: int = 300 # Safety limit for stepping tol: float = 1e-6 # Numeric tolerance - Assumptions: * Binary system (LK/HK). * Constant molar overflow (straight rectifying/stripping lines). * Feed plate determined by q-line intersection. - Output: { "N_theoretical": int, "rectifying_stages": int, "stripping_stages": int, "includes_total_condenser": bool, "includes_partial_reboiler": bool } Notes ----- * The McCabe–Thiele stepper uses piecewise linear interpolation of eq data if provided as (x,y) pairs. * Rectifying operating line: y = (R/(R+1)) x + xD/(R+1) * q-line (feed): y = (q/(q-1)) x - zF/(q-1) (q != 1 case) Special cases: - q = 1 (saturated liquid): vertical line at x = zF - q = 0 (saturated vapor): line slope 0 through y = zF * Stripping line is constructed through feed intersection and (xB, xB) pinch.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.mass_transfer.drying_rate`
+
+**Source:** `processpi/calculations/mass_transfer/drying_rate.py`
+
+**Purpose:** Mass-transfer calculation primitive.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `DryingRate` | `DryingRate(...)` | Detailed batch drying time and flux calculations across constant-rate and falling-rate periods. Two workflows: (A) Use direct constant-rate flux + falling-rate coefficient Inputs: M_dry: float # Dry solid mass (kg dry basis) A: float # Exposed drying area (m^2) X_i: float # Initial moisture content (kg water/kg dry solid) X_f: float # Final moisture content (kg water/kg dry solid) X_c: float # Critical moisture content (kg/kg dry solid) X_star: float # Equilibrium moisture content (kg/kg dry solid) N_c: float # Constant-rate flux (kg/m^2/s), e.g., measured or from HT/MT analysis k_f: float # Falling-rate coefficient (1/s) with linear-w.r.t-free-moisture assumption Output: { "t_constant_s": float, "t_falling_s": float, "t_total_s": float, "avg_flux_kg_m2_s": float } Model: * Constant-rate period: t_c = (M_dry/A) * (X_i - X_c) / N_c * Falling-rate (linear w.r.t free moisture X - X*): N = k_f * (X - X_star) t_f = (M_dry/A) * ln( (X_c - X_star) / (X_f - X_star) ) / k_f (B) Compute constant-rate flux from a mass-transfer coefficient (Lewis analogy style) Inputs: M_dry, A, X_i, X_f, X_c, X_star (as above) h_m: float # Mass-transfer coefficient (m/s) rho_v: float # Vapor density at interface/film (kg/m^3) Y_s: float # Humidity ratio (kg vapor/kg dry gas) at surface (saturation) Y_inf: float # Humidity ratio in bulk gas (kg/kg_dry_gas) k_f: float # Falling-rate coefficient (1/s) Output: same keys as (A) Model: N_c = h_m * rho_v * (Y_s - Y_inf) | `validate_inputs()`, `calculate()` |
+
+##### `DryingRate`
+
+Detailed batch drying time and flux calculations across constant-rate and falling-rate periods. Two workflows: (A) Use direct constant-rate flux + falling-rate coefficient Inputs: M_dry: float # Dry solid mass (kg dry basis) A: float # Exposed drying area (m^2) X_i: float # Initial moisture content (kg water/kg dry solid) X_f: float # Final moisture content (kg water/kg dry solid) X_c: float # Critical moisture content (kg/kg dry solid) X_star: float # Equilibrium moisture content (kg/kg dry solid) N_c: float # Constant-rate flux (kg/m^2/s), e.g., measured or from HT/MT analysis k_f: float # Falling-rate coefficient (1/s) with linear-w.r.t-free-moisture assumption Output: { "t_constant_s": float, "t_falling_s": float, "t_total_s": float, "avg_flux_kg_m2_s": float } Model: * Constant-rate period: t_c = (M_dry/A) * (X_i - X_c) / N_c * Falling-rate (linear w.r.t free moisture X - X*): N = k_f * (X - X_star) t_f = (M_dry/A) * ln( (X_c - X_star) / (X_f - X_star) ) / k_f (B) Compute constant-rate flux from a mass-transfer coefficient (Lewis analogy style) Inputs: M_dry, A, X_i, X_f, X_c, X_star (as above) h_m: float # Mass-transfer coefficient (m/s) rho_v: float # Vapor density at interface/film (kg/m^3) Y_s: float # Humidity ratio (kg vapor/kg dry gas) at surface (saturation) Y_inf: float # Humidity ratio in bulk gas (kg/kg_dry_gas) k_f: float # Falling-rate coefficient (1/s) Output: same keys as (A) Model: N_c = h_m * rho_v * (Y_s - Y_inf)
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.reaction_engineering.__init__`
+
+**Source:** `processpi/calculations/reaction_engineering/__init__.py`
+
+**Purpose:** Reaction-engineering calculation primitive.
+
+No public classes or functions discovered in this module.
+
+### `processpi.calculations.reaction_engineering.catalyst_activity`
+
+**Source:** `processpi/calculations/reaction_engineering/catalyst_activity.py`
+
+**Purpose:** Reaction-engineering calculation primitive.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `CatalystActivity` | `CatalystActivity(...)` | Catalyst activity decay & temperature correction utilities. Workflows (select with `model`): -------------------------------- 1) First-order deactivation: model = "first_order" Inputs: k_d or (A_d, Ea_d, T[, R]) # deactivation constant (1/time) or Arrhenius params t: float # time on stream a0: float = 1.0 # initial activity Output: {"a": float} Equation: a(t) = a0 * exp(-k_d * t) 2) Power-law deactivation order n: model = "power_order" Inputs: n: float # deactivation order (n >= 0) k_d or (A_d, Ea_d, T[, R]) # deactivation constant or Arrhenius t: float a0: float = 1.0 Output: {"a": float} Equation: da/dt = -k_d * a^n => if n = 1: a = a0 exp(-k_d t) if n != 1: a = a0 * [1 + (n-1) k_d t / a0^{(n-1)}]^(-1/(n-1)) 3) Temperature correction for activity-related constants (Arrhenius): model = "arrhenius_correction" Inputs: A_d, Ea_d, T[, R] Output: {"k_d": float} Equation: k_d = A_d * exp(-Ea_d/(R*T)) Notes ----- * For consistency, default R = 8.314 if not supplied. * a0 typically in [0,1], but any positive value is allowed for generic scaling. | `validate_inputs()`, `calculate()` |
+
+##### `CatalystActivity`
+
+Catalyst activity decay & temperature correction utilities. Workflows (select with `model`): -------------------------------- 1) First-order deactivation: model = "first_order" Inputs: k_d or (A_d, Ea_d, T[, R]) # deactivation constant (1/time) or Arrhenius params t: float # time on stream a0: float = 1.0 # initial activity Output: {"a": float} Equation: a(t) = a0 * exp(-k_d * t) 2) Power-law deactivation order n: model = "power_order" Inputs: n: float # deactivation order (n >= 0) k_d or (A_d, Ea_d, T[, R]) # deactivation constant or Arrhenius t: float a0: float = 1.0 Output: {"a": float} Equation: da/dt = -k_d * a^n => if n = 1: a = a0 exp(-k_d t) if n != 1: a = a0 * [1 + (n-1) k_d t / a0^{(n-1)}]^(-1/(n-1)) 3) Temperature correction for activity-related constants (Arrhenius): model = "arrhenius_correction" Inputs: A_d, Ea_d, T[, R] Output: {"k_d": float} Equation: k_d = A_d * exp(-Ea_d/(R*T)) Notes ----- * For consistency, default R = 8.314 if not supplied. * a0 typically in [0,1], but any positive value is allowed for generic scaling.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.reaction_engineering.reaction_rate`
+
+**Source:** `processpi/calculations/reaction_engineering/reaction_rate.py`
+
+**Purpose:** Reaction-engineering calculation primitive.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ReactionRate` | `ReactionRate(...)` | General reaction-rate calculator supporting several kinetic models. Workflows (select with `model`): -------------------------------- 1) Power law (elementary / empirical): model = "power_law" Inputs: C: Mapping[str, float] # species concentrations, mol/L (or consistent units) exponents: Mapping[str, float] # reaction orders for each species (e.g., {"A":1, "B":1}) k: float # rate constant (units consistent with orders & C) (optional) A, Ea, T, R # If k not given, compute k via Arrhenius: k = A*exp(-Ea/(R*T)) Output: {"rate": float} Equation: r = k * Π_i C_i^{a_i} 2) Langmuir–Hinshelwood (adsorption + surface reaction): model = "langmuir_hinshelwood" Inputs: k or (A, Ea, T, R) # rate constant or Arrhenius params C: Mapping[str, float] # species concentrations (e.g., {"A":..., "B":...}) K: Mapping[str, float] # adsorption constants for species present numerator: Mapping[str, float] # stoich exponents in numerator (default {"A":1}) denom_power: float = 1.0 # overall power on denominator (default 1) Output: {"rate": float} Equation (generic): r = k * Π_j (C_j)^{ν_j} / [ 1 + Σ_i K_i C_i ]^{denom_power} 3) Michaelis–Menten (enzymatic form, optional): model = "michaelis_menten" Inputs: Vmax: float Km: float S: float # substrate concentration Output: {"rate": float} Equation: r = Vmax * S / (Km + S) Notes ----- * Units are your responsibility; keep them consistent. * If both `k` and (A,Ea,T[,R]) are provided, `k` is used and Arrhenius params ignored. * Default R = 8.314 if not supplied and Arrhenius is used. | `validate_inputs()`, `calculate()` |
+
+##### `ReactionRate`
+
+General reaction-rate calculator supporting several kinetic models. Workflows (select with `model`): -------------------------------- 1) Power law (elementary / empirical): model = "power_law" Inputs: C: Mapping[str, float] # species concentrations, mol/L (or consistent units) exponents: Mapping[str, float] # reaction orders for each species (e.g., {"A":1, "B":1}) k: float # rate constant (units consistent with orders & C) (optional) A, Ea, T, R # If k not given, compute k via Arrhenius: k = A*exp(-Ea/(R*T)) Output: {"rate": float} Equation: r = k * Π_i C_i^{a_i} 2) Langmuir–Hinshelwood (adsorption + surface reaction): model = "langmuir_hinshelwood" Inputs: k or (A, Ea, T, R) # rate constant or Arrhenius params C: Mapping[str, float] # species concentrations (e.g., {"A":..., "B":...}) K: Mapping[str, float] # adsorption constants for species present numerator: Mapping[str, float] # stoich exponents in numerator (default {"A":1}) denom_power: float = 1.0 # overall power on denominator (default 1) Output: {"rate": float} Equation (generic): r = k * Π_j (C_j)^{ν_j} / [ 1 + Σ_i K_i C_i ]^{denom_power} 3) Michaelis–Menten (enzymatic form, optional): model = "michaelis_menten" Inputs: Vmax: float Km: float S: float # substrate concentration Output: {"rate": float} Equation: r = Vmax * S / (Km + S) Notes ----- * Units are your responsibility; keep them consistent. * If both `k` and (A,Ea,T[,R]) are provided, `k` is used and Arrhenius params ignored. * Default R = 8.314 if not supplied and Arrhenius is used.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.reaction_engineering.residence_time`
+
+**Source:** `processpi/calculations/reaction_engineering/residence_time.py`
+
+**Purpose:** Reaction-engineering calculation primitive.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ResidenceTime` | `ResidenceTime(...)` | Space time (τ) and conversion relations for ideal reactors. Workflows (select with `mode`): ------------------------------- 1) Space time: mode = "tau" Inputs: V: float # reactor volume Q: float # volumetric flow rate Output: {"tau": float, "space_velocity": float} Equations: τ = V / Q SV = 1 / τ 2) Conversion for first-order kinetics (isothermal, constant density): mode = "conversion" Inputs: reactor: "CSTR" or "PFR" k: float # first-order rate constant (1/time) tau: float # space time (V/Q) Output: {"X": float} Equations: CSTR: X = (k τ) / (1 + k τ) PFR: X = 1 - exp(-k τ) | `validate_inputs()`, `calculate()` |
+
+##### `ResidenceTime`
+
+Space time (τ) and conversion relations for ideal reactors. Workflows (select with `mode`): ------------------------------- 1) Space time: mode = "tau" Inputs: V: float # reactor volume Q: float # volumetric flow rate Output: {"tau": float, "space_velocity": float} Equations: τ = V / Q SV = 1 / τ 2) Conversion for first-order kinetics (isothermal, constant density): mode = "conversion" Inputs: reactor: "CSTR" or "PFR" k: float # first-order rate constant (1/time) tau: float # space time (V/Q) Output: {"X": float} Equations: CSTR: X = (k τ) / (1 + k τ) PFR: X = 1 - exp(-k τ)
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.thermodynamics.__init__`
+
+**Source:** `processpi/calculations/thermodynamics/__init__.py`
+
+**Purpose:** Thermodynamic calculation primitive.
+
+No public classes or functions discovered in this module.
+
+### `processpi.calculations.thermodynamics.enthalpy_change`
+
+**Source:** `processpi/calculations/thermodynamics/enthalpy_change.py`
+
+**Purpose:** Thermodynamic calculation primitive.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `EnthalpyChange` | `EnthalpyChange(...)` | Calculate enthalpy change using: ΔH = m * Cp * ΔT | `validate_inputs()`, `calculate()` |
+
+##### `EnthalpyChange`
+
+Calculate enthalpy change using: ΔH = m * Cp * ΔT
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.thermodynamics.entropy_change`
+
+**Source:** `processpi/calculations/thermodynamics/entropy_change.py`
+
+**Purpose:** Thermodynamic calculation primitive.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `EntropyChange` | `EntropyChange(...)` | Calculate entropy change (ideal reversible process): ΔS = m * Cp * ln(T2/T1) | `validate_inputs()`, `calculate()` |
+
+##### `EntropyChange`
+
+Calculate entropy change (ideal reversible process): ΔS = m * Cp * ln(T2/T1)
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.calculations.thermodynamics.heat_of_vaporization`
+
+**Source:** `processpi/calculations/thermodynamics/heat_of_vaporization.py`
+
+**Purpose:** Thermodynamic calculation primitive.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `HeatOfVaporization` | `HeatOfVaporization(...)` | Calculate heat required for vaporization: Q = m * ΔHvap | `validate_inputs()`, `calculate()` |
+
+##### `HeatOfVaporization`
+
+Calculate heat required for vaporization: Q = m * ΔHvap
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_inputs` | `validate_inputs(self)` | No source docstring provided. |
+| `calculate` | `calculate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,27 @@
+# `processpi.cli` API
+
+## Overview
+
+ProcessPI module.
+
+### Design assumptions and limitations
+
+- Calculations generally expect engineering quantities in the units documented by the corresponding class constructor or module examples.
+- Unit wrapper objects expose `.to("unit")`; many higher-level models accept either ProcessPI unit objects or numeric SI values depending on context.
+- Validation is implemented in each class through `validate_inputs()` or constructor checks where available; invalid or missing inputs generally raise `ValueError`, `TypeError`, or `NotImplementedError`.
+- The API reference below is generated from source signatures and public names. If a class has limited source docstrings, consult its examples and calculation result keys for engineering interpretation.
+
+## Public modules
+
+### `processpi.cli`
+
+**Source:** `processpi/cli.py`
+
+**Purpose:** Command line interface for ProcessPI.
+
+#### Functions
+
+| Function | Signature | Description |
+| --- | --- | --- |
+| `build_parser` | `build_parser()` | No source docstring provided. |
+| `main` | `main(argv: list[str] | None=None)` | No source docstring provided. |

--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -1,0 +1,854 @@
+# `processpi.components` API
+
+## Overview
+
+Chemical component/property model with DIPPR-style constants or category defaults.
+
+### Design assumptions and limitations
+
+- Calculations generally expect engineering quantities in the units documented by the corresponding class constructor or module examples.
+- Unit wrapper objects expose `.to("unit")`; many higher-level models accept either ProcessPI unit objects or numeric SI values depending on context.
+- Validation is implemented in each class through `validate_inputs()` or constructor checks where available; invalid or missing inputs generally raise `ValueError`, `TypeError`, or `NotImplementedError`.
+- The API reference below is generated from source signatures and public names. If a class has limited source docstrings, consult its examples and calculation result keys for engineering interpretation.
+
+## Public modules
+
+### `processpi.components.__init__`
+
+**Source:** `processpi/components/__init__.py`
+
+**Purpose:** ProcessPI Components Module =========================== Automatically discovers all chemical component classes in this package and exposes them for direct import. Example: from processpi.components import Water, Ethanol, Acetone
+
+No public classes or functions discovered in this module.
+
+### `processpi.components.aceticacid`
+
+**Source:** `processpi/components/aceticacid.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `AceticAcid` | `AceticAcid(...)` | Represents the properties and constants for Acetic Acid ($CH_3COOH$). This class provides a comprehensive set of physical and thermodynamic properties for Acetic Acid, which are essential for various process engineering calculations. These properties are stored as class attributes and are available for use by other calculation modules within the ProcessPI library. **Properties:** - `name`: The common name of the compound. - `formula`: The chemical formula. - `molecular_weight`: The molar mass in g/mol. - `_critical_temperature`: The critical temperature, above which a substance cannot exist as a liquid, regardless of pressure. - `_critical_pressure`: The critical pressure, the vapor pressure at the critical temperature. - `_critical_volume`: The critical volume per kmole. - `_critical_zc`: The critical compressibility factor. - `_critical_acentric_factor`: The acentric factor, a measure of the non-sphericity of the molecule. - `_density_constants`: Constants for calculating density as a function of temperature. - `_specific_heat_constants`: Constants for calculating specific heat capacity as a function of temperature. - `_viscosity_constants`: Constants for calculating viscosity as a function of temperature. - `_thermal_conductivity_constants`: Constants for calculating thermal conductivity as a function of temperature. - `_vapor_pressure_constants`: Constants for calculating vapor pressure as a function of temperature using the Antoine equation or similar models. - `_enthalpy_constants`: Constants for calculating enthalpy as a function of temperature. | — |
+
+##### `AceticAcid`
+
+Represents the properties and constants for Acetic Acid ($CH_3COOH$). This class provides a comprehensive set of physical and thermodynamic properties for Acetic Acid, which are essential for various process engineering calculations. These properties are stored as class attributes and are available for use by other calculation modules within the ProcessPI library. **Properties:** - `name`: The common name of the compound. - `formula`: The chemical formula. - `molecular_weight`: The molar mass in g/mol. - `_critical_temperature`: The critical temperature, above which a substance cannot exist as a liquid, regardless of pressure. - `_critical_pressure`: The critical pressure, the vapor pressure at the critical temperature. - `_critical_volume`: The critical volume per kmole. - `_critical_zc`: The critical compressibility factor. - `_critical_acentric_factor`: The acentric factor, a measure of the non-sphericity of the molecule. - `_density_constants`: Constants for calculating density as a function of temperature. - `_specific_heat_constants`: Constants for calculating specific heat capacity as a function of temperature. - `_viscosity_constants`: Constants for calculating viscosity as a function of temperature. - `_thermal_conductivity_constants`: Constants for calculating thermal conductivity as a function of temperature. - `_vapor_pressure_constants`: Constants for calculating vapor pressure as a function of temperature using the Antoine equation or similar models. - `_enthalpy_constants`: Constants for calculating enthalpy as a function of temperature.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.acetone`
+
+**Source:** `processpi/components/acetone.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Acetone` | `Acetone(...)` | Represents the properties and constants for Acetone ($C_3H_6O$). This class provides a comprehensive set of physical and thermodynamic properties for Acetone, which are essential for various process engineering calculations. These properties are stored as class attributes and are available for use by other calculation modules within the ProcessPI library. **Properties:** - `name`: The common name of the compound. - `formula`: The chemical formula. - `molecular_weight`: The molar mass in g/mol. - `_critical_temperature`: The critical temperature, above which a substance cannot exist as a liquid, regardless of pressure. - `_critical_pressure`: The critical pressure, the vapor pressure at the critical temperature. - `_critical_volume`: The critical volume per kmole. - `_critical_zc`: The critical compressibility factor. - `_critical_acentric_factor`: The acentric factor, a measure of the non-sphericity of the molecule. - `_density_constants`: Constants for calculating density as a function of temperature. - `_specific_heat_constants`: Constants for calculating specific heat capacity as a function of temperature. - `_viscosity_constants`: Constants for calculating viscosity as a function of temperature. - `_thermal_conductivity_constants`: Constants for calculating thermal conductivity as a function of temperature. - `_vapor_pressure_constants`: Constants for calculating vapor pressure as a function of temperature using the Antoine equation or similar models. - `_enthalpy_constants`: Constants for calculating enthalpy as a function of temperature. | — |
+
+##### `Acetone`
+
+Represents the properties and constants for Acetone ($C_3H_6O$). This class provides a comprehensive set of physical and thermodynamic properties for Acetone, which are essential for various process engineering calculations. These properties are stored as class attributes and are available for use by other calculation modules within the ProcessPI library. **Properties:** - `name`: The common name of the compound. - `formula`: The chemical formula. - `molecular_weight`: The molar mass in g/mol. - `_critical_temperature`: The critical temperature, above which a substance cannot exist as a liquid, regardless of pressure. - `_critical_pressure`: The critical pressure, the vapor pressure at the critical temperature. - `_critical_volume`: The critical volume per kmole. - `_critical_zc`: The critical compressibility factor. - `_critical_acentric_factor`: The acentric factor, a measure of the non-sphericity of the molecule. - `_density_constants`: Constants for calculating density as a function of temperature. - `_specific_heat_constants`: Constants for calculating specific heat capacity as a function of temperature. - `_viscosity_constants`: Constants for calculating viscosity as a function of temperature. - `_thermal_conductivity_constants`: Constants for calculating thermal conductivity as a function of temperature. - `_vapor_pressure_constants`: Constants for calculating vapor pressure as a function of temperature using the Antoine equation or similar models. - `_enthalpy_constants`: Constants for calculating enthalpy as a function of temperature.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.acrylicacid`
+
+**Source:** `processpi/components/acrylicacid.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `AcrylicAcid` | `AcrylicAcid(...)` | Represents the properties and constants for Acrylic Acid ($C_3H_4O_2$). This class provides a comprehensive set of physical and thermodynamic properties for Acrylic Acid, which are essential for various process engineering calculations. These properties are stored as class attributes and are available for use by other calculation modules within the ProcessPI library. **Properties:** - `name`: The common name of the compound. - `formula`: The chemical formula. - `molecular_weight`: The molar mass in g/mol. - `_critical_temperature`: The critical temperature, above which a substance cannot exist as a liquid, regardless of pressure. - `_critical_pressure`: The critical pressure, the vapor pressure at the critical temperature. - `_critical_volume`: The critical volume per kmole. - `_critical_zc`: The critical compressibility factor. - `_critical_acentric_factor`: The acentric factor, a measure of the non-sphericity of the molecule. - `_density_constants`: Constants for calculating density as a function of temperature. - `_specific_heat_constants`: Constants for calculating specific heat capacity as a function of temperature. - `_viscosity_constants`: Constants for calculating viscosity as a function of temperature. - `_thermal_conductivity_constants`: Constants for calculating thermal conductivity as a function of temperature. - `_vapor_pressure_constants`: Constants for calculating vapor pressure as a function of temperature using the Antoine equation or similar models. - `_enthalpy_constants`: Constants for calculating enthalpy as a function of temperature. | — |
+
+##### `AcrylicAcid`
+
+Represents the properties and constants for Acrylic Acid ($C_3H_4O_2$). This class provides a comprehensive set of physical and thermodynamic properties for Acrylic Acid, which are essential for various process engineering calculations. These properties are stored as class attributes and are available for use by other calculation modules within the ProcessPI library. **Properties:** - `name`: The common name of the compound. - `formula`: The chemical formula. - `molecular_weight`: The molar mass in g/mol. - `_critical_temperature`: The critical temperature, above which a substance cannot exist as a liquid, regardless of pressure. - `_critical_pressure`: The critical pressure, the vapor pressure at the critical temperature. - `_critical_volume`: The critical volume per kmole. - `_critical_zc`: The critical compressibility factor. - `_critical_acentric_factor`: The acentric factor, a measure of the non-sphericity of the molecule. - `_density_constants`: Constants for calculating density as a function of temperature. - `_specific_heat_constants`: Constants for calculating specific heat capacity as a function of temperature. - `_viscosity_constants`: Constants for calculating viscosity as a function of temperature. - `_thermal_conductivity_constants`: Constants for calculating thermal conductivity as a function of temperature. - `_vapor_pressure_constants`: Constants for calculating vapor pressure as a function of temperature using the Antoine equation or similar models. - `_enthalpy_constants`: Constants for calculating enthalpy as a function of temperature.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.air`
+
+**Source:** `processpi/components/air.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Air` | `Air(...)` | Represents the properties and constants for Air (a molecular mixture). This class provides a comprehensive set of physical and thermodynamic properties for Air, which are essential for various process engineering calculations. These properties are stored as class attributes and are available for use by other calculation modules within the ProcessPI library. **Properties:** - `name`: The common name of the compound. - `formula`: The chemical formula. - `molecular_weight`: The molar mass in g/mol. - `_critical_temperature`: The critical temperature, above which a substance cannot exist as a liquid, regardless of pressure. - `_critical_pressure`: The critical pressure, the vapor pressure at the critical temperature. - `_critical_volume`: The critical volume per kmole. - `_critical_zc`: The critical compressibility factor. - `_critical_acentric_factor`: The acentric factor, a measure of the non-sphericity of the molecule. - `_density_constants`: Constants for calculating density as a function of temperature. - `_specific_heat_constants`: Constants for calculating specific heat capacity as a function of temperature. - `_viscosity_constants`: Constants for calculating viscosity as a function of temperature. - `_thermal_conductivity_constants`: Constants for calculating thermal conductivity as a function of temperature. - `_vapor_pressure_constants`: Constants for calculating vapor pressure as a function of temperature using the Antoine equation or similar models. - `_enthalpy_constants`: Constants for calculating enthalpy as a function of temperature. | — |
+
+##### `Air`
+
+Represents the properties and constants for Air (a molecular mixture). This class provides a comprehensive set of physical and thermodynamic properties for Air, which are essential for various process engineering calculations. These properties are stored as class attributes and are available for use by other calculation modules within the ProcessPI library. **Properties:** - `name`: The common name of the compound. - `formula`: The chemical formula. - `molecular_weight`: The molar mass in g/mol. - `_critical_temperature`: The critical temperature, above which a substance cannot exist as a liquid, regardless of pressure. - `_critical_pressure`: The critical pressure, the vapor pressure at the critical temperature. - `_critical_volume`: The critical volume per kmole. - `_critical_zc`: The critical compressibility factor. - `_critical_acentric_factor`: The acentric factor, a measure of the non-sphericity of the molecule. - `_density_constants`: Constants for calculating density as a function of temperature. - `_specific_heat_constants`: Constants for calculating specific heat capacity as a function of temperature. - `_viscosity_constants`: Constants for calculating viscosity as a function of temperature. - `_thermal_conductivity_constants`: Constants for calculating thermal conductivity as a function of temperature. - `_vapor_pressure_constants`: Constants for calculating vapor pressure as a function of temperature using the Antoine equation or similar models. - `_enthalpy_constants`: Constants for calculating enthalpy as a function of temperature.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.ammonia`
+
+**Source:** `processpi/components/ammonia.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Ammonia` | `Ammonia(...)` | Represents the properties and constants for Ammonia ($NH_3$). This class provides a comprehensive set of physical and thermodynamic properties for Ammonia, which are essential for various process engineering calculations. These properties are stored as class attributes and are available for use by other calculation modules within the ProcessPI library. **Properties:** - `name`: The common name of the compound. - `formula`: The chemical formula. - `molecular_weight`: The molar mass in g/mol. - `_critical_temperature`: The critical temperature, above which a substance cannot exist as a liquid, regardless of pressure. - `_critical_pressure`: The critical pressure, the vapor pressure at the critical temperature. - `_critical_volume`: The critical volume per kmole. - `_critical_zc`: The critical compressibility factor. - `_critical_acentric_factor`: The acentric factor, a measure of the non-sphericity of the molecule. - `_density_constants`: Constants for calculating density as a function of temperature. - `_specific_heat_constants`: Constants for calculating specific heat capacity as a function of temperature. - `_viscosity_constants`: Constants for calculating viscosity as a function of temperature. - `_thermal_conductivity_constants`: Constants for calculating thermal conductivity as a function of temperature. - `_vapor_pressure_constants`: Constants for calculating vapor pressure as a function of temperature using the Antoine equation or similar models. - `_enthalpy_constants`: Constants for calculating enthalpy as a function of temperature. | `specific_heat()` |
+
+##### `Ammonia`
+
+Represents the properties and constants for Ammonia ($NH_3$). This class provides a comprehensive set of physical and thermodynamic properties for Ammonia, which are essential for various process engineering calculations. These properties are stored as class attributes and are available for use by other calculation modules within the ProcessPI library. **Properties:** - `name`: The common name of the compound. - `formula`: The chemical formula. - `molecular_weight`: The molar mass in g/mol. - `_critical_temperature`: The critical temperature, above which a substance cannot exist as a liquid, regardless of pressure. - `_critical_pressure`: The critical pressure, the vapor pressure at the critical temperature. - `_critical_volume`: The critical volume per kmole. - `_critical_zc`: The critical compressibility factor. - `_critical_acentric_factor`: The acentric factor, a measure of the non-sphericity of the molecule. - `_density_constants`: Constants for calculating density as a function of temperature. - `_specific_heat_constants`: Constants for calculating specific heat capacity as a function of temperature. - `_viscosity_constants`: Constants for calculating viscosity as a function of temperature. - `_thermal_conductivity_constants`: Constants for calculating thermal conductivity as a function of temperature. - `_vapor_pressure_constants`: Constants for calculating vapor pressure as a function of temperature using the Antoine equation or similar models. - `_enthalpy_constants`: Constants for calculating enthalpy as a function of temperature.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `specific_heat` | `specific_heat(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.base`
+
+**Source:** `processpi/components/base.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `PropertyMethod` | `PropertyMethod(self, func)` | Descriptor that allows both property-style and method-style access. Example: @PropertyMethod def density(self): return 100 # obj.density -> 100 # obj.density() -> 100 | — |
+| `Component` | `Component(self, temperature: Temperature=None, pressure: Pressure=None, density: Density=None, specific_heat: SpecificHeat=None, viscosity: Viscosity=None, thermal_conductivity: ThermalConductivity=None, vapor_pressure: Pressure=None, enthalpy: HeatOfVaporization=None)` | Abstract base class for a chemical component with DIPPR-style property methods. | `name()`, `formula()`, `molecular_weight()`, `phase()`, `density()`, `specific_heat()`, `viscosity()`, `thermal_conductivity()`, `vapor_pressure()`, `enthalpy()` |
+
+##### `PropertyMethod`
+
+Descriptor that allows both property-style and method-style access. Example: @PropertyMethod def density(self): return 100 # obj.density -> 100 # obj.density() -> 100
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `Component`
+
+Abstract base class for a chemical component with DIPPR-style property methods.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `name` | `name(self)` | No source docstring provided. |
+| `formula` | `formula(self)` | No source docstring provided. |
+| `molecular_weight` | `molecular_weight(self)` | No source docstring provided. |
+| `phase` | `phase(self)` | Detects phase based on system pressure and vapor pressure. Returns: "gas" or "liquid" |
+| `density` | `density(self)` | Returns density (kg/m³): - Gas: Ideal Gas Law (PV = nRT) - Liquid: DIPPR correlation |
+| `specific_heat` | `specific_heat(self)` | No source docstring provided. |
+| `viscosity` | `viscosity(self)` | Returns viscosity (Pa·s): - Liquid: DIPPR correlation - Gas: Sutherland approximation |
+| `thermal_conductivity` | `thermal_conductivity(self)` | No source docstring provided. |
+| `vapor_pressure` | `vapor_pressure(self)` | No source docstring provided. |
+| `enthalpy` | `enthalpy(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.benzene`
+
+**Source:** `processpi/components/benzene.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Benzene` | `Benzene(...)` | Represents the chemical component Benzene ($C_6H_6$). This class provides a comprehensive set of physical and thermodynamic properties for Benzene, including its molecular weight, critical properties, and constants for various property calculations. | `specific_heat()`, `hx_data()`, `httype()` |
+
+##### `Benzene`
+
+Represents the chemical component Benzene ($C_6H_6$). This class provides a comprehensive set of physical and thermodynamic properties for Benzene, including its molecular weight, critical properties, and constants for various property calculations.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `specific_heat` | `specific_heat(self)` | Calculates the specific heat of Benzene at a given temperature. The calculation uses a polynomial fit for specific heat ($C_p$) as a function of temperature. The function selects a set of constants based on the provided temperature value to ensure accuracy. Args: temperature (Temperature): The temperature at which to calculate the specific heat, in Kelvin. Returns: SpecificHeat: The calculated specific heat in units of J/kgK. |
+| `hx_data` | `hx_data(self)` | No source docstring provided. |
+| `httype` | `httype(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.benzoicacid`
+
+**Source:** `processpi/components/benzoicacid.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `BenzoicAcid` | `BenzoicAcid(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `BenzoicAcid`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.bromine`
+
+**Source:** `processpi/components/bromine.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Bromine` | `Bromine(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `Bromine`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.butane`
+
+**Source:** `processpi/components/butane.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Butane` | `Butane(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `Butane`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.carbondioxide`
+
+**Source:** `processpi/components/carbondioxide.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Carbondioxide` | `Carbondioxide(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `Carbondioxide`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.carbonmonoxide`
+
+**Source:** `processpi/components/carbonmonoxide.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `CarbonMonoxide` | `CarbonMonoxide(...)` | No source docstring provided. See module purpose and examples. | `specific_heat()` |
+
+##### `CarbonMonoxide`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `specific_heat` | `specific_heat(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.carbontetrachloride`
+
+**Source:** `processpi/components/carbontetrachloride.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `CarbonTetrachloride` | `CarbonTetrachloride(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `CarbonTetrachloride`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.chlorine`
+
+**Source:** `processpi/components/chlorine.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Chlorine` | `Chlorine(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `Chlorine`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.chlorobenzene`
+
+**Source:** `processpi/components/chlorobenzene.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ChloroBenzene` | `ChloroBenzene(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `ChloroBenzene`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.chloroform`
+
+**Source:** `processpi/components/chloroform.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Chloroform` | `Chloroform(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `Chloroform`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.chloromethane`
+
+**Source:** `processpi/components/chloromethane.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ChloroMethane` | `ChloroMethane(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `ChloroMethane`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.constants`
+
+**Source:** `processpi/components/constants.py`
+
+**Purpose:** Physical constants used across Components.
+
+No public classes or functions discovered in this module.
+
+### `processpi.components.cyanogen`
+
+**Source:** `processpi/components/cyanogen.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Cyanogen` | `Cyanogen(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `Cyanogen`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.cyclohexene`
+
+**Source:** `processpi/components/cyclohexene.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Cyclohexane` | `Cyclohexane(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `Cyclohexane`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.ethane`
+
+**Source:** `processpi/components/ethane.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Ethane` | `Ethane(...)` | No source docstring provided. See module purpose and examples. | `specific_heat()` |
+
+##### `Ethane`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `specific_heat` | `specific_heat(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.ethanol`
+
+**Source:** `processpi/components/ethanol.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Ethanol` | `Ethanol(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `Ethanol`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.ethylacetate`
+
+**Source:** `processpi/components/ethylacetate.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `EthlylAcetate` | `EthlylAcetate(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `EthlylAcetate`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.ethylene`
+
+**Source:** `processpi/components/ethylene.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Ethlylene` | `Ethlylene(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `Ethlylene`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.fluorine`
+
+**Source:** `processpi/components/fluorine.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Fluorine` | `Fluorine(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `Fluorine`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.fluorobenzene`
+
+**Source:** `processpi/components/fluorobenzene.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `FluoroBenzene` | `FluoroBenzene(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `FluoroBenzene`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.formicacid`
+
+**Source:** `processpi/components/formicacid.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `FormicAcid` | `FormicAcid(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `FormicAcid`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.gas`
+
+**Source:** `processpi/components/gas.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Gas` | `Gas(...)` | No source docstring provided. See module purpose and examples. | `density()` |
+
+##### `Gas`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `density` | `density(self)` | Density for a generic gas using the ideal gas equation: rho = (P * M) / (R * T) |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.inorganic_liquid`
+
+**Source:** `processpi/components/inorganic_liquid.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `InorganicLiquid` | `InorganicLiquid(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `InorganicLiquid`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.methanol`
+
+**Source:** `processpi/components/methanol.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Methanol` | `Methanol(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `Methanol`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.oil`
+
+**Source:** `processpi/components/oil.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Oil` | `Oil(...)` | No source docstring provided. See module purpose and examples. | `hx_data()`, `httype()` |
+
+##### `Oil`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `hx_data` | `hx_data(self)` | No source docstring provided. |
+| `httype` | `httype(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.organic_liquid`
+
+**Source:** `processpi/components/organic_liquid.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `OrganicLiquid` | `OrganicLiquid(...)` | No source docstring provided. See module purpose and examples. | `hx_data()`, `httype()` |
+
+##### `OrganicLiquid`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `hx_data` | `hx_data(self)` | No source docstring provided. |
+| `httype` | `httype(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.steam`
+
+**Source:** `processpi/components/steam.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Steam` | `Steam(self, temperature: Temperature=None, pressure: Pressure=None, phase: Literal['liquid', 'vapor']='vapor')` | No source docstring provided. See module purpose and examples. | `density()`, `specific_heat()`, `viscosity()`, `thermal_conductivity()`, `vapor_pressure()`, `enthalpy()` |
+
+##### `Steam`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `density` | `density(self)` | No source docstring provided. |
+| `specific_heat` | `specific_heat(self)` | No source docstring provided. |
+| `viscosity` | `viscosity(self)` | No source docstring provided. |
+| `thermal_conductivity` | `thermal_conductivity(self)` | No source docstring provided. |
+| `vapor_pressure` | `vapor_pressure(self)` | No source docstring provided. |
+| `enthalpy` | `enthalpy(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.toluene`
+
+**Source:** `processpi/components/toluene.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Toluene` | `Toluene(...)` | No source docstring provided. See module purpose and examples. | `hx_data()`, `httype()` |
+
+##### `Toluene`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `hx_data` | `hx_data(self)` | No source docstring provided. |
+| `httype` | `httype(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.vapor`
+
+**Source:** `processpi/components/vapor.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Vapor` | `Vapor(...)` | No source docstring provided. See module purpose and examples. | — |
+
+##### `Vapor`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.components.water`
+
+**Source:** `processpi/components/water.py`
+
+**Purpose:** Chemical component/property model with DIPPR-style constants or category defaults.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Water` | `Water(...)` | No source docstring provided. See module purpose and examples. | `density()`, `hx_data()`, `httype()` |
+
+##### `Water`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `density` | `density(self, temperature: Temperature=None)` | No source docstring provided. |
+| `hx_data` | `hx_data(self)` | No source docstring provided. |
+| `httype` | `httype(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.

--- a/docs/api/constants.md
+++ b/docs/api/constants.md
@@ -1,0 +1,22 @@
+# `processpi.constants` API
+
+## Overview
+
+ProcessPI module.
+
+### Design assumptions and limitations
+
+- Calculations generally expect engineering quantities in the units documented by the corresponding class constructor or module examples.
+- Unit wrapper objects expose `.to("unit")`; many higher-level models accept either ProcessPI unit objects or numeric SI values depending on context.
+- Validation is implemented in each class through `validate_inputs()` or constructor checks where available; invalid or missing inputs generally raise `ValueError`, `TypeError`, or `NotImplementedError`.
+- The API reference below is generated from source signatures and public names. If a class has limited source docstrings, consult its examples and calculation result keys for engineering interpretation.
+
+## Public modules
+
+### `processpi.constants`
+
+**Source:** `processpi/constants.py`
+
+**Purpose:** ProcessPI module.
+
+No public classes or functions discovered in this module.

--- a/docs/api/equipment.md
+++ b/docs/api/equipment.md
@@ -1,0 +1,318 @@
+# `processpi.equipment` API
+
+## Overview
+
+ProcessPI module.
+
+### Design assumptions and limitations
+
+- Calculations generally expect engineering quantities in the units documented by the corresponding class constructor or module examples.
+- Unit wrapper objects expose `.to("unit")`; many higher-level models accept either ProcessPI unit objects or numeric SI values depending on context.
+- Validation is implemented in each class through `validate_inputs()` or constructor checks where available; invalid or missing inputs generally raise `ValueError`, `TypeError`, or `NotImplementedError`.
+- The API reference below is generated from source signatures and public names. If a class has limited source docstrings, consult its examples and calculation result keys for engineering interpretation.
+
+## Public modules
+
+### `processpi.equipment.__init__`
+
+**Source:** `processpi/equipment/__init__.py`
+
+**Purpose:** Equipment package for ProcessPI v0.3.0.
+
+No public classes or functions discovered in this module.
+
+### `processpi.equipment.base`
+
+**Source:** `processpi/equipment/base.py`
+
+**Purpose:** ProcessPI module.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `PortMap` | `PortMap(self, names: Optional[Iterable[str]]=None)` | Dict-like port container with backward compatibility for list-style indexing. - Preferred usage: map by port name, e.g. ``ports['in']``. - Legacy compatibility: integer index access remains supported, e.g. ``ports[0]``. - Iteration yields stream values (legacy list-like behavior). | `add_port()`, `has_port()`, `values_ordered()` |
+| `Equipment` | `Equipment(self, name: str, inlet_ports: int=0, outlet_ports: int=0, inlet_names: Optional[List[str]]=None, outlet_names: Optional[List[str]]=None)` | Base class for all equipment units. Canonical interface: - self.inlets: dict[str, MaterialStream\|None] - self.outlets: dict[str, MaterialStream\|None] Backward compatibility: - list-style indexing (e.g., ``self.inlets[0]``) still works via PortMap. | `connect_inlet()`, `connect_outlet()`, `attach_stream()` |
+
+##### `PortMap`
+
+Dict-like port container with backward compatibility for list-style indexing. - Preferred usage: map by port name, e.g. ``ports['in']``. - Legacy compatibility: integer index access remains supported, e.g. ``ports[0]``. - Iteration yields stream values (legacy list-like behavior).
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `add_port` | `add_port(self, name: str)` | No source docstring provided. |
+| `has_port` | `has_port(self, name: str)` | No source docstring provided. |
+| `values_ordered` | `values_ordered(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `Equipment`
+
+Base class for all equipment units. Canonical interface: - self.inlets: dict[str, MaterialStream|None] - self.outlets: dict[str, MaterialStream|None] Backward compatibility: - list-style indexing (e.g., ``self.inlets[0]``) still works via PortMap.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `connect_inlet` | `connect_inlet(self, port_name: str, stream: MaterialStream)` | No source docstring provided. |
+| `connect_outlet` | `connect_outlet(self, port_name: str, stream: MaterialStream)` | No source docstring provided. |
+| `attach_stream` | `attach_stream(self, stream: MaterialStream, port: Literal['inlet', 'outlet'], index: int=0)` | Backward-compatible stream attach by indexed port. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.equipment.heatexchangers.__init__`
+
+**Source:** `processpi/equipment/heatexchangers/__init__.py`
+
+**Purpose:** Heat-exchanger equipment models for thermal sizing, hydraulic checks, rating, and phase-change services.
+
+No public classes or functions discovered in this module.
+
+### `processpi.equipment.heatexchangers.base`
+
+**Source:** `processpi/equipment/heatexchangers/base.py`
+
+**Purpose:** Heat-exchanger equipment models for thermal sizing, hydraulic checks, rating, and phase-change services.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `HeatExchangerBaseMixin` | `HeatExchangerBaseMixin(...)` | No source docstring provided. See module purpose and examples. | — |
+| `HeatExchanger` | `HeatExchanger(self, hot_in: MaterialStream, cold_in: MaterialStream, hot_out: Optional[MaterialStream]=None, cold_out: Optional[MaterialStream]=None, **specs: Any)` | No source docstring provided. See module purpose and examples. | `heat_duty()`, `lmtd()`, `area()`, `overall_u()`, `design()` |
+
+##### `HeatExchangerBaseMixin`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `HeatExchanger`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `heat_duty` | `heat_duty(self, hot: Dict[str, float], cold: Dict[str, float])` | No source docstring provided. |
+| `lmtd` | `lmtd(self, th_in: float, th_out: float, tc_in: float, tc_out: float)` | No source docstring provided. |
+| `area` | `area(self, q_w: float, u: float, dtlm: float)` | No source docstring provided. |
+| `overall_u` | `overall_u(self, h_tube: float, h_shell: float, fouling_factor: float=0.0)` | No source docstring provided. |
+| `design` | `design(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.equipment.heatexchangers.bell_delaware`
+
+**Source:** `processpi/equipment/heatexchangers/bell_delaware.py`
+
+**Purpose:** Heat-exchanger equipment models for thermal sizing, hydraulic checks, rating, and phase-change services.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `BellDelawareHX` | `BellDelawareHX(...)` | No source docstring provided. See module purpose and examples. | `design()` |
+
+##### `BellDelawareHX`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `design` | `design(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.equipment.heatexchangers.condenser`
+
+**Source:** `processpi/equipment/heatexchangers/condenser.py`
+
+**Purpose:** Heat-exchanger equipment models for thermal sizing, hydraulic checks, rating, and phase-change services.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `CondenserHX` | `CondenserHX(self, *args: Any, method: str='kern', **kwargs: Any)` | Production-oriented shell-and-tube condenser with phase-change safeguards. | `design()`, `rate()` |
+
+##### `CondenserHX`
+
+Production-oriented shell-and-tube condenser with phase-change safeguards.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `design` | `design(self)` | No source docstring provided. |
+| `rate` | `rate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.equipment.heatexchangers.double_pipe`
+
+**Source:** `processpi/equipment/heatexchangers/double_pipe.py`
+
+**Purpose:** Heat-exchanger equipment models for thermal sizing, hydraulic checks, rating, and phase-change services.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `DoublePipeHX` | `DoublePipeHX(...)` | No source docstring provided. See module purpose and examples. | `design()`, `rate()` |
+
+##### `DoublePipeHX`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `design` | `design(self)` | No source docstring provided. |
+| `rate` | `rate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.equipment.heatexchangers.engine`
+
+**Source:** `processpi/equipment/heatexchangers/engine.py`
+
+**Purpose:** Heat-exchanger equipment models for thermal sizing, hydraulic checks, rating, and phase-change services.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `HeatExchangerResults` | `HeatExchangerResults(...)` | No source docstring provided. See module purpose and examples. | `summary()`, `detailed_summary()`, `trace()`, `debug_summary()` |
+| `HeatExchangerEngine` | `HeatExchangerEngine(self, name: Optional[str]=None, method: str='kern', **kwargs: Any)` | No source docstring provided. See module purpose and examples. | `fit()`, `run()`, `summary()`, `results()` |
+
+##### `HeatExchangerResults`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `summary` | `summary(self)` | No source docstring provided. |
+| `detailed_summary` | `detailed_summary(self)` | No source docstring provided. |
+| `trace` | `trace(self)` | No source docstring provided. |
+| `debug_summary` | `debug_summary(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `HeatExchangerEngine`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `fit` | `fit(self, hot_in: MaterialStream, cold_in: MaterialStream, hot_out: Optional[MaterialStream]=None, cold_out: Optional[MaterialStream]=None, hx_type: Optional[str]=None, **kwargs: Any)` | No source docstring provided. |
+| `run` | `run(self)` | No source docstring provided. |
+| `summary` | `summary(self)` | No source docstring provided. |
+| `results` | `results(self)` | Return design results |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.equipment.heatexchangers.evaporator`
+
+**Source:** `processpi/equipment/heatexchangers/evaporator.py`
+
+**Purpose:** Heat-exchanger equipment models for thermal sizing, hydraulic checks, rating, and phase-change services.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `EvaporatorHX` | `EvaporatorHX(self, *args: Any, method: str='kern', **kwargs: Any)` | No source docstring provided. See module purpose and examples. | `design()`, `rate()` |
+
+##### `EvaporatorHX`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `design` | `design(self)` | No source docstring provided. |
+| `rate` | `rate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.equipment.heatexchangers.reboiler`
+
+**Source:** `processpi/equipment/heatexchangers/reboiler.py`
+
+**Purpose:** Heat-exchanger equipment models for thermal sizing, hydraulic checks, rating, and phase-change services.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ReboilerHX` | `ReboilerHX(self, *args: Any, method: str='kern', **kwargs: Any)` | Shell-and-tube reboiler built from Evaporator phase-change architecture. | `design()`, `rate()` |
+
+##### `ReboilerHX`
+
+Shell-and-tube reboiler built from Evaporator phase-change architecture.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `design` | `design(self)` | No source docstring provided. |
+| `rate` | `rate(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.equipment.heatexchangers.shell_and_tube`
+
+**Source:** `processpi/equipment/heatexchangers/shell_and_tube.py`
+
+**Purpose:** Heat-exchanger equipment models for thermal sizing, hydraulic checks, rating, and phase-change services.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ShellAndTubeHX` | `ShellAndTubeHX(self, *args: Any, method: str='kern', **kwargs: Any)` | No source docstring provided. See module purpose and examples. | `rate()`, `design()` |
+
+##### `ShellAndTubeHX`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `rate` | `rate(self)` | No source docstring provided. |
+| `design` | `design(self)` | Main design entry point for Shell & Tube HX. Supports: - Kern method - Bell-Delaware method Returns: Dict[str, Any] |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.equipment.heatexchangers.standards`
+
+**Source:** `processpi/equipment/heatexchangers/standards.py`
+
+**Purpose:** Heat-exchanger equipment models for thermal sizing, hydraulic checks, rating, and phase-change services.
+
+#### Functions
+
+| Function | Signature | Description |
+| --- | --- | --- |
+| `get_u_range` | `get_u_range(hx_type: str, service_type: str, hot_type: str, cold_type: str)` | No source docstring provided. |
+| `get_velocity_range` | `get_velocity_range(component)` | No source docstring provided. |
+| `select_tube_configuration` | `select_tube_configuration(area_required, hot, cold)` | No source docstring provided. |
+| `tube_length_select` | `tube_length_select(tube_length, ld)` | No source docstring provided. |
+| `get_fouling_factor` | `get_fouling_factor(fluid_key: str, velocity: float | None=None, temperature: float | None=None, database: dict | None=None, debug: bool=True)` | Returns fouling factor based on ProcessPI fouling standards. Parameters ---------- fluid_key : str Fluid/service lookup key. Example: "water" "treated_water" "hydrocarbons" "crude" velocity : float, optional Fluid velocity in m/s. temperature : float, optional Fluid temperature in °C. database : dict, optional Fouling factor database. debug : bool Print debug messages. Returns ------- float Fouling factor in m2.K/W |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,23 @@
+# API Reference
+
+
+This reference was regenerated from the Python source inventory. It is intentionally module-oriented so every public package, module, class, function, and method discovered under `processpi/` is discoverable from the documentation.
+
+## Packages
+
+- [__init__](./__init__.md)
+- [calculations](./calculations.md)
+- [cli](./cli.md)
+- [components](./components.md)
+- [constants](./constants.md)
+- [equipment](./equipment.md)
+- [integration](./integration.md)
+- [pipelines](./pipelines.md)
+- [streams](./streams.md)
+- [units](./units.md)
+
+## Source-of-truth audit notes
+
+- The implemented top-level packages are `calculations`, `components`, `equipment`, `integration`, `pipelines`, `streams`, and `units`.
+- Requested names such as `processpi.hx`, `processpi.thermo`, `processpi.fluids`, `processpi.hydraulics`, `processpi.piping`, `processpi.pumps`, `processpi.correlations`, `processpi.materials`, and `processpi.properties` are not implemented as importable top-level packages in this repository; equivalent capabilities live under `processpi.equipment.heatexchangers`, `processpi.calculations.*`, `processpi.pipelines.*`, and `processpi.components`.
+- Public API includes class methods and module functions that do not start with an underscore; internal helper methods are intentionally excluded from the tabular reference.

--- a/docs/api/integration.md
+++ b/docs/api/integration.md
@@ -1,0 +1,52 @@
+# `processpi.integration` API
+
+## Overview
+
+Flowsheet integration layer for connecting equipment and streams.
+
+### Design assumptions and limitations
+
+- Calculations generally expect engineering quantities in the units documented by the corresponding class constructor or module examples.
+- Unit wrapper objects expose `.to("unit")`; many higher-level models accept either ProcessPI unit objects or numeric SI values depending on context.
+- Validation is implemented in each class through `validate_inputs()` or constructor checks where available; invalid or missing inputs generally raise `ValueError`, `TypeError`, or `NotImplementedError`.
+- The API reference below is generated from source signatures and public names. If a class has limited source docstrings, consult its examples and calculation result keys for engineering interpretation.
+
+## Public modules
+
+### `processpi.integration.__init__`
+
+**Source:** `processpi/integration/__init__.py`
+
+**Purpose:** Integration utilities such as flowsheet management.
+
+No public classes or functions discovered in this module.
+
+### `processpi.integration.flowsheet`
+
+**Source:** `processpi/integration/flowsheet.py`
+
+**Purpose:** Flowsheet integration layer for connecting equipment and streams.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Flowsheet` | `Flowsheet(self, name: str)` | A flowsheet manager for sequential simulation. Responsibilities: - Hold equipment + streams - Define explicit connections - Auto-build execution order from connections - Run equipment automatically - Collect results for summary | `add_equipment()`, `add_material_stream()`, `add_energy_stream()`, `connect()`, `run()`, `solve_sequential()`, `summary()` |
+
+##### `Flowsheet`
+
+A flowsheet manager for sequential simulation. Responsibilities: - Hold equipment + streams - Define explicit connections - Auto-build execution order from connections - Run equipment automatically - Collect results for summary
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `add_equipment` | `add_equipment(self, unit: Equipment)` | No source docstring provided. |
+| `add_material_stream` | `add_material_stream(self, stream: MaterialStream)` | No source docstring provided. |
+| `add_energy_stream` | `add_energy_stream(self, stream: EnergyStream)` | No source docstring provided. |
+| `connect` | `connect(self, *args)` | Connect stream between units using named ports. Preferred signature: connect(stream, from_unit, from_port, to_unit, to_port) Backward-compatible signature: connect(stream, to_unit, to_port) |
+| `run` | `run(self)` | Topologically sorted flowsheet solve. |
+| `solve_sequential` | `solve_sequential(self)` | Simple sequential solve in registration order. |
+| `summary` | `summary(self)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.

--- a/docs/api/pipelines.md
+++ b/docs/api/pipelines.md
@@ -1,0 +1,455 @@
+# `processpi.pipelines` API
+
+## Overview
+
+Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+### Design assumptions and limitations
+
+- Calculations generally expect engineering quantities in the units documented by the corresponding class constructor or module examples.
+- Unit wrapper objects expose `.to("unit")`; many higher-level models accept either ProcessPI unit objects or numeric SI values depending on context.
+- Validation is implemented in each class through `validate_inputs()` or constructor checks where available; invalid or missing inputs generally raise `ValueError`, `TypeError`, or `NotImplementedError`.
+- The API reference below is generated from source signatures and public names. If a class has limited source docstrings, consult its examples and calculation result keys for engineering interpretation.
+
+## Public modules
+
+### `processpi.pipelines.__init__`
+
+**Source:** `processpi/pipelines/__init__.py`
+
+**Purpose:** ProcessPI Pipelines Module ========================== Provides core components for the fluid flow simulation engine, including: - Pipeline elements: Pipe, Pump, Vessel, Junction - Main engine: PipelineEngine for simulations and analysis Example: from processpi.pipelines import PipelineEngine, Pipe, Pump
+
+No public classes or functions discovered in this module.
+
+### `processpi.pipelines.base`
+
+**Source:** `processpi/pipelines/base.py`
+
+**Purpose:** Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `PipelineBase` | `PipelineBase(self, name: Optional[str]=None, **kwargs: Any)` | Abstract base class for all pipeline-related components and calculations in the ProcessPI simulation suite. Provides: - A unified way to store metadata like `name` - A flexible params dictionary for input configuration - Utility methods for safe parameter access and validation | `calculate()`, `get_param()`, `validate_required()` |
+
+##### `PipelineBase`
+
+Abstract base class for all pipeline-related components and calculations in the ProcessPI simulation suite. Provides: - A unified way to store metadata like `name` - A flexible params dictionary for input configuration - Utility methods for safe parameter access and validation
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `calculate` | `calculate(self)` | Perform the core calculation for the pipeline object. Must be implemented by subclasses. Returns: dict: A dictionary containing calculation results. |
+| `get_param` | `get_param(self, key: str, default: Any=None)` | Retrieve a parameter safely with a default fallback. Args: key (str): Parameter name. default (Any, optional): Value to return if key not found. Returns: Any: The parameter value or default. |
+| `validate_required` | `validate_required(self, required_keys: list[str])` | Validate that required parameters are present in `self.params`. Args: required_keys (list[str]): Required parameter names. Raises: ValueError: If any required parameters are missing. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.pipelines.design_rules`
+
+**Source:** `processpi/pipelines/design_rules.py`
+
+**Purpose:** Design rules module for ProcessPi pipelines. This module defines reusable validation rules for pipeline steps, ensuring that each step is well-formed, inputs/outputs are consistent, and parameters meet expected requirements.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `DesignRuleError` | `DesignRuleError(...)` | Custom exception for design rule violations. | — |
+| `DesignRules` | `DesignRules(...)` | Provides static design rule checks for pipeline steps and configurations. | `validate_step_name()`, `validate_inputs_outputs()`, `validate_parameters()`, `validate_callable()`, `validate_pipeline_consistency()`, `summary()` |
+
+##### `DesignRuleError`
+
+Custom exception for design rule violations.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `DesignRules`
+
+Provides static design rule checks for pipeline steps and configurations.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `validate_step_name` | `validate_step_name(name: str)` | Ensures that the step name is valid (non-empty and alphanumeric with underscores). |
+| `validate_inputs_outputs` | `validate_inputs_outputs(inputs: List[str], outputs: List[str])` | Ensures that inputs and outputs are lists of non-empty strings and do not overlap. |
+| `validate_parameters` | `validate_parameters(params: Dict[str, Any], required: List[str]=None)` | Ensures that required parameters are present. |
+| `validate_callable` | `validate_callable(func: Callable, name: str='')` | Ensures that a provided function or callable is valid. |
+| `validate_pipeline_consistency` | `validate_pipeline_consistency(steps: List[Dict[str, Any]])` | Checks that pipeline steps are connected properly, with consistent data flow. |
+| `summary` | `summary()` | Returns a summary of available design rules. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.pipelines.engine`
+
+**Source:** `processpi/pipelines/engine.py`
+
+**Purpose:** Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ElementReport` | `ElementReport(...)` | A data class to store the results of a single pipeline element calculation. | `as_dict()` |
+| `PipelineEngine` | `PipelineEngine(self, **kwargs: Any)` | Pipeline simulation and sizing engine. This class provides a comprehensive set of tools for modeling fluid flow in pipelines. It can handle single pipes, series networks, and parallel networks, calculating pressure drop, velocity, Reynolds number, and other key fluid properties. Usage: 1. Instantiate the engine: `engine = PipelineEngine()` 2. Configure inputs with `.fit()`: `engine.fit(fluid=water, flowrate=1.0)` 3. Run the simulation: `results = engine.run()` 4. Access results: `results.summary()` The object stores the last results in `self._results` (PipelineResults). | `fit()`, `run()`, `summary()` |
+
+##### `ElementReport`
+
+A data class to store the results of a single pipeline element calculation.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `as_dict` | `as_dict(self)` | Convert the dataclass to a dictionary. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `PipelineEngine`
+
+Pipeline simulation and sizing engine. This class provides a comprehensive set of tools for modeling fluid flow in pipelines. It can handle single pipes, series networks, and parallel networks, calculating pressure drop, velocity, Reynolds number, and other key fluid properties. Usage: 1. Instantiate the engine: `engine = PipelineEngine()` 2. Configure inputs with `.fit()`: `engine.fit(fluid=water, flowrate=1.0)` 3. Run the simulation: `results = engine.run()` 4. Access results: `results.summary()` The object stores the last results in `self._results` (PipelineResults).
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `fit` | `fit(self, **kwargs: Any)` | Configures engine inputs with unit-aware conversions and normalized keys. Args: **kwargs: Input parameters (e.g., flowrate, diameter, network). Returns: PipelineEngine: The configured engine instance. Raises: TypeError: If the provided network is not a PipelineNetwork. |
+| `run` | `run(self)` | Execute pipeline simulation and return PipelineResults with all losses included. |
+| `summary` | `summary(self)` | Returns the summary of the last run. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.pipelines.equipment`
+
+**Source:** `processpi/pipelines/equipment.py`
+
+**Purpose:** Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Equipment` | `Equipment(self, name: str, pressure_drop: float=0.0, description: str='')` | Represents a generic piece of inline process equipment within a fluid flow network, such as a heat exchanger, filter, or control valve. This class models the equipment as a component that causes a fixed pressure drop. It also includes attributes to define its connections within a network. | `add_inlet()`, `add_outlet()` |
+
+##### `Equipment`
+
+Represents a generic piece of inline process equipment within a fluid flow network, such as a heat exchanger, filter, or control valve. This class models the equipment as a component that causes a fixed pressure drop. It also includes attributes to define its connections within a network.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `add_inlet` | `add_inlet(self, node: Any)` | Adds a node to the list of inlet connections. Args: node (Any): The node object to connect as an inlet. |
+| `add_outlet` | `add_outlet(self, node: Any)` | Adds a node to the list of outlet connections. Args: node (Any): The node object to connect as an outlet. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.pipelines.fittings`
+
+**Source:** `processpi/pipelines/fittings.py`
+
+**Purpose:** Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Fitting` | `Fitting(self, fitting_type: str, diameter: Optional[Diameter]=None, quantity: int=1)` | Represents a pipe fitting for head loss and equivalent length calculations. | `equivalent_length()`, `k_factor()`, `calculate()` |
+
+##### `Fitting`
+
+Represents a pipe fitting for head loss and equivalent length calculations.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `equivalent_length` | `equivalent_length(self)` | Returns the equivalent length (Le) for the fitting type. If Le depends on diameter and diameter is missing, raises a ValueError. |
+| `k_factor` | `k_factor(self)` | Returns the K-factor for the fitting type. If K depends on diameter and diameter is missing, raises a ValueError. |
+| `calculate` | `calculate(self)` | Returns a summary dictionary with fitting data and calculated values. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.pipelines.insulation`
+
+**Source:** `processpi/pipelines/insulation.py`
+
+**Purpose:** Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+No public classes or functions discovered in this module.
+
+### `processpi.pipelines.materials`
+
+**Source:** `processpi/pipelines/materials.py`
+
+**Purpose:** Pipeline Materials Specifications and Properties This module contains physical and mechanical properties of pipeline materials commonly used in process industries. All values are representative and may vary depending on standards (ASME, ASTM, ISO) and manufacturer data.
+
+#### Functions
+
+| Function | Signature | Description |
+| --- | --- | --- |
+| `get_material_property` | `get_material_property(material: str, prop: str)` | Get a specific property of a pipeline material. Args: material (str): Material code (e.g., 'CS', 'SS316', 'PVC'). prop (str): Property name (e.g., 'density', 'roughness'). Returns: Any: Property value if found, else None. |
+| `get_material_data` | `get_material_data(material: str)` | Get all properties for a given pipeline material. Args: material (str): Material code. Returns: dict: Dictionary of material properties. |
+
+### `processpi.pipelines.network`
+
+**Source:** `processpi/pipelines/network.py`
+
+**Purpose:** Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Node` | `Node(self, name: str, elevation: float=0.0)` | Represents a connection point, junction, or endpoint in a pipeline network. Nodes have a name for identification and an elevation for calculating static head differences in the system. | — |
+| `PipelineNetwork` | `PipelineNetwork(self, name: str, connection_type: Optional[str]='series')` | A framework for defining a process pipeline network. This class provides a dual-purpose structure: 1. A **node-and-edge graph** for general network problems. 2. A **composable series/parallel block model** for easier, hierarchical construction and calculation, compatible with a `PipelineEngine`. | `series()`, `parallel()`, `add()`, `add_series()`, `add_parallel()`, `add_node()`, `get_node()`, `add_edge()`, `add_fitting()`, `add_subnetwork()`, `validate()`, `describe()`, `schematic()`, `get_all_pipes()`, `visualize_network()` |
+
+##### `Node`
+
+Represents a connection point, junction, or endpoint in a pipeline network. Nodes have a name for identification and an elevation for calculating static head differences in the system.
+
+**Methods**
+
+No public methods beyond constructor/properties were discovered.
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+##### `PipelineNetwork`
+
+A framework for defining a process pipeline network. This class provides a dual-purpose structure: 1. A **node-and-edge graph** for general network problems. 2. A **composable series/parallel block model** for easier, hierarchical construction and calculation, compatible with a `PipelineEngine`.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `series` | `series(name: str, *elements: Branch)` | Class method to create a series block pre-populated with elements. Args: name (str): The name for the series network. *elements (Branch): A variable number of elements (Pipes, Fittings, or other networks) to be added in series. Returns: PipelineNetwork: A new PipelineNetwork instance configured for series flow. |
+| `parallel` | `parallel(name: str, *branches: Branch)` | Class method to create a parallel block with pre-defined branches. Args: name (str): The name for the parallel network. *branches (Branch): A variable number of branches (elements or child networks) that exist in parallel. Returns: PipelineNetwork: A new PipelineNetwork instance configured for parallel flow. |
+| `add` | `add(self, *elements: Branch)` | A unified method to append one or more elements to the current network block. This provides a more fluent and readable interface for building. Args: *elements (Branch): One or more elements to add. Returns: PipelineNetwork: The current network instance, allowing for method chaining. |
+| `add_series` | `add_series(self, *elements: Branch)` | Adds a series group to the network. If the current network is a series block, it appends the new elements directly. If it is a parallel block, it wraps the new elements in a child series network, which is then added as a branch. This preserves the correct hierarchical structure. Args: *elements (Branch): The elements to add to the series group. Returns: PipelineNetwork: The current network instance for chaining. |
+| `add_parallel` | `add_parallel(self, *branches: Branch)` | Adds a parallel group to the network. If the current network is a parallel block, it appends the new branches directly. If it is a series block, it wraps the new branches in a child parallel network, which is then added as a single element. Args: *branches (Branch): The branches (elements or networks) to add to the parallel group. Returns: PipelineNetwork: The current network instance for chaining. |
+| `add_node` | `add_node(self, name: str, elevation: float=0.0)` | Adds a new node (junction) to the network's internal node dictionary. Args: name (str): The unique name of the node. elevation (float, optional): The elevation in meters. Defaults to 0.0. Returns: Node: The newly created Node object. Raises: ValueError: If a node with the given name already exists. |
+| `get_node` | `get_node(self, name: str)` | Fetches an existing node by name from the network's node dictionary. Args: name (str): The name of the node to retrieve. Returns: Node: The found Node object. Raises: KeyError: If the node does not exist in the network. |
+| `add_edge` | `add_edge(self, component: Union[Pipe, Pump, Vessel, Equipment], start_node: str, end_node: str)` | Adds a connection (an edge) between two existing nodes using a component. This method strictly links components that have a defined inlet and outlet to the network's nodes. It also automatically adds the component to the network's `elements` list. Args: component (Union[Pipe, Pump, Vessel, Equipment]): The component to connect. start_node (str): The name of the inlet node. end_node (str): The name of the outlet node. Raises: ValueError: If either the start or end node is not found, or if a self-loop (start=end) is attempted. TypeError: If the component type is not supported for edge creation. |
+| `add_fitting` | `add_fitting(self, fitting: Fitting, at_node: str)` | Adds a fitting to a specific node within the network. Fittings are considered zero-length elements, so they are associated with a single node rather than an edge. Args: fitting (Fitting): The fitting object to add. at_node (str): The name of the node where the fitting is located. Raises: ValueError: If the specified node does not exist. |
+| `add_subnetwork` | `add_subnetwork(self, subnetwork: 'PipelineNetwork')` | Adds an existing PipelineNetwork instance as a child element. This provides compatibility with code that constructs subnetworks separately. Args: subnetwork (PipelineNetwork): The pre-built subnetwork to add. Raises: ValueError: If the subnetwork is the same as the parent network. |
+| `validate` | `validate(self)` | Performs a comprehensive check for common network errors. This includes checking for unconnected nodes and ensuring all elements have required properties. Raises: ValueError: If any validation errors are found. The exception message will list all detected issues. |
+| `describe` | `describe(self, level: int=0)` | Returns a detailed, hierarchical string representation of the network. Args: level (int): The current indentation level for nested networks. Returns: str: A multi-line string describing the network's structure. |
+| `schematic` | `schematic(self)` | Generates an ASCII schematic representation of the network's hierarchical structure. Returns: str: A multi-line string visual representation of the network. |
+| `get_all_pipes` | `get_all_pipes(self)` | Returns a flat list of all Pipe objects in this network, including nested subnetworks. Returns: list[Pipe]: List of Pipe objects found in the network. |
+| `visualize_network` | `visualize_network(self, compact=False, width=1200, height=800)` | Interactive P&ID-style visualization using Plotly. Supports series, parallel, and circular loops. compact=True shortens node/edge labels for compact diagrams. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.pipelines.nozzle`
+
+**Source:** `processpi/pipelines/nozzle.py`
+
+**Purpose:** Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Nozzle` | `Nozzle(self, name: str, cv: float)` | No source docstring provided. See module purpose and examples. | `pressure_drop_at_flow()` |
+
+##### `Nozzle`
+
+Public class discovered from source. Constructor parameters are shown in the class table above.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `pressure_drop_at_flow` | `pressure_drop_at_flow(self, q: VolumetricFlowRate)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.pipelines.pipelineresults`
+
+**Source:** `processpi/pipelines/pipelineresults.py`
+
+**Purpose:** Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `PipelineResults` | `PipelineResults(self, results: Dict[str, Any])` | Stores pipeline simulation results with full unit safety. Supports formatted summaries, detailed component tables, and raw exports. | `pipe_diameter()`, `summary()`, `detailed_summary()` |
+
+##### `PipelineResults`
+
+Stores pipeline simulation results with full unit safety. Supports formatted summaries, detailed component tables, and raw exports.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `pipe_diameter` | `pipe_diameter(self)` | No source docstring provided. |
+| `summary` | `summary(self)` | Print and return a clean summary of results with units. |
+| `detailed_summary` | `detailed_summary(self)` | Print a component-level breakdown in table form. Supports both old-style (nested dict) and new-style (flat keys) results. Removes duplicate rows and fills missing types. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.pipelines.pipes`
+
+**Source:** `processpi/pipelines/pipes.py`
+
+**Purpose:** Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Pipe` | `Pipe(self, name: str, nominal_diameter: Optional[Diameter]=None, schedule: str='STD', material: str='CS', length: Optional[Length]=None, inlet_pressure: Optional[Pressure]=None, outlet_pressure: Optional[Pressure]=None, internal_diameter: Optional[Diameter]=None, flow_rate: Optional[VolumetricFlowRate]=None, **kwargs: Any)` | Represents a straight section of a process pipeline. Encapsulates geometry (diameter, length), material properties (roughness), and state (inlet/outlet pressure). Useful for flow and pressure drop calculations, and compatible with optimization workflows. | `cross_sectional_area()`, `surface_area()`, `pressure_difference()`, `to_dict()`, `calculate()` |
+
+##### `Pipe`
+
+Represents a straight section of a process pipeline. Encapsulates geometry (diameter, length), material properties (roughness), and state (inlet/outlet pressure). Useful for flow and pressure drop calculations, and compatible with optimization workflows.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `cross_sectional_area` | `cross_sectional_area(self)` | Calculate internal cross-sectional area (m²). |
+| `surface_area` | `surface_area(self)` | Calculate external surface area (m²). |
+| `pressure_difference` | `pressure_difference(self)` | Calculate ΔP (inlet - outlet). |
+| `to_dict` | `to_dict(self)` | Export all key pipe data as a dictionary. |
+| `calculate` | `calculate(self)` | Return pipe data (for engine compatibility). |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.pipelines.piping_costs`
+
+**Source:** `processpi/pipelines/piping_costs.py`
+
+**Purpose:** Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `PipeCostModel` | `PipeCostModel(self, cost_data: Dict[str, Dict[str, float]])` | A simple model for calculating piping system costs based on diameter, material, and length. Costs are in dollars per meter. | `default_steel_model()`, `get_pipe_cost()`, `calculate_network_cost()` |
+
+##### `PipeCostModel`
+
+A simple model for calculating piping system costs based on diameter, material, and length. Costs are in dollars per meter.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `default_steel_model` | `default_steel_model(cls)` | Returns a predefined cost model for carbon steel pipes. |
+| `get_pipe_cost` | `get_pipe_cost(self, nominal_diameter: Union[str, float, int], material: str)` | Retrieves the cost per meter for a given pipe size and material. |
+| `calculate_network_cost` | `calculate_network_cost(self, network: PipelineNetwork)` | Calculates the total cost of all pipes in a given network. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.pipelines.pumps`
+
+**Source:** `processpi/pipelines/pumps.py`
+
+**Purpose:** Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Pump` | `Pump(self, name: str, pump_type: str, flow_rate: Optional[VolumetricFlowRate]=None, head: Optional[Length]=None, density: Optional[Density]=None, efficiency: Optional[float]=None, inlet_pressure: Optional[Pressure]=None, outlet_pressure: Optional[Pressure]=None)` | Represents a pump in a pipeline system. Attributes: name (str): The name of the pump. pump_type (str): Type of pump (e.g., 'centrifugal', 'positive_displacement'). flow_rate (Optional[FlowRate]): Volumetric flow rate. head (Optional[Length]): Pump head, representing the energy added per unit weight of fluid. density (Density): Fluid density. efficiency (float): Pump efficiency (0 < η <= 1). inlet_pressure (Optional[Pressure]): Inlet pressure to the pump. outlet_pressure (Optional[Pressure]): Outlet pressure from the pump. start_node (Optional[Any]): The node object at the pump's inlet. end_node (Optional[Any]): The node object at the pump's outlet. | `hydraulic_power()`, `brake_power()`, `to_dict()`, `calculate()` |
+
+##### `Pump`
+
+Represents a pump in a pipeline system. Attributes: name (str): The name of the pump. pump_type (str): Type of pump (e.g., 'centrifugal', 'positive_displacement'). flow_rate (Optional[FlowRate]): Volumetric flow rate. head (Optional[Length]): Pump head, representing the energy added per unit weight of fluid. density (Density): Fluid density. efficiency (float): Pump efficiency (0 < η <= 1). inlet_pressure (Optional[Pressure]): Inlet pressure to the pump. outlet_pressure (Optional[Pressure]): Outlet pressure from the pump. start_node (Optional[Any]): The node object at the pump's inlet. end_node (Optional[Any]): The node object at the pump's outlet.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `hydraulic_power` | `hydraulic_power(self)` | Calculates the hydraulic power (fluid power) delivered by the pump. Formula: P_h = ρ * g * Q * H Returns: Optional[Power]: The hydraulic power as a Power object (W), or None if flow rate or head is not defined. |
+| `brake_power` | `brake_power(self)` | Calculates the brake power (shaft power) required to drive the pump, considering its efficiency. Formula: P_b = P_h / η Returns: Optional[Power]: The brake power as a Power object (W), or None if hydraulic power cannot be calculated. |
+| `to_dict` | `to_dict(self)` | Exports pump properties and calculations as a dictionary for reporting. |
+| `calculate` | `calculate(self)` | This method serves as a wrapper to perform calculations and return the results as a dictionary. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.pipelines.selection`
+
+**Source:** `processpi/pipelines/selection.py`
+
+**Purpose:** Pipeline Material Selection Module This module provides logic for selecting appropriate pipeline materials based on design conditions such as temperature, pressure, and corrosion requirements. Uses data from materials.py
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `MaterialSelector` | `MaterialSelector(self, design_temp: float, design_pressure: float, corrosive: bool=False)` | Class for selecting suitable pipeline materials. | `filter_materials()`, `recommend_material()` |
+
+##### `MaterialSelector`
+
+Class for selecting suitable pipeline materials.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `filter_materials` | `filter_materials(self)` | Filter materials that can withstand design conditions. Returns: list: Suitable material codes. |
+| `recommend_material` | `recommend_material(self)` | Recommend the most suitable material based on design conditions. Returns: dict: Recommended material data. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.pipelines.standards`
+
+**Source:** `processpi/pipelines/standards.py`
+
+**Purpose:** Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+#### Functions
+
+| Function | Signature | Description |
+| --- | --- | --- |
+| `get_internal_diameter` | `get_internal_diameter(nominal_diameter: Diameter, schedule: str='STD')` | Returns internal diameter for a given nominal diameter and schedule. |
+| `get_thickness` | `get_thickness(nominal_diameter: Diameter, schedule: str='STD')` | Returns wall thickness for a given nominal diameter and schedule. |
+| `get_roughness` | `get_roughness(material: str)` | Returns roughness for given material. Defaults if not found. |
+| `get_recommended_velocity` | `get_recommended_velocity(service: str)` | Returns recommended velocity (m/s) for a given chemical or general service. |
+| `get_nearest_diameter` | `get_nearest_diameter(calculated_diameter: Diameter)` | Returns the nearest standard nominal diameter for a given calculated diameter. |
+| `get_standard_pipe_data` | `get_standard_pipe_data(nominal_diameter: Diameter, schedule: str='STD')` | Returns a dictionary of standard pipe properties for a given nominal size and schedule. |
+| `get_k_factor` | `get_k_factor(fitting_type: str)` | Retrieve the standard K-factor (loss coefficient) for a given fitting type. |
+| `list_available_pipe_diameters` | `list_available_pipe_diameters()` | Returns a list of all available standard nominal pipe diameters. |
+| `get_next_standard_nominal` | `get_next_standard_nominal(diameter_m: float)` | Finds the next standard nominal size >= given diameter (inner diameter basis). If no larger diameter is found, returns the largest available. |
+| `get_previous_standard_nominal` | `get_previous_standard_nominal(nominal_diameter: Diameter)` | Finds the previous standard nominal size in the sorted list. |
+| `get_next_next_standard_nominal` | `get_next_next_standard_nominal(nominal_diameter: Diameter)` | Finds the next-next standard nominal size in the sorted list. |
+| `get_standard_diameters_list` | `get_standard_diameters_list()` | Returns a sorted list of standard nominal diameters. |
+| `get_equivalent_length` | `get_equivalent_length(fitting_type: str)` | Return the equivalent length multiplier (Le/D) for a fitting type. |
+| `get_k_factor` | `get_k_factor(fitting_type: str, reynolds_number: Optional[float]=None, relative_roughness: Optional[float]=None, diameter: Optional[float]=None)` | Return the K-factor (resistance coefficient) for a fitting type. Includes logic for Reynolds number-dependent fittings. Args: fitting_type: The type of fitting. reynolds_number: Reynolds number of the flow (for fittings where K depends on Re). relative_roughness: Pipe roughness divided by diameter (not always used). diameter: Pipe internal diameter in meters. Returns: The K-factor as a float, or None if not found. |
+| `get_nominal_dia_from_internal_dia` | `get_nominal_dia_from_internal_dia(internal_diameter: Diameter, schedule: str='STD')` | Finds the nominal diameter of a pipe given its internal diameter and schedule. This function performs a reverse lookup in the PIPE_SCHEDULES data. It iterates through all nominal diameters and calculates the corresponding internal diameter for a given schedule. It returns the first nominal diameter that matches the input internal diameter. Args: internal_diameter (Diameter): The internal diameter of the pipe. schedule (str): The pipe schedule (e.g., "STD", "40", "80"). Returns: Optional[Diameter]: The nominal diameter, or None if no match is found. |
+
+### `processpi.pipelines.vessel`
+
+**Source:** `processpi/pipelines/vessel.py`
+
+**Purpose:** Pipeline, fittings, material, network, hydraulic engine, or standards helper.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Vessel` | `Vessel(self, name: str, volume: float=0.0, pressure: float=0.0, temperature: float=0.0)` | Vessel represents a storage or process vessel in a fluid network. It can have one or more inlet and outlet connections, allowing it to serve as a hub for fluid flow within a pipeline system. | `add_inlet()`, `add_outlet()` |
+
+##### `Vessel`
+
+Vessel represents a storage or process vessel in a fluid network. It can have one or more inlet and outlet connections, allowing it to serve as a hub for fluid flow within a pipeline system.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `add_inlet` | `add_inlet(self, node)` | Attaches a new inlet node to the vessel. Args: node: The node object (e.g., from a Pipe or Pump) that feeds into the vessel. |
+| `add_outlet` | `add_outlet(self, node)` | Attaches a new outlet node to the vessel. Args: node: The node object (e.g., from a Pipe or Valve) that the vessel feeds into. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.

--- a/docs/api/streams.md
+++ b/docs/api/streams.md
@@ -1,0 +1,76 @@
+# `processpi.streams` API
+
+## Overview
+
+Material or energy stream object for equipment and flowsheet integration.
+
+### Design assumptions and limitations
+
+- Calculations generally expect engineering quantities in the units documented by the corresponding class constructor or module examples.
+- Unit wrapper objects expose `.to("unit")`; many higher-level models accept either ProcessPI unit objects or numeric SI values depending on context.
+- Validation is implemented in each class through `validate_inputs()` or constructor checks where available; invalid or missing inputs generally raise `ValueError`, `TypeError`, or `NotImplementedError`.
+- The API reference below is generated from source signatures and public names. If a class has limited source docstrings, consult its examples and calculation result keys for engineering interpretation.
+
+## Public modules
+
+### `processpi.streams.__init__`
+
+**Source:** `processpi/streams/__init__.py`
+
+**Purpose:** Material or energy stream object for equipment and flowsheet integration.
+
+No public classes or functions discovered in this module.
+
+### `processpi.streams.energy`
+
+**Source:** `processpi/streams/energy.py`
+
+**Purpose:** Material or energy stream object for equipment and flowsheet integration.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `EnergyStream` | `EnergyStream(self, name: str)` | Represents an energy stream (heat or work transfer). Can bind to equipment and log Q/W duties automatically. Notes ----- * Positive duty = energy input (to equipment) * Negative duty = energy output (from equipment) * Duties are stored with units (`Power`) to ensure consistency. | `bind_equipment()`, `record()`, `total_duty()` |
+
+##### `EnergyStream`
+
+Represents an energy stream (heat or work transfer). Can bind to equipment and log Q/W duties automatically. Notes ----- * Positive duty = energy input (to equipment) * Negative duty = energy output (from equipment) * Duties are stored with units (`Power`) to ensure consistency.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `bind_equipment` | `bind_equipment(self, equipment)` | Optionally keep reference to equipment if needed later. |
+| `record` | `record(self, duty: Union[float, Power], tag: str, equipment: str)` | Log an energy duty. Parameters ---------- duty : float \| Power Energy duty (W). If float is given, assumed in watts. tag : str Label such as 'Q_in', 'Q_out', 'W_in', 'W_out'. equipment : str Name of equipment associated with this duty. |
+| `total_duty` | `total_duty(self, tag: Optional[str]=None)` | Return cumulative duty as a Power object. Optionally filter by tag. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.streams.material`
+
+**Source:** `processpi/streams/material.py`
+
+**Purpose:** Material or energy stream object for equipment and flowsheet integration.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `MaterialStream` | `MaterialStream(self, name: str, component: Optional[object]=None, pressure: Optional[Pressure]=None, temperature: Optional[Temperature]=None, density: Optional[Density]=None, specific_heat: Optional[SpecificHeat]=None, flow_rate: Optional[VolumetricFlowRate]=None, mass_flow: Optional[MassFlowRate]=None, molar_flow: Optional[MolarFlowRate]=None, composition: Optional[Dict[str, float]]=None, basis: str='mole', molecular_weights: Optional[Dict[str, float]]=None, phase: Optional[str]=None)` | Represents a process material stream with thermodynamic state and composition information. Supports two initialization modes: ----------------------------------- 1) Component-based: from processpi.components import Water s1 = MaterialStream("Hot Water", component=Water(), temperature=Temperature(350, "K"), mass_flow=MassFlowRate(2, "kg/s")) 2) Manual property-based: s2 = MaterialStream("Custom Fluid", temperature=Temperature(350, "K"), pressure=Pressure(2, "bar"), density=Density(1000, "kg/m3"), cp=HeatCapacity(4200, "J/kg-K"), flow_rate=VolumetricFlowRate(0.001, "m3/s")) | `set_composition()`, `mass_flow()`, `molar_flow()`, `avg_mw()`, `copy()` |
+
+##### `MaterialStream`
+
+Represents a process material stream with thermodynamic state and composition information. Supports two initialization modes: ----------------------------------- 1) Component-based: from processpi.components import Water s1 = MaterialStream("Hot Water", component=Water(), temperature=Temperature(350, "K"), mass_flow=MassFlowRate(2, "kg/s")) 2) Manual property-based: s2 = MaterialStream("Custom Fluid", temperature=Temperature(350, "K"), pressure=Pressure(2, "bar"), density=Density(1000, "kg/m3"), cp=HeatCapacity(4200, "J/kg-K"), flow_rate=VolumetricFlowRate(0.001, "m3/s"))
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `set_composition` | `set_composition(self, components: Dict[str, float], basis: str='mole')` | No source docstring provided. |
+| `mass_flow` | `mass_flow(self)` | No source docstring provided. |
+| `molar_flow` | `molar_flow(self)` | No source docstring provided. |
+| `avg_mw` | `avg_mw(self)` | Average molecular weight (kg/mol) from composition + MW dict |
+| `copy` | `copy(self, name: str)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.

--- a/docs/api/units.md
+++ b/docs/api/units.md
@@ -1,0 +1,606 @@
+# `processpi.units` API
+
+## Overview
+
+Engineering unit wrapper that stores a value and converts among supported units.
+
+### Design assumptions and limitations
+
+- Calculations generally expect engineering quantities in the units documented by the corresponding class constructor or module examples.
+- Unit wrapper objects expose `.to("unit")`; many higher-level models accept either ProcessPI unit objects or numeric SI values depending on context.
+- Validation is implemented in each class through `validate_inputs()` or constructor checks where available; invalid or missing inputs generally raise `ValueError`, `TypeError`, or `NotImplementedError`.
+- The API reference below is generated from source signatures and public names. If a class has limited source docstrings, consult its examples and calculation result keys for engineering interpretation.
+
+## Public modules
+
+### `processpi.units.__init__`
+
+**Source:** `processpi/units/__init__.py`
+
+**Purpose:** ProcessPI Units Module ====================== Automatically discovers and exposes all unit variable classes in this package. The base class `Variable` is always included. Example: from processpi.units import Length, Pressure, Temperature
+
+No public classes or functions discovered in this module.
+
+### `processpi.units.area`
+
+**Source:** `processpi/units/area.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Area` | `Area(self, value, units='m2')` | Represents an Area quantity. Default SI unit: Square Meter (m2). Example: a1 = Area(100, "cm2") a2 = Area(0.5, "m2") | `to()` |
+
+##### `Area`
+
+Represents an Area quantity. Default SI unit: Square Meter (m2). Example: a1 = Area(100, "cm2") a2 = Area(0.5, "m2")
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.base`
+
+**Source:** `processpi/units/base.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Variable` | `Variable(self, value: float, units: str)` | A generic physical variable with value and units. Should be subclassed for specific physical types. | `to()`, `to_base()`, `from_base()` |
+
+##### `Variable`
+
+A generic physical variable with value and units. Should be subclassed for specific physical types.
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_units: str)` | No source docstring provided. |
+| `to_base` | `to_base(self)` | No source docstring provided. |
+| `from_base` | `from_base(self, base_value: float, target_units: str)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.density`
+
+**Source:** `processpi/units/density.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Density` | `Density(self, value, units='kg/m3')` | Represents a Density quantity. Default SI unit: kilograms per cubic meter (kg/m³). Example: d1 = Density(1000) # 1000 kg/m³ d2 = Density(1, "g/cm³") # 1 gram per cubic centimeter | `to()` |
+
+##### `Density`
+
+Represents a Density quantity. Default SI unit: kilograms per cubic meter (kg/m³). Example: d1 = Density(1000) # 1000 kg/m³ d2 = Density(1, "g/cm³") # 1 gram per cubic centimeter
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.diameter`
+
+**Source:** `processpi/units/diameter.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Diameter` | `Diameter(self, value, units='m')` | Represents a Diameter quantity. Default SI unit: meters (m). | `to_base()`, `to()` |
+
+##### `Diameter`
+
+Represents a Diameter quantity. Default SI unit: meters (m).
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to_base` | `to_base(self)` | Return the base (SI) value in meters. |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.dimensionless`
+
+**Source:** `processpi/units/dimensionless.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Dimensionless` | `Dimensionless(self, value)` | Represents a dimensionless quantity (e.g., Reynolds number, friction factor). Default SI unit: none (unitless). Example: Re = Dimensionless(5000) # Reynolds number f = Dimensionless(0.02) # Friction factor | `to()` |
+
+##### `Dimensionless`
+
+Represents a dimensionless quantity (e.g., Reynolds number, friction factor). Default SI unit: none (unitless). Example: Re = Dimensionless(5000) # Reynolds number f = Dimensionless(0.02) # Friction factor
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit=None)` | Conversion is not applicable, but provided for interface consistency. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.heat_flow`
+
+**Source:** `processpi/units/heat_flow.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `HeatFlow` | `HeatFlow(self, value, units='W')` | Represents Heat Flow (total heat transfer rate). Default SI unit: W (Watts) Example: Q = HeatFlow(5000, "W") Q.to("kW") # -> 5.0 kW | `to()` |
+
+##### `HeatFlow`
+
+Represents Heat Flow (total heat transfer rate). Default SI unit: W (Watts) Example: Q = HeatFlow(5000, "W") Q.to("kW") # -> 5.0 kW
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.heat_flux`
+
+**Source:** `processpi/units/heat_flux.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `HeatFlux` | `HeatFlux(self, value, units='W/m2')` | Represents Heat Flux (heat transfer rate per unit area). Default SI unit: W/m2 (Watts per square meter) Example: q = HeatFlux(300, "W/m²") | `to()` |
+
+##### `HeatFlux`
+
+Represents Heat Flux (heat transfer rate per unit area). Default SI unit: W/m2 (Watts per square meter) Example: q = HeatFlux(300, "W/m²")
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.heat_of_vaporization`
+
+**Source:** `processpi/units/heat_of_vaporization.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `HeatOfVaporization` | `HeatOfVaporization(self, value, units='J/kg')` | Represents Heat of Vaporization. Default SI unit: J/kg (Joules per kilogram) Example: hv1 = HeatOfVaporization(2257000) # 2.257 MJ/kg hv2 = HeatOfVaporization(540, "cal/g") # 540 cal/g = ~2.259 MJ/kg | `to()` |
+
+##### `HeatOfVaporization`
+
+Represents Heat of Vaporization. Default SI unit: J/kg (Joules per kilogram) Example: hv1 = HeatOfVaporization(2257000) # 2.257 MJ/kg hv2 = HeatOfVaporization(540, "cal/g") # 540 cal/g = ~2.259 MJ/kg
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.heat_transfer_coefficient`
+
+**Source:** `processpi/units/heat_transfer_coefficient.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `HeatTransferCoefficient` | `HeatTransferCoefficient(self, value, units='W/m2K')` | Represents Heat Transfer Coefficient. Default SI unit: W/m2K (Watts per square meter-Kelvin) Example: h = HeatTransferCoefficient(200, "W/m2K") | `to()` |
+
+##### `HeatTransferCoefficient`
+
+Represents Heat Transfer Coefficient. Default SI unit: W/m2K (Watts per square meter-Kelvin) Example: h = HeatTransferCoefficient(200, "W/m2K")
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.length`
+
+**Source:** `processpi/units/length.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Length` | `Length(self, value, units='m')` | Represents a Length quantity Variable. Default SI unit: Meters (m). Example: length = Length(30) # 30 meters length = Length(30, "in") # 30 inches | `to()` |
+
+##### `Length`
+
+Represents a Length quantity Variable. Default SI unit: Meters (m). Example: length = Length(30) # 30 meters length = Length(30, "in") # 30 inches
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.mass`
+
+**Source:** `processpi/units/mass.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Mass` | `Mass(self, value, units='kg')` | Represents a Mass quantity. Default SI unit: Kilogram (kg). Example: m1 = Mass(500, "g") m2 = Mass(2, "kg") | `to()` |
+
+##### `Mass`
+
+Represents a Mass quantity. Default SI unit: Kilogram (kg). Example: m1 = Mass(500, "g") m2 = Mass(2, "kg")
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.mass_flowrate`
+
+**Source:** `processpi/units/mass_flowrate.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `MassFlowRate` | `MassFlowRate(self, value, units='kg/s')` | Represents a Mass Flow Rate quantity. Default SI unit: kilograms per second (kg/s). Example: m1 = MassFlowRate(100, "kg/h") m2 = MassFlowRate(0.5, "lb/s") | `to()` |
+
+##### `MassFlowRate`
+
+Represents a Mass Flow Rate quantity. Default SI unit: kilograms per second (kg/s). Example: m1 = MassFlowRate(100, "kg/h") m2 = MassFlowRate(0.5, "lb/s")
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.molar_flowrate`
+
+**Source:** `processpi/units/molar_flowrate.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `MolarFlowRate` | `MolarFlowRate(self, value, units='mol/s')` | Represents a Molar Flow Rate quantity. Default SI unit: mol/s. Example: n1 = MolarFlowRate(100, "mol/h") n2 = MolarFlowRate(0.5, "kmol/s") | `to()` |
+
+##### `MolarFlowRate`
+
+Represents a Molar Flow Rate quantity. Default SI unit: mol/s. Example: n1 = MolarFlowRate(100, "mol/h") n2 = MolarFlowRate(0.5, "kmol/s")
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.power`
+
+**Source:** `processpi/units/power.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Power` | `Power(self, value, units='W')` | Represents a Power quantity. Default SI unit: watt (W). Example: p1 = Power(1000) # 1000 W p2 = Power(1, "kW") # 1 kilowatt p3 = Power(0.5, "MW") # 0.5 megawatt p4 = Power(1.34, "hp") # 1.34 horsepower | `to()` |
+
+##### `Power`
+
+Represents a Power quantity. Default SI unit: watt (W). Example: p1 = Power(1000) # 1000 W p2 = Power(1, "kW") # 1 kilowatt p3 = Power(0.5, "MW") # 0.5 megawatt p4 = Power(1.34, "hp") # 1.34 horsepower
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.pressure`
+
+**Source:** `processpi/units/pressure.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Pressure` | `Pressure(self, value, units='Pa')` | Represents a Pressure quantity. Default SI unit: Pascal (Pa). Example: p1 = Pressure(1, "atm") p2 = Pressure(101325, "Pa") | `to_base()`, `from_base()`, `to()` |
+
+##### `Pressure`
+
+Represents a Pressure quantity. Default SI unit: Pascal (Pa). Example: p1 = Pressure(1, "atm") p2 = Pressure(101325, "Pa")
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to_base` | `to_base(self)` | Convert to base SI unit (Pa). |
+| `from_base` | `from_base(self, base_value: float, target_units: str)` | Convert from Pa to target units and return a Pressure object. |
+| `to` | `to(self, target_unit)` | Return new Pressure in target units. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.specific_heat`
+
+**Source:** `processpi/units/specific_heat.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `SpecificHeat` | `SpecificHeat(self, value, units='kJ/kgK')` | Represents Specific Heat Capacity. Default SI unit: kJ/kgK Example: cp1 = SpecificHeat(4.186, "kJ/kgK") cp2 = SpecificHeat(1.0, "cal/gK") | `to()` |
+
+##### `SpecificHeat`
+
+Represents Specific Heat Capacity. Default SI unit: kJ/kgK Example: cp1 = SpecificHeat(4.186, "kJ/kgK") cp2 = SpecificHeat(1.0, "cal/gK")
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.strings`
+
+**Source:** `processpi/units/strings.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `StringUnit` | `StringUnit(self, value: str, category: str='string')` | Represents a string-based categorical quantity (e.g., flow type, phase, material category). Default unit: none (string). Example: flow = StringUnit("Laminar", "flow_type") phase = StringUnit("Gas", "phase_state") | `to()` |
+
+##### `StringUnit`
+
+Represents a string-based categorical quantity (e.g., flow type, phase, material category). Default unit: none (string). Example: flow = StringUnit("Laminar", "flow_type") phase = StringUnit("Gas", "phase_state")
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit=None)` | Conversion is not applicable for string-based units. Provided only for interface consistency. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.temperature`
+
+**Source:** `processpi/units/temperature.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Temperature` | `Temperature(self, value, units='K')` | Represents a Temperature quantity. Default SI unit: Kelvin (K). Example: t1 = Temperature(100, "C") # 100°C t2 = Temperature(373.15) # 373.15 K | `to()` |
+
+##### `Temperature`
+
+Represents a Temperature quantity. Default SI unit: Kelvin (K). Example: t1 = Temperature(100, "C") # 100°C t2 = Temperature(373.15) # 373.15 K
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.thermal_conductivity`
+
+**Source:** `processpi/units/thermal_conductivity.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ThermalConductivity` | `ThermalConductivity(self, value, units='W/mK')` | Represents Thermal Conductivity of a material. Default SI unit: W/mK (Watts per meter-Kelvin) Example: k = ThermalConductivity(0.5, "W/mK") | `to()` |
+
+##### `ThermalConductivity`
+
+Represents Thermal Conductivity of a material. Default SI unit: W/mK (Watts per meter-Kelvin) Example: k = ThermalConductivity(0.5, "W/mK")
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.thermal_resistance`
+
+**Source:** `processpi/units/thermal_resistance.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `ThermalResistance` | `ThermalResistance(self, value, units='K/W')` | Represents Thermal Resistance. Default SI unit: K/W (Kelvin per Watt) Example: r1 = ThermalResistance(0.5, "K/W") r2 = ThermalResistance(2, "C/W") | `to()` |
+
+##### `ThermalResistance`
+
+Represents Thermal Resistance. Default SI unit: K/W (Kelvin per Watt) Example: r1 = ThermalResistance(0.5, "K/W") r2 = ThermalResistance(2, "C/W")
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.velocity`
+
+**Source:** `processpi/units/velocity.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Velocity` | `Velocity(self, value, units='m/s')` | Represents a Velocity quantity. Default SI unit: meters per second (m/s). | `to_base()`, `from_base()`, `to()` |
+
+##### `Velocity`
+
+Represents a Velocity quantity. Default SI unit: meters per second (m/s).
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to_base` | `to_base(self)` | No source docstring provided. |
+| `from_base` | `from_base(self, base_value, target_units)` | No source docstring provided. |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.viscosity`
+
+**Source:** `processpi/units/viscosity.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Viscosity` | `Viscosity(self, value, units='Pa·s')` | Represents a viscosity quantity. Supports both dynamic viscosity (Pa·s) and kinematic viscosity (m²/s). Example: v1 = Viscosity(1e-3, units="Pa·s") # Dynamic viscosity v2 = Viscosity(1, units="cSt") # Kinematic viscosity | `to()` |
+
+##### `Viscosity`
+
+Represents a viscosity quantity. Supports both dynamic viscosity (Pa·s) and kinematic viscosity (m²/s). Example: v1 = Viscosity(1e-3, units="Pa·s") # Dynamic viscosity v2 = Viscosity(1, units="cSt") # Kinematic viscosity
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.volume`
+
+**Source:** `processpi/units/volume.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `Volume` | `Volume(self, value, units='m3')` | Represents a Volume quantity. Default SI unit: Cubic Meter (m3). Example: v1 = Volume(1, "L") v2 = Volume(0.001, "m3") | `to()` |
+
+##### `Volume`
+
+Represents a Volume quantity. Default SI unit: Cubic Meter (m3). Example: v1 = Volume(1, "L") v2 = Volume(0.001, "m3")
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.
+
+### `processpi.units.volumetric_flowrate`
+
+**Source:** `processpi/units/volumetric_flowrate.py`
+
+**Purpose:** Engineering unit wrapper that stores a value and converts among supported units.
+
+#### Classes
+
+| Class | Constructor | Description | Public methods |
+| --- | --- | --- | --- |
+| `VolumetricFlowRate` | `VolumetricFlowRate(self, value, units='m3/s')` | Represents a Volumetric Flow Rate quantity. Default SI unit: Cubic meters per second (m³/s). Example: v1 = VolumetricFlowRate(2, "m3/h") v2 = VolumetricFlowRate(500, "L/min") | `to()`, `from_mass_flow()` |
+
+##### `VolumetricFlowRate`
+
+Represents a Volumetric Flow Rate quantity. Default SI unit: Cubic meters per second (m³/s). Example: v1 = VolumetricFlowRate(2, "m3/h") v2 = VolumetricFlowRate(500, "L/min")
+
+**Methods**
+
+| Method | Signature | Notes |
+| --- | --- | --- |
+| `to` | `to(self, target_unit)` | No source docstring provided. |
+| `from_mass_flow` | `from_mass_flow(cls, mass_flow: 'MassFlowRate', density: 'Density')` | Convert a mass flow rate to volumetric flow rate using density. Q_vol = m_dot / rho |
+
+**Typical exceptions**: `ValueError` for invalid engineering inputs, `TypeError` for incompatible object types, and `NotImplementedError` where a future method is reserved.

--- a/docs/audit/documentation-audit-report.md
+++ b/docs/audit/documentation-audit-report.md
@@ -1,0 +1,79 @@
+# Documentation Audit Report
+
+## Audit method
+
+The documentation update began by generating a source inventory from every Python module under `processpi/`. The generated inventory page is the source of truth for public packages, modules, classes, functions, methods, and CLI entry points.
+
+## Pages added
+
+- `docs/audit/source-inventory.md`
+- `docs/audit/documentation-audit-report.md`
+- `docs/api/index.md`
+- `docs/api/calculations.md`
+- `docs/api/components.md`
+- `docs/api/equipment.md`
+- `docs/api/integration.md`
+- `docs/api/pipelines.md`
+- `docs/api/streams.md`
+- `docs/api/units.md`
+- `docs/api/cli.md`
+- `docs/user-guide/engineering/heat-exchangers.md`
+- `docs/user-guide/engineering/properties-streams.md`
+- `docs/user-guide/cli.md`
+- `docs/user-guide/tutorials/getting-started.md`
+- `docs/user-guide/tutorials/process-engineering-examples.md`
+- `docs/user-guide/tutorials/advanced-workflows.md`
+
+## Pages updated
+
+- `mkdocs.yml` navigation was reorganized to expose the new audit, engineering, CLI, tutorial, and generated API pages.
+- `docs/about/changelog.md` was updated with the documentation modernization release note.
+- `docs/about/roadmap.md` was updated to reflect implementation-aligned documentation priorities.
+
+## Missing or renamed packages discovered
+
+The requested scope mentioned several top-level packages that are not implemented as importable modules in this repository:
+
+- `processpi.hx`
+- `processpi.thermo`
+- `processpi.fluids`
+- `processpi.hydraulics`
+- `processpi.piping`
+- `processpi.pumps`
+- `processpi.correlations`
+- `processpi.materials`
+- `processpi.properties`
+
+Equivalent implemented functionality is currently organized as:
+
+- Heat exchangers: `processpi.equipment.heatexchangers`
+- Heat-transfer calculations: `processpi.calculations.heat_transfer`
+- Thermodynamics: `processpi.calculations.thermodynamics`
+- Fluid calculations: `processpi.calculations.fluids`
+- Piping and hydraulics: `processpi.pipelines`
+- Materials helpers: `processpi.pipelines.materials`
+- Component properties: `processpi.components`
+- Units: `processpi.units`
+
+## Missing code documentation discovered
+
+- Many public classes have limited or missing source docstrings.
+- Several calculation classes have constructor signatures inherited from `CalculationBase`, so parameter documentation is often available only through source validation logic and examples.
+- The standalone `BellDelawareHX.design()` method is future-reserved, even though the engine accepts `method="bell_delaware"`.
+- The CLI was advertised in packaging but required an importable `processpi.cli` module to match the console entry point.
+
+## Remaining documentation gaps
+
+- Add source docstrings with units and correlation validity ranges for every calculation class.
+- Add regression-tested examples for every API page.
+- Add detailed component correlation provenance and valid temperature/pressure ranges.
+- Add mechanical-design limitations for heat exchangers and pipelines in more detail.
+- Add generated parameter tables from runtime signatures when the project adopts mkdocstrings or equivalent tooling.
+
+## Recommended future improvements
+
+1. Add `mkdocstrings-python` to documentation dependencies and replace static API tables with automatic reference blocks.
+2. Add doctest or pytest coverage for every tutorial snippet.
+3. Introduce a structured component database file with citation metadata and range validation.
+4. Split preliminary heat-exchanger design from rating and mechanical design in the API names.
+5. Add CLI calculation subcommands only after the Python API stabilizes.

--- a/docs/audit/source-inventory.md
+++ b/docs/audit/source-inventory.md
@@ -1,0 +1,979 @@
+# Source Inventory Audit
+
+Generated before documentation edits from every `*.py` file under `processpi/`.
+
+## Package inventory
+
+- `processpi.__init__` — 1 module(s)
+- `processpi.calculations` — 56 module(s)
+- `processpi.cli` — 1 module(s)
+- `processpi.components` — 37 module(s)
+- `processpi.constants` — 1 module(s)
+- `processpi.equipment` — 12 module(s)
+- `processpi.integration` — 2 module(s)
+- `processpi.pipelines` — 17 module(s)
+- `processpi.streams` — 3 module(s)
+- `processpi.units` — 25 module(s)
+
+## Module, class, and function inventory
+
+### `processpi.__init__`
+
+- Source: `processpi/__init__.py`
+- Public classes/functions: none
+
+### `processpi.calculations.__init__`
+
+- Source: `processpi/calculations/__init__.py`
+- Public classes/functions: none
+
+### `processpi.calculations.base`
+
+- Source: `processpi/calculations/base.py`
+- Public classes:
+  - `CalculationBase`; methods: validate_inputs, calculate, get_inputs, to_dict
+
+### `processpi.calculations.engine`
+
+- Source: `processpi/calculations/engine.py`
+- Public classes:
+  - `CalculationEngine`; methods: register_calculation, calculate
+
+### `processpi.calculations.fluids.__init__`
+
+- Source: `processpi/calculations/fluids/__init__.py`
+- Public classes/functions: none
+
+### `processpi.calculations.fluids.flow_type`
+
+- Source: `processpi/calculations/fluids/flow_type.py`
+- Public classes:
+  - `TypeOfFlow`; methods: validate_inputs, calculate
+
+### `processpi.calculations.fluids.friction_factor_colebrookwhite`
+
+- Source: `processpi/calculations/fluids/friction_factor_colebrookwhite.py`
+- Public classes:
+  - `ColebrookWhite`; methods: validate_inputs, calculate
+
+### `processpi.calculations.fluids.optimium_pipe_dia`
+
+- Source: `processpi/calculations/fluids/optimium_pipe_dia.py`
+- Public classes:
+  - `OptimumPipeDiameter`; methods: validate_inputs, calculate
+
+### `processpi.calculations.fluids.pressure_drop_darcy`
+
+- Source: `processpi/calculations/fluids/pressure_drop_darcy.py`
+- Public classes:
+  - `PressureDropDarcy`; methods: validate_inputs, calculate
+
+### `processpi.calculations.fluids.pressure_drop_fanning`
+
+- Source: `processpi/calculations/fluids/pressure_drop_fanning.py`
+- Public classes:
+  - `PressureDropFanning`; methods: validate_inputs, calculate
+
+### `processpi.calculations.fluids.pressure_drop_hazen_williams`
+
+- Source: `processpi/calculations/fluids/pressure_drop_hazen_williams.py`
+- Public classes:
+  - `PressureDropHazenWilliams`; methods: validate_inputs, calculate
+
+### `processpi.calculations.fluids.pump_power`
+
+- Source: `processpi/calculations/fluids/pump_power.py`
+- Public classes:
+  - `PumpPower`; methods: validate_inputs, calculate
+
+### `processpi.calculations.fluids.reynolds_number`
+
+- Source: `processpi/calculations/fluids/reynolds_number.py`
+- Public classes:
+  - `ReynoldsNumber`; methods: validate_inputs, calculate
+
+### `processpi.calculations.fluids.velocity`
+
+- Source: `processpi/calculations/fluids/velocity.py`
+- Public classes:
+  - `FluidVelocity`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.__init__`
+
+- Source: `processpi/calculations/heat_transfer/__init__.py`
+- Public classes/functions: none
+
+### `processpi.calculations.heat_transfer.biot`
+
+- Source: `processpi/calculations/heat_transfer/biot.py`
+- Public classes:
+  - `BiotNumber`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.boiling_chen`
+
+- Source: `processpi/calculations/heat_transfer/boiling_chen.py`
+- Public classes:
+  - `ChenBoiling`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.combined_modes`
+
+- Source: `processpi/calculations/heat_transfer/combined_modes.py`
+- Public classes:
+  - `ConductionConvectionCombined`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.condensation`
+
+- Source: `processpi/calculations/heat_transfer/condensation.py`
+- Public classes:
+  - `CondensingVapourFilm`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.condensation_dropwise`
+
+- Source: `processpi/calculations/heat_transfer/condensation_dropwise.py`
+- Public classes:
+  - `DropwiseCondensation`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.condensation_nusselt`
+
+- Source: `processpi/calculations/heat_transfer/condensation_nusselt.py`
+- Public classes:
+  - `NusseltCondensation`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.conduction_heat_loss`
+
+- Source: `processpi/calculations/heat_transfer/conduction_heat_loss.py`
+- Public classes:
+  - `ConductionHeatLoss`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.convection_heat_loss`
+
+- Source: `processpi/calculations/heat_transfer/convection_heat_loss.py`
+- Public classes:
+  - `ConvectionHeatLoss`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.crossflow_tube`
+
+- Source: `processpi/calculations/heat_transfer/crossflow_tube.py`
+- Public classes:
+  - `CrossFlowSingleTube`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.fourier`
+
+- Source: `processpi/calculations/heat_transfer/fourier.py`
+- Public classes:
+  - `FourierNumber`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.fourierlaw`
+
+- Source: `processpi/calculations/heat_transfer/fourierlaw.py`
+- Public classes:
+  - `FourierLaw`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.grashof`
+
+- Source: `processpi/calculations/heat_transfer/grashof.py`
+- Public classes:
+  - `GrashofNumber`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.heat_exchanger`
+
+- Source: `processpi/calculations/heat_transfer/heat_exchanger.py`
+- Public classes:
+  - `SensibleHeatDuty`; methods: validate_inputs, calculate
+  - `LatentHeatDuty`; methods: validate_inputs, calculate
+  - `KernNusselt`; methods: validate_inputs, calculate
+  - `ConvectiveCoefficient`; methods: validate_inputs, calculate
+  - `DarcyPressureDrop`; methods: validate_inputs, calculate
+  - `ReynoldsFromProperties`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.heat_exchanger_area`
+
+- Source: `processpi/calculations/heat_transfer/heat_exchanger_area.py`
+- Public classes:
+  - `HeatExchangerArea`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.hx_kern`
+
+- Source: `processpi/calculations/heat_transfer/hx_kern.py`
+- Public classes:
+  - `SensibleDuty`; methods: validate_inputs, calculate
+  - `LatentDuty`; methods: validate_inputs, calculate
+  - `Reynolds`; methods: validate_inputs, calculate
+  - `DittusBoelter`; methods: validate_inputs, calculate
+  - `KernShellNu`; methods: validate_inputs, calculate
+  - `ConvectiveH`; methods: validate_inputs, calculate
+  - `TubeCountFromArea`; methods: validate_inputs, calculate
+  - `ShellDiameterEstimate`; methods: validate_inputs, calculate
+  - `DarcyDrop`; methods: validate_inputs, calculate
+  - `CondensationHTC`; methods: validate_inputs, calculate
+  - `BoilingHTC`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.lmtd`
+
+- Source: `processpi/calculations/heat_transfer/lmtd.py`
+- Public classes:
+  - `LMTD`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.newton_cooling`
+
+- Source: `processpi/calculations/heat_transfer/newton_cooling.py`
+- Public classes:
+  - `NewtonCooling`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.ntu`
+
+- Source: `processpi/calculations/heat_transfer/ntu.py`
+- Public classes:
+  - `NTUHeatExchanger`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.nusselt`
+
+- Source: `processpi/calculations/heat_transfer/nusselt.py`
+- Public classes:
+  - `NusseltNumber`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.overall_u`
+
+- Source: `processpi/calculations/heat_transfer/overall_u.py`
+- Public classes:
+  - `OverallHeatTransferCoefficient`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.peclet`
+
+- Source: `processpi/calculations/heat_transfer/peclet.py`
+- Public classes:
+  - `PecletNumber`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.prandtl`
+
+- Source: `processpi/calculations/heat_transfer/prandtl.py`
+- Public classes:
+  - `PrandtlNumber`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.radial_cylinder`
+
+- Source: `processpi/calculations/heat_transfer/radial_cylinder.py`
+- Public classes:
+  - `RadialHeatFlowCylinder`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.radiation_blackbody`
+
+- Source: `processpi/calculations/heat_transfer/radiation_blackbody.py`
+- Public classes:
+  - `BlackbodyRadiation`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.radiation_exchange`
+
+- Source: `processpi/calculations/heat_transfer/radiation_exchange.py`
+- Public classes:
+  - `RadiationExchange`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.radiation_greybody`
+
+- Source: `processpi/calculations/heat_transfer/radiation_greybody.py`
+- Public classes:
+  - `GreybodyRadiation`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.radiation_viewfactor`
+
+- Source: `processpi/calculations/heat_transfer/radiation_viewfactor.py`
+- Public classes:
+  - `RadiationWithViewFactor`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.resistance`
+
+- Source: `processpi/calculations/heat_transfer/resistance.py`
+- Public classes:
+  - `ThermalResistanceSeries`; methods: validate_inputs, calculate
+  - `ThermalResistanceParallel`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.reyleigh`
+
+- Source: `processpi/calculations/heat_transfer/reyleigh.py`
+- Public classes:
+  - `RayleighNumber`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.rohsenow_boiling`
+
+- Source: `processpi/calculations/heat_transfer/rohsenow_boiling.py`
+- Public classes:
+  - `RohsenowBoiling`; methods: validate_inputs, calculate
+
+### `processpi.calculations.heat_transfer.stefan_boltzmann`
+
+- Source: `processpi/calculations/heat_transfer/stefan_boltzmann.py`
+- Public classes:
+  - `StefanBoltzmann`; methods: validate_inputs, calculate
+
+### `processpi.calculations.mass_transfer.__init__`
+
+- Source: `processpi/calculations/mass_transfer/__init__.py`
+- Public classes/functions: none
+
+### `processpi.calculations.mass_transfer.distillation_stage_count`
+
+- Source: `processpi/calculations/mass_transfer/distillation_stage_count.py`
+- Public classes:
+  - `DistillationStageCount`; methods: validate_inputs, calculate
+
+### `processpi.calculations.mass_transfer.drying_rate`
+
+- Source: `processpi/calculations/mass_transfer/drying_rate.py`
+- Public classes:
+  - `DryingRate`; methods: validate_inputs, calculate
+
+### `processpi.calculations.reaction_engineering.__init__`
+
+- Source: `processpi/calculations/reaction_engineering/__init__.py`
+- Public classes/functions: none
+
+### `processpi.calculations.reaction_engineering.catalyst_activity`
+
+- Source: `processpi/calculations/reaction_engineering/catalyst_activity.py`
+- Public classes:
+  - `CatalystActivity`; methods: validate_inputs, calculate
+
+### `processpi.calculations.reaction_engineering.reaction_rate`
+
+- Source: `processpi/calculations/reaction_engineering/reaction_rate.py`
+- Public classes:
+  - `ReactionRate`; methods: validate_inputs, calculate
+
+### `processpi.calculations.reaction_engineering.residence_time`
+
+- Source: `processpi/calculations/reaction_engineering/residence_time.py`
+- Public classes:
+  - `ResidenceTime`; methods: validate_inputs, calculate
+
+### `processpi.calculations.thermodynamics.__init__`
+
+- Source: `processpi/calculations/thermodynamics/__init__.py`
+- Public classes/functions: none
+
+### `processpi.calculations.thermodynamics.enthalpy_change`
+
+- Source: `processpi/calculations/thermodynamics/enthalpy_change.py`
+- Public classes:
+  - `EnthalpyChange`; methods: validate_inputs, calculate
+
+### `processpi.calculations.thermodynamics.entropy_change`
+
+- Source: `processpi/calculations/thermodynamics/entropy_change.py`
+- Public classes:
+  - `EntropyChange`; methods: validate_inputs, calculate
+
+### `processpi.calculations.thermodynamics.heat_of_vaporization`
+
+- Source: `processpi/calculations/thermodynamics/heat_of_vaporization.py`
+- Public classes:
+  - `HeatOfVaporization`; methods: validate_inputs, calculate
+
+### `processpi.cli`
+
+- Source: `processpi/cli.py`
+- Public functions:
+  - `build_parser()`
+  - `main(argv: list[str] | None=None)`
+
+### `processpi.components.__init__`
+
+- Source: `processpi/components/__init__.py`
+- Public classes/functions: none
+
+### `processpi.components.aceticacid`
+
+- Source: `processpi/components/aceticacid.py`
+- Public classes:
+  - `AceticAcid`; methods: none
+
+### `processpi.components.acetone`
+
+- Source: `processpi/components/acetone.py`
+- Public classes:
+  - `Acetone`; methods: none
+
+### `processpi.components.acrylicacid`
+
+- Source: `processpi/components/acrylicacid.py`
+- Public classes:
+  - `AcrylicAcid`; methods: none
+
+### `processpi.components.air`
+
+- Source: `processpi/components/air.py`
+- Public classes:
+  - `Air`; methods: none
+
+### `processpi.components.ammonia`
+
+- Source: `processpi/components/ammonia.py`
+- Public classes:
+  - `Ammonia`; methods: specific_heat
+
+### `processpi.components.base`
+
+- Source: `processpi/components/base.py`
+- Public classes:
+  - `PropertyMethod`; methods: none
+  - `Component`; methods: name, formula, molecular_weight, phase, density, specific_heat, viscosity, thermal_conductivity, vapor_pressure, enthalpy
+
+### `processpi.components.benzene`
+
+- Source: `processpi/components/benzene.py`
+- Public classes:
+  - `Benzene`; methods: specific_heat, hx_data, httype
+
+### `processpi.components.benzoicacid`
+
+- Source: `processpi/components/benzoicacid.py`
+- Public classes:
+  - `BenzoicAcid`; methods: none
+
+### `processpi.components.bromine`
+
+- Source: `processpi/components/bromine.py`
+- Public classes:
+  - `Bromine`; methods: none
+
+### `processpi.components.butane`
+
+- Source: `processpi/components/butane.py`
+- Public classes:
+  - `Butane`; methods: none
+
+### `processpi.components.carbondioxide`
+
+- Source: `processpi/components/carbondioxide.py`
+- Public classes:
+  - `Carbondioxide`; methods: none
+
+### `processpi.components.carbonmonoxide`
+
+- Source: `processpi/components/carbonmonoxide.py`
+- Public classes:
+  - `CarbonMonoxide`; methods: specific_heat
+
+### `processpi.components.carbontetrachloride`
+
+- Source: `processpi/components/carbontetrachloride.py`
+- Public classes:
+  - `CarbonTetrachloride`; methods: none
+
+### `processpi.components.chlorine`
+
+- Source: `processpi/components/chlorine.py`
+- Public classes:
+  - `Chlorine`; methods: none
+
+### `processpi.components.chlorobenzene`
+
+- Source: `processpi/components/chlorobenzene.py`
+- Public classes:
+  - `ChloroBenzene`; methods: none
+
+### `processpi.components.chloroform`
+
+- Source: `processpi/components/chloroform.py`
+- Public classes:
+  - `Chloroform`; methods: none
+
+### `processpi.components.chloromethane`
+
+- Source: `processpi/components/chloromethane.py`
+- Public classes:
+  - `ChloroMethane`; methods: none
+
+### `processpi.components.constants`
+
+- Source: `processpi/components/constants.py`
+- Public classes/functions: none
+
+### `processpi.components.cyanogen`
+
+- Source: `processpi/components/cyanogen.py`
+- Public classes:
+  - `Cyanogen`; methods: none
+
+### `processpi.components.cyclohexene`
+
+- Source: `processpi/components/cyclohexene.py`
+- Public classes:
+  - `Cyclohexane`; methods: none
+
+### `processpi.components.ethane`
+
+- Source: `processpi/components/ethane.py`
+- Public classes:
+  - `Ethane`; methods: specific_heat
+
+### `processpi.components.ethanol`
+
+- Source: `processpi/components/ethanol.py`
+- Public classes:
+  - `Ethanol`; methods: none
+
+### `processpi.components.ethylacetate`
+
+- Source: `processpi/components/ethylacetate.py`
+- Public classes:
+  - `EthlylAcetate`; methods: none
+
+### `processpi.components.ethylene`
+
+- Source: `processpi/components/ethylene.py`
+- Public classes:
+  - `Ethlylene`; methods: none
+
+### `processpi.components.fluorine`
+
+- Source: `processpi/components/fluorine.py`
+- Public classes:
+  - `Fluorine`; methods: none
+
+### `processpi.components.fluorobenzene`
+
+- Source: `processpi/components/fluorobenzene.py`
+- Public classes:
+  - `FluoroBenzene`; methods: none
+
+### `processpi.components.formicacid`
+
+- Source: `processpi/components/formicacid.py`
+- Public classes:
+  - `FormicAcid`; methods: none
+
+### `processpi.components.gas`
+
+- Source: `processpi/components/gas.py`
+- Public classes:
+  - `Gas`; methods: density
+
+### `processpi.components.inorganic_liquid`
+
+- Source: `processpi/components/inorganic_liquid.py`
+- Public classes:
+  - `InorganicLiquid`; methods: none
+
+### `processpi.components.methanol`
+
+- Source: `processpi/components/methanol.py`
+- Public classes:
+  - `Methanol`; methods: none
+
+### `processpi.components.oil`
+
+- Source: `processpi/components/oil.py`
+- Public classes:
+  - `Oil`; methods: hx_data, httype
+
+### `processpi.components.organic_liquid`
+
+- Source: `processpi/components/organic_liquid.py`
+- Public classes:
+  - `OrganicLiquid`; methods: hx_data, httype
+
+### `processpi.components.steam`
+
+- Source: `processpi/components/steam.py`
+- Public classes:
+  - `Steam`; methods: density, specific_heat, viscosity, thermal_conductivity, vapor_pressure, enthalpy
+
+### `processpi.components.toluene`
+
+- Source: `processpi/components/toluene.py`
+- Public classes:
+  - `Toluene`; methods: hx_data, httype
+
+### `processpi.components.vapor`
+
+- Source: `processpi/components/vapor.py`
+- Public classes:
+  - `Vapor`; methods: none
+
+### `processpi.components.water`
+
+- Source: `processpi/components/water.py`
+- Public classes:
+  - `Water`; methods: density, hx_data, httype
+
+### `processpi.constants`
+
+- Source: `processpi/constants.py`
+- Public classes/functions: none
+
+### `processpi.equipment.__init__`
+
+- Source: `processpi/equipment/__init__.py`
+- Public classes/functions: none
+
+### `processpi.equipment.base`
+
+- Source: `processpi/equipment/base.py`
+- Public classes:
+  - `PortMap`; methods: add_port, has_port, values_ordered
+  - `Equipment`; methods: connect_inlet, connect_outlet, attach_stream
+
+### `processpi.equipment.heatexchangers.__init__`
+
+- Source: `processpi/equipment/heatexchangers/__init__.py`
+- Public classes/functions: none
+
+### `processpi.equipment.heatexchangers.base`
+
+- Source: `processpi/equipment/heatexchangers/base.py`
+- Public classes:
+  - `HeatExchangerBaseMixin`; methods: none
+  - `HeatExchanger`; methods: heat_duty, lmtd, area, overall_u, design
+
+### `processpi.equipment.heatexchangers.bell_delaware`
+
+- Source: `processpi/equipment/heatexchangers/bell_delaware.py`
+- Public classes:
+  - `BellDelawareHX`; methods: design
+
+### `processpi.equipment.heatexchangers.condenser`
+
+- Source: `processpi/equipment/heatexchangers/condenser.py`
+- Public classes:
+  - `CondenserHX`; methods: design, rate
+
+### `processpi.equipment.heatexchangers.double_pipe`
+
+- Source: `processpi/equipment/heatexchangers/double_pipe.py`
+- Public classes:
+  - `DoublePipeHX`; methods: design, rate
+
+### `processpi.equipment.heatexchangers.engine`
+
+- Source: `processpi/equipment/heatexchangers/engine.py`
+- Public classes:
+  - `HeatExchangerResults`; methods: summary, detailed_summary, trace, debug_summary
+  - `HeatExchangerEngine`; methods: fit, run, summary, results
+
+### `processpi.equipment.heatexchangers.evaporator`
+
+- Source: `processpi/equipment/heatexchangers/evaporator.py`
+- Public classes:
+  - `EvaporatorHX`; methods: design, rate
+
+### `processpi.equipment.heatexchangers.reboiler`
+
+- Source: `processpi/equipment/heatexchangers/reboiler.py`
+- Public classes:
+  - `ReboilerHX`; methods: design, rate
+
+### `processpi.equipment.heatexchangers.shell_and_tube`
+
+- Source: `processpi/equipment/heatexchangers/shell_and_tube.py`
+- Public classes:
+  - `ShellAndTubeHX`; methods: rate, design
+
+### `processpi.equipment.heatexchangers.standards`
+
+- Source: `processpi/equipment/heatexchangers/standards.py`
+- Public functions:
+  - `get_u_range(hx_type: str, service_type: str, hot_type: str, cold_type: str)`
+  - `get_velocity_range(component)`
+  - `select_tube_configuration(area_required, hot, cold)`
+  - `tube_length_select(tube_length, ld)`
+  - `get_fouling_factor(fluid_key: str, velocity: float | None=None, temperature: float | None=None, database: dict | None=None, debug: bool=True)`
+
+### `processpi.integration.__init__`
+
+- Source: `processpi/integration/__init__.py`
+- Public classes/functions: none
+
+### `processpi.integration.flowsheet`
+
+- Source: `processpi/integration/flowsheet.py`
+- Public classes:
+  - `Flowsheet`; methods: add_equipment, add_material_stream, add_energy_stream, connect, run, solve_sequential, summary
+
+### `processpi.pipelines.__init__`
+
+- Source: `processpi/pipelines/__init__.py`
+- Public classes/functions: none
+
+### `processpi.pipelines.base`
+
+- Source: `processpi/pipelines/base.py`
+- Public classes:
+  - `PipelineBase`; methods: calculate, get_param, validate_required
+
+### `processpi.pipelines.design_rules`
+
+- Source: `processpi/pipelines/design_rules.py`
+- Public classes:
+  - `DesignRuleError`; methods: none
+  - `DesignRules`; methods: validate_step_name, validate_inputs_outputs, validate_parameters, validate_callable, validate_pipeline_consistency, summary
+
+### `processpi.pipelines.engine`
+
+- Source: `processpi/pipelines/engine.py`
+- Public classes:
+  - `ElementReport`; methods: as_dict
+  - `PipelineEngine`; methods: fit, run, summary
+
+### `processpi.pipelines.equipment`
+
+- Source: `processpi/pipelines/equipment.py`
+- Public classes:
+  - `Equipment`; methods: add_inlet, add_outlet
+
+### `processpi.pipelines.fittings`
+
+- Source: `processpi/pipelines/fittings.py`
+- Public classes:
+  - `Fitting`; methods: equivalent_length, k_factor, calculate
+
+### `processpi.pipelines.insulation`
+
+- Source: `processpi/pipelines/insulation.py`
+- Public classes/functions: none
+
+### `processpi.pipelines.materials`
+
+- Source: `processpi/pipelines/materials.py`
+- Public functions:
+  - `get_material_property(material: str, prop: str)`
+  - `get_material_data(material: str)`
+
+### `processpi.pipelines.network`
+
+- Source: `processpi/pipelines/network.py`
+- Public classes:
+  - `Node`; methods: none
+  - `PipelineNetwork`; methods: series, parallel, add, add_series, add_parallel, add_node, get_node, add_edge, add_fitting, add_subnetwork, validate, describe, schematic, get_all_pipes, visualize_network
+
+### `processpi.pipelines.nozzle`
+
+- Source: `processpi/pipelines/nozzle.py`
+- Public classes:
+  - `Nozzle`; methods: pressure_drop_at_flow
+
+### `processpi.pipelines.pipelineresults`
+
+- Source: `processpi/pipelines/pipelineresults.py`
+- Public classes:
+  - `PipelineResults`; methods: pipe_diameter, summary, detailed_summary
+
+### `processpi.pipelines.pipes`
+
+- Source: `processpi/pipelines/pipes.py`
+- Public classes:
+  - `Pipe`; methods: cross_sectional_area, surface_area, pressure_difference, to_dict, calculate
+
+### `processpi.pipelines.piping_costs`
+
+- Source: `processpi/pipelines/piping_costs.py`
+- Public classes:
+  - `PipeCostModel`; methods: default_steel_model, get_pipe_cost, calculate_network_cost
+
+### `processpi.pipelines.pumps`
+
+- Source: `processpi/pipelines/pumps.py`
+- Public classes:
+  - `Pump`; methods: hydraulic_power, brake_power, to_dict, calculate
+
+### `processpi.pipelines.selection`
+
+- Source: `processpi/pipelines/selection.py`
+- Public classes:
+  - `MaterialSelector`; methods: filter_materials, recommend_material
+
+### `processpi.pipelines.standards`
+
+- Source: `processpi/pipelines/standards.py`
+- Public functions:
+  - `get_internal_diameter(nominal_diameter: Diameter, schedule: str='STD')`
+  - `get_thickness(nominal_diameter: Diameter, schedule: str='STD')`
+  - `get_roughness(material: str)`
+  - `get_recommended_velocity(service: str)`
+  - `get_nearest_diameter(calculated_diameter: Diameter)`
+  - `get_standard_pipe_data(nominal_diameter: Diameter, schedule: str='STD')`
+  - `get_k_factor(fitting_type: str)`
+  - `list_available_pipe_diameters()`
+  - `get_next_standard_nominal(diameter_m: float)`
+  - `get_previous_standard_nominal(nominal_diameter: Diameter)`
+  - `get_next_next_standard_nominal(nominal_diameter: Diameter)`
+  - `get_standard_diameters_list()`
+  - `get_equivalent_length(fitting_type: str)`
+  - `get_k_factor(fitting_type: str, reynolds_number: Optional[float]=None, relative_roughness: Optional[float]=None, diameter: Optional[float]=None)`
+  - `get_nominal_dia_from_internal_dia(internal_diameter: Diameter, schedule: str='STD')`
+
+### `processpi.pipelines.vessel`
+
+- Source: `processpi/pipelines/vessel.py`
+- Public classes:
+  - `Vessel`; methods: add_inlet, add_outlet
+
+### `processpi.streams.__init__`
+
+- Source: `processpi/streams/__init__.py`
+- Public classes/functions: none
+
+### `processpi.streams.energy`
+
+- Source: `processpi/streams/energy.py`
+- Public classes:
+  - `EnergyStream`; methods: bind_equipment, record, total_duty
+
+### `processpi.streams.material`
+
+- Source: `processpi/streams/material.py`
+- Public classes:
+  - `MaterialStream`; methods: set_composition, mass_flow, molar_flow, avg_mw, copy
+
+### `processpi.units.__init__`
+
+- Source: `processpi/units/__init__.py`
+- Public classes/functions: none
+
+### `processpi.units.area`
+
+- Source: `processpi/units/area.py`
+- Public classes:
+  - `Area`; methods: to
+
+### `processpi.units.base`
+
+- Source: `processpi/units/base.py`
+- Public classes:
+  - `Variable`; methods: to, to_base, from_base
+
+### `processpi.units.density`
+
+- Source: `processpi/units/density.py`
+- Public classes:
+  - `Density`; methods: to
+
+### `processpi.units.diameter`
+
+- Source: `processpi/units/diameter.py`
+- Public classes:
+  - `Diameter`; methods: to_base, to
+
+### `processpi.units.dimensionless`
+
+- Source: `processpi/units/dimensionless.py`
+- Public classes:
+  - `Dimensionless`; methods: to
+
+### `processpi.units.heat_flow`
+
+- Source: `processpi/units/heat_flow.py`
+- Public classes:
+  - `HeatFlow`; methods: to
+
+### `processpi.units.heat_flux`
+
+- Source: `processpi/units/heat_flux.py`
+- Public classes:
+  - `HeatFlux`; methods: to
+
+### `processpi.units.heat_of_vaporization`
+
+- Source: `processpi/units/heat_of_vaporization.py`
+- Public classes:
+  - `HeatOfVaporization`; methods: to
+
+### `processpi.units.heat_transfer_coefficient`
+
+- Source: `processpi/units/heat_transfer_coefficient.py`
+- Public classes:
+  - `HeatTransferCoefficient`; methods: to
+
+### `processpi.units.length`
+
+- Source: `processpi/units/length.py`
+- Public classes:
+  - `Length`; methods: to
+
+### `processpi.units.mass`
+
+- Source: `processpi/units/mass.py`
+- Public classes:
+  - `Mass`; methods: to
+
+### `processpi.units.mass_flowrate`
+
+- Source: `processpi/units/mass_flowrate.py`
+- Public classes:
+  - `MassFlowRate`; methods: to
+
+### `processpi.units.molar_flowrate`
+
+- Source: `processpi/units/molar_flowrate.py`
+- Public classes:
+  - `MolarFlowRate`; methods: to
+
+### `processpi.units.power`
+
+- Source: `processpi/units/power.py`
+- Public classes:
+  - `Power`; methods: to
+
+### `processpi.units.pressure`
+
+- Source: `processpi/units/pressure.py`
+- Public classes:
+  - `Pressure`; methods: to_base, from_base, to
+
+### `processpi.units.specific_heat`
+
+- Source: `processpi/units/specific_heat.py`
+- Public classes:
+  - `SpecificHeat`; methods: to
+
+### `processpi.units.strings`
+
+- Source: `processpi/units/strings.py`
+- Public classes:
+  - `StringUnit`; methods: to
+
+### `processpi.units.temperature`
+
+- Source: `processpi/units/temperature.py`
+- Public classes:
+  - `Temperature`; methods: to
+
+### `processpi.units.thermal_conductivity`
+
+- Source: `processpi/units/thermal_conductivity.py`
+- Public classes:
+  - `ThermalConductivity`; methods: to
+
+### `processpi.units.thermal_resistance`
+
+- Source: `processpi/units/thermal_resistance.py`
+- Public classes:
+  - `ThermalResistance`; methods: to
+
+### `processpi.units.velocity`
+
+- Source: `processpi/units/velocity.py`
+- Public classes:
+  - `Velocity`; methods: to_base, from_base, to
+
+### `processpi.units.viscosity`
+
+- Source: `processpi/units/viscosity.py`
+- Public classes:
+  - `Viscosity`; methods: to
+
+### `processpi.units.volume`
+
+- Source: `processpi/units/volume.py`
+- Public classes:
+  - `Volume`; methods: to
+
+### `processpi.units.volumetric_flowrate`
+
+- Source: `processpi/units/volumetric_flowrate.py`
+- Public classes:
+  - `VolumetricFlowRate`; methods: to, from_mass_flow
+
+## CLI inventory
+
+- Packaging advertises the console script `processpi=processpi.cli:main` in `setup.py`.
+- A root-level `cli.py` existed with `main()` that printed a startup message; the package module `processpi.cli` is now documented as the supported import path.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,10 +22,10 @@ hide:
       with the tools to model, optimize, and visualize complex process networks with precision and ease.
     </div>
     <div style="margin-top: 1.5rem;">
-      <a class="md-button md-button--primary" href="installation/">
+      <a class="md-button md-button--primary" href="installation.md">
         Get Started
       </a>
-      <a class="md-button" href="user-guide/introduction/">
+      <a class="md-button" href="user-guide/introduction.md">
         Learn More
       </a>
     </div>
@@ -72,10 +72,10 @@ hide:
 
 <div class="grid cards" markdown>
 
--   :material-download: **[Installation](installation/)**  
+-   :material-download: **[Installation](installation.md)**  
     Quick setup guide to install Process PI and get started with Python.
 
--   :material-book-open-variant: **[User Guide](user-guide/introduction/)**  
+-   :material-book-open-variant: **[User Guide](user-guide/introduction.md)**  
     Step-by-step tutorials and detailed documentation for all features.
 
 -   :material-lightbulb-on-outline: **[Examples](examples/index.md)**  

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -1,0 +1,72 @@
+# Command Line Interface
+
+## Installation
+
+Install ProcessPI from a local checkout or distribution package:
+
+```bash
+pip install processpi
+```
+
+For repository development:
+
+```bash
+pip install -e .
+```
+
+The package entry point is configured as:
+
+```text
+processpi = processpi.cli:main
+```
+
+## Commands and options
+
+### `processpi`
+
+Prints a short CLI landing message.
+
+```bash
+processpi
+```
+
+Expected output:
+
+```text
+ProcessPI command line interface
+Use 'processpi doctor' for an import check or 'processpi --help' for options.
+```
+
+### `processpi --help`
+
+Displays CLI help, including available commands and options.
+
+```bash
+processpi --help
+```
+
+### `processpi --version`
+
+Shows the installed package version.
+
+```bash
+processpi --version
+```
+
+### `processpi doctor`
+
+Checks that ProcessPI imports and reports the installed version.
+
+```bash
+processpi doctor
+```
+
+Expected output:
+
+```text
+ProcessPI <version> is importable.
+```
+
+## Current CLI scope
+
+The CLI is intentionally small. Engineering calculations are currently exposed through the Python API, not through calculation-specific terminal subcommands. Use the tutorials and API reference for programmatic workflows.

--- a/docs/user-guide/components/chlorobenzene.md
+++ b/docs/user-guide/components/chlorobenzene.md
@@ -1,0 +1,5 @@
+# Chlorobenzene
+
+Chlorobenzene is implemented as `processpi.components.chlorobenzene.ChloroBenzene`.
+
+For the source-derived API entry, see the [components API reference](../../api/components.md).

--- a/docs/user-guide/components/components.md
+++ b/docs/user-guide/components/components.md
@@ -17,8 +17,8 @@ These components can be used in calculations, simulations, and design workflows 
 - [Chloroform](chloroform.md)  
 - [Carbon Tetrachloride](carbon_tetrachloride.md)  
 - [Chloro Methane](chloromethane.md)  
-- [Cyclobenzene](cyclobenzene.md)  
-- [Cyclohexane](cyclohexane.md)  
+- [Chlorobenzene](chlorobenzene.md)  
+- [Cyclohexene](cyclohexene.md)  
 - [Ethane](ethane.md)  
 - [Ethanol](ethanol.md)  
 - [Ethyl Acetate](ethylacetate.md)  
@@ -50,4 +50,4 @@ These components can be used in calculations, simulations, and design workflows 
 The Components Library is continuously expanding.  
 Future releases will include additional hydrocarbons, refrigerants, solvents, and specialty chemicals commonly used in process industries.  
 
-Stay tuned for updates in the [changelog](../about/changelog.md) and contribute your requests via the [GitHub repository](https://github.com/varma666/ProcessPi).  
+Stay tuned for updates in the [changelog](../../about/changelog.md) and contribute your requests via the [GitHub repository](https://github.com/varma666/ProcessPi).  

--- a/docs/user-guide/engineering/heat-exchangers.md
+++ b/docs/user-guide/engineering/heat-exchangers.md
@@ -1,0 +1,218 @@
+# Heat Exchanger Engineering Guide
+
+## Overview
+
+ProcessPI implements heat-exchanger workflows under `processpi.equipment.heatexchangers` and supporting calculation primitives under `processpi.calculations.heat_transfer`. The implemented equipment layer is centered on `HeatExchangerEngine`, which selects an exchanger class, runs sizing or rating logic, and returns `HeatExchangerResults` with engineering summaries, detailed data, traces, warnings, and recommendations.
+
+## Implemented exchanger models
+
+| Model | Import path | Purpose | Status |
+| --- | --- | --- | --- |
+| Shell-and-tube | `processpi.equipment.heatexchangers.shell_and_tube.ShellAndTubeHX` | Kern-style thermal sizing/rating with geometry, velocity, pressure-drop, L/D, fouling, and feasibility checks. | Implemented |
+| Condenser | `processpi.equipment.heatexchangers.condenser.CondenserHX` | Shell-and-tube condenser with latent duty, near-isothermal hot side, condensation HTC, orientation effects, and optional vertical static head. | Implemented |
+| Evaporator | `processpi.equipment.heatexchangers.evaporator.EvaporatorHX` | Phase-change evaporator service derived from shell-and-tube logic. | Implemented |
+| Reboiler | `processpi.equipment.heatexchangers.reboiler.ReboilerHX` | Reboiler-style service derived from evaporator behavior. | Implemented |
+| Double pipe | `processpi.equipment.heatexchangers.double_pipe.DoublePipeHX` | Small-duty exchanger sizing/rating. | Implemented |
+| Bell-Delaware | `processpi.equipment.heatexchangers.bell_delaware.BellDelawareHX` and `method="bell_delaware"` | Method name is accepted by the engine; correction-factor helper calculations are not a full standalone `BellDelawareHX.design()` implementation. | Partial/future-reserved |
+
+!!! warning "Bell-Delaware scope"
+    `HeatExchangerEngine(method="bell_delaware")` is accepted and routes shell-and-tube service through the current shell-and-tube model. The standalone `BellDelawareHX.design()` class raises `NotImplementedError`, so documentation should not present a complete TEMA/Bell-Delaware design package as implemented.
+
+## Sizing workflow
+
+1. Create `MaterialStream` objects for hot and cold inlet streams. Provide component, temperature, pressure, phase, and either mass flow or flow rate plus density.
+2. Provide at least one thermal specification: hot outlet, cold outlet, explicit `Q`, or phase-change data such as `latent_heat`.
+3. Choose `hx_type` explicitly or allow `HeatExchangerEngine` to infer it:
+   - vapor hot inlet to liquid hot outlet: condenser;
+   - cold outlet vapor: reboiler;
+   - small flows: double pipe;
+   - otherwise shell-and-tube.
+4. The exchanger estimates or validates heat duty, outlet temperatures, LMTD, correction factor, corrected LMTD, assumed U, required area, tube geometry, shell geometry, velocities, heat-transfer coefficients, calculated U, and pressure drops.
+5. The result object exposes:
+   - `summary()` for a readable report;
+   - `detailed_summary()` for the raw dictionary;
+   - `trace()` for grouped engineering calculations;
+   - `debug_summary()` for convergence, U, pressure-drop, and warning diagnostics.
+
+## Engineering theory
+
+### LMTD
+
+The log mean temperature difference is used when the driving force changes along an exchanger:
+
+\[
+\Delta T_{lm}=\frac{\Delta T_1-\Delta T_2}{\ln(\Delta T_1/\Delta T_2)}
+\]
+
+ProcessPI uses the `LMTD` calculation primitive and stabilizes near-isothermal phase-change cases when terminal differences become too small.
+
+### Correction factors
+
+Shell-and-tube exchangers with multiple passes deviate from ideal countercurrent flow. `ShellAndTubeHX` evaluates one-shell and two-shell-pass correction factor formulas from R/S temperature ratios and searches common shell/tube pass combinations. If no candidate reaches the practical threshold used by the code, the result includes warnings and recommendations.
+
+### Tube-side HTC
+
+Tube-side convection uses Reynolds, Prandtl, and Nusselt relationships. For turbulent tube flow, ProcessPI includes Dittus-Boelter-style support via `DittusBoelter` and converts Nusselt number to heat-transfer coefficient with `ConvectiveH`:
+
+\[
+h=\frac{Nu\,k}{D}
+\]
+
+### Shell-side HTC
+
+The shell-side path uses Kern-style shell Nusselt support through `KernShellNu`. Inputs are based on shell-equivalent geometry, mass velocity, fluid properties, baffle spacing, and tube layout assumptions. This is appropriate for preliminary engineering and screening, not a replacement for vendor thermal design.
+
+### Condensation coefficients
+
+`CondenserHX` calculates latent duty with `LatentDuty` and estimates condensation HTC with `CondensationHTC`. It applies orientation and condensing-side factors, and clips the coefficient to practical bounds to avoid unrealistic preliminary designs.
+
+### Reynolds, Prandtl, and Nusselt numbers
+
+- Reynolds number compares inertial and viscous forces and drives laminar/turbulent regime decisions.
+- Prandtl number compares momentum and thermal diffusivity.
+- Nusselt number converts dimensionless convection correlations into HTC.
+
+The reusable primitives are documented in the heat-transfer API reference.
+
+### Pressure-drop and hydraulic constraints
+
+Tube and shell pressure drops use Darcy-style pressure-drop primitives, flow area estimates, tube-pass effects, shell velocity estimates, and practical velocity ranges by side/service. Results include `tube_dp`, `shell_dp`, `tube_velocity`, and `shell_velocity`. Treat outputs as preliminary hydraulic screening until project-specific fittings, nozzles, maldistribution, vibration, and vendor geometry are included.
+
+### Fouling considerations
+
+`get_fouling_factor()` in `processpi.equipment.heatexchangers.standards` provides a standards-helper lookup by fluid key, with optional velocity and temperature context. Overall U combines tube film, fouling resistance, and shell film resistances. Users can also provide explicit fouling assumptions through exchanger specs.
+
+### Feasibility checks and optimization
+
+The shell-and-tube workflow records warnings for nonphysical terminal temperatures, low correction factors, geometry clipping, L/D limits, velocity constraints, tube-count caps, and pressure-drop concerns. These diagnostics are returned with the result rather than hidden.
+
+## Practical examples
+
+### Water cooler
+
+```python
+from processpi.streams.material import MaterialStream
+from processpi.units import Density, MassFlowRate, Pressure, SpecificHeat, Temperature
+from processpi.equipment.heatexchangers.engine import HeatExchangerEngine
+
+hot = MaterialStream(
+    name="hot_water_in",
+    temperature=Temperature(80, "C"),
+    pressure=Pressure(2, "bar"),
+    density=Density(971.8, "kg/m3"),
+    specific_heat=SpecificHeat(4190, "J/kgK"),
+    mass_flow=MassFlowRate(2.0, "kg/s"),
+    phase="liquid",
+)
+
+cold = MaterialStream(
+    name="cooling_water_in",
+    temperature=Temperature(25, "C"),
+    pressure=Pressure(2, "bar"),
+    density=Density(997, "kg/m3"),
+    specific_heat=SpecificHeat(4180, "J/kgK"),
+    mass_flow=MassFlowRate(3.0, "kg/s"),
+    phase="liquid",
+)
+
+hot_out = hot.copy("hot_water_out")
+hot_out.temperature = Temperature(45, "C")
+
+result = (
+    HeatExchangerEngine(method="kern")
+    .fit(hot_in=hot, cold_in=cold, hot_out=hot_out, hx_type="shell_and_tube")
+    .run()
+)
+print(result.summary())
+```
+
+### Condenser
+
+```python
+from processpi.streams.material import MaterialStream
+from processpi.units import Density, MassFlowRate, Pressure, SpecificHeat, Temperature
+from processpi.equipment.heatexchangers.engine import HeatExchangerEngine
+
+steam = MaterialStream(
+    name="steam_in",
+    temperature=Temperature(100, "C"),
+    pressure=Pressure(1.0, "bar"),
+    density=Density(0.60, "kg/m3"),
+    specific_heat=SpecificHeat(2010, "J/kgK"),
+    mass_flow=MassFlowRate(0.5, "kg/s"),
+    phase="vapor",
+)
+condensate = steam.copy("condensate_out")
+condensate.phase = "liquid"
+condensate.temperature = Temperature(95, "C")
+condensate.density = Density(962, "kg/m3")
+
+cooling = MaterialStream(
+    name="cooling_water",
+    temperature=Temperature(25, "C"),
+    pressure=Pressure(2, "bar"),
+    density=Density(997, "kg/m3"),
+    specific_heat=SpecificHeat(4180, "J/kgK"),
+    mass_flow=MassFlowRate(5.0, "kg/s"),
+    phase="liquid",
+)
+
+result = HeatExchangerEngine().fit(
+    hot_in=steam,
+    cold_in=cooling,
+    hot_out=condensate,
+    hx_type="condenser",
+    latent_heat=2_257_000,
+    condensing_side="shell",
+    orientation="horizontal",
+).run()
+```
+
+### Reboiler-style service
+
+```python
+result = HeatExchangerEngine().fit(
+    hot_in=steam,
+    cold_in=process_liquid,
+    cold_out=process_vapor,
+    hx_type="reboiler",
+    latent_heat=350_000,
+    latent_side="cold",
+).run()
+```
+
+### Rating an existing exchanger
+
+```python
+result = HeatExchangerEngine(method="kern").fit(
+    hot_in=hot,
+    cold_in=cold,
+    hot_out=hot_out,
+    hx_type="shell_and_tube",
+    tube_od=0.019,
+    tube_id=0.016,
+    tube_length=6.0,
+    tube_count=120,
+    tube_passes=2,
+    shell_passes=1,
+    shell_diameter=0.45,
+).run()
+
+print(result.detailed_summary()["U_calculated"])
+print(result.trace())
+```
+
+### Pressure-drop estimation
+
+```python
+details = result.detailed_summary()
+print("Tube-side ΔP:", details["tube_dp"].to("bar"))
+print("Shell-side ΔP:", details["shell_dp"].to("bar"))
+```
+
+## Limitations
+
+- Heat-exchanger results are preliminary engineering calculations.
+- TEMA mechanical design, vibration checks, nozzle losses, detailed maldistribution, two-phase pressure-drop maps, and vendor rating are not complete.
+- `BellDelawareHX.design()` is explicitly future-reserved.
+- Stream properties are only as accurate as the supplied components and user overrides.

--- a/docs/user-guide/engineering/properties-streams.md
+++ b/docs/user-guide/engineering/properties-streams.md
@@ -1,0 +1,102 @@
+# Components, Properties, and Streams
+
+## Overview
+
+ProcessPI stores chemical-component behavior under `processpi.components`, unit wrappers under `processpi.units`, and stream state under `processpi.streams`. The current component model combines fixed component constants, DIPPR-style correlations, ideal-gas density behavior, and user overrides passed into the component constructor.
+
+## Component database structure
+
+Each concrete component class subclasses `processpi.components.base.Component` and provides at minimum:
+
+- `name`
+- `formula`
+- `molecular_weight` in g/mol
+- correlation constants such as density, heat capacity, viscosity, thermal conductivity, vapor pressure, or heat of vaporization when available
+
+Implemented component modules include water, steam, air, ammonia, benzene, toluene, ethanol, methanol, acetone, acetic acid, carbon dioxide, carbon monoxide, chlorine, chloroform, bromine, butane, ethane, and additional organic/inorganic categories. See the generated components API inventory for the exact import paths and public classes.
+
+## Property access pattern
+
+Component properties use a descriptor that supports both property-style and method-style access:
+
+```python
+from processpi.components.water import Water
+from processpi.units import Temperature, Pressure
+
+water = Water(temperature=Temperature(25, "C"), pressure=Pressure(1, "atm"))
+
+rho = water.density()       # method-style
+rho_value = water.density.value  # property-style wrapper value
+cp = water.specific_heat()
+phase = water.phase()
+```
+
+## Units used
+
+| Property | Typical wrapper | Common base unit |
+| --- | --- | --- |
+| Temperature | `Temperature` | K |
+| Pressure | `Pressure` | Pa |
+| Density | `Density` | kg/m3 |
+| Specific heat | `SpecificHeat` | J/kgK |
+| Viscosity | `Viscosity` | Pa.s |
+| Thermal conductivity | `ThermalConductivity` | W/mK |
+| Heat of vaporization | `HeatOfVaporization` | J/kg |
+| Mass flow | `MassFlowRate` | kg/s |
+| Volumetric flow | `VolumetricFlowRate` | m3/s |
+
+## Data validation methods
+
+- Component property methods raise `ValueError` when a calculated value is unphysical, for example negative or excessively high heat capacity.
+- Unit wrappers raise conversion errors for unsupported units.
+- `MaterialStream` normalizes composition fractions and derives mass or molar flow when enough density, volumetric flow, composition, and molecular-weight data are available.
+
+## Property retrieval example
+
+```python
+from processpi.components.benzene import Benzene
+from processpi.units import Temperature, Pressure
+
+benzene = Benzene(temperature=Temperature(60, "C"), pressure=Pressure(1, "atm"))
+print(benzene.density().to("kg/m3"))
+print(benzene.viscosity().to("Pa.s"))
+print(benzene.vapor_pressure().to("bar"))
+```
+
+## Thermodynamic calculation example
+
+```python
+from processpi.calculations.heat_transfer.hx_kern import SensibleDuty
+
+# m_dot [kg/s], cp [J/kgK], temperatures [K or C differences]
+result = SensibleDuty(m_dot=1.0, cp=4180, t_in=80, t_out=40).calculate()
+print(result.to("kW"))
+```
+
+## Mixture and stream example
+
+`MaterialStream` supports composition dictionaries and average molecular weight calculation when molecular weights are supplied.
+
+```python
+from processpi.streams.material import MaterialStream
+from processpi.units import MassFlowRate, Temperature, Pressure
+
+stream = MaterialStream(
+    name="binary_feed",
+    mass_flow=MassFlowRate(1.0, "kg/s"),
+    temperature=Temperature(30, "C"),
+    pressure=Pressure(1, "bar"),
+    composition={"ethanol": 0.4, "water": 0.6},
+    basis="mole",
+    molecular_weights={"ethanol": 46.07, "water": 18.015},
+)
+
+print(stream.avg_mw())
+print(stream.molar_flow())
+```
+
+## Limitations
+
+- The component system is not a full equation-of-state package.
+- Mixture property blending is limited; users should provide validated mixture properties for design-critical calculations.
+- Correlation ranges are not universally enforced for every component.

--- a/docs/user-guide/features.md
+++ b/docs/user-guide/features.md
@@ -55,4 +55,4 @@ Here’s what you can do with it:
 
 ---
 
-👉 Browse the [Examples](../examples/pipeline-example.md) to see ProcessPI in action.
+👉 Browse the [Examples](../examples/index.md) to see ProcessPI in action.

--- a/docs/user-guide/tutorials/advanced-workflows.md
+++ b/docs/user-guide/tutorials/advanced-workflows.md
@@ -1,0 +1,47 @@
+# Advanced Workflows
+
+## Programmatic calculations
+
+ProcessPI classes are regular Python objects. A common pattern is to wrap calculation inputs in dictionaries or dataclasses, loop through design cases, and collect `.calculate()` or `.detailed_summary()` outputs.
+
+```python
+from processpi.calculations.fluids.reynolds_number import ReynoldsNumber
+
+cases = [
+    {"density": 1000, "velocity": 1.0, "diameter": 0.05, "viscosity": 0.001},
+    {"density": 1000, "velocity": 2.0, "diameter": 0.05, "viscosity": 0.001},
+]
+
+for case in cases:
+    print(ReynoldsNumber(**case).calculate())
+```
+
+## Batch heat-exchanger screening
+
+```python
+results = []
+for tube_length in [3.0, 4.5, 6.0]:
+    result = HeatExchangerEngine().fit(
+        hot_in=hot,
+        cold_in=cold,
+        hot_out=hot_out,
+        hx_type="shell_and_tube",
+        tube_length=tube_length,
+    ).run()
+    results.append(result.detailed_summary())
+```
+
+## Integration into larger projects
+
+Use ProcessPI as a calculation kernel:
+
+- Keep stream creation at project boundaries.
+- Convert external units into ProcessPI units before calculation.
+- Store raw result dictionaries for auditability.
+- Treat warning lists as required engineering review items.
+
+## Automation guidance
+
+- Validate inputs before batch runs.
+- Record package version, source assumptions, and units with every calculation set.
+- Avoid using preliminary exchanger outputs as final mechanical design.

--- a/docs/user-guide/tutorials/getting-started.md
+++ b/docs/user-guide/tutorials/getting-started.md
@@ -1,0 +1,38 @@
+# Getting Started Tutorial
+
+## Install
+
+```bash
+pip install processpi
+```
+
+For local development from the repository:
+
+```bash
+pip install -e .
+```
+
+## First calculation
+
+```python
+from processpi.calculations.fluids.velocity import FluidVelocity
+
+velocity = FluidVelocity(volumetric_flow_rate=0.01, diameter=0.1).calculate()
+print(velocity)
+```
+
+## Project structure
+
+- `processpi.components` — component/property classes.
+- `processpi.units` — engineering unit wrappers and conversions.
+- `processpi.calculations` — reusable calculation primitives.
+- `processpi.pipelines` — pipe, pump, fitting, network, standards, and hydraulic engine models.
+- `processpi.equipment.heatexchangers` — exchanger sizing/rating models.
+- `processpi.streams` — material and energy streams.
+- `processpi.integration` — flowsheet connection layer.
+
+## Next steps
+
+- Use the heat-exchanger engineering guide for thermal equipment.
+- Use the pipeline examples for hydraulic-network calculations.
+- Use the generated API reference when you need exact class and method names.

--- a/docs/user-guide/tutorials/process-engineering-examples.md
+++ b/docs/user-guide/tutorials/process-engineering-examples.md
@@ -1,0 +1,43 @@
+# Process Engineering Examples
+
+## Heat exchanger sizing
+
+See the [Heat Exchanger Engineering Guide](../engineering/heat-exchangers.md) for a full water-cooler example using `HeatExchangerEngine`.
+
+## Heat exchanger rating
+
+Provide fixed geometry such as tube size, tube count, passes, length, and shell diameter to rate an existing shell-and-tube exchanger. Use `result.detailed_summary()` to inspect calculated U, velocities, and pressure drops.
+
+## Fluid property calculation
+
+```python
+from processpi.components.water import Water
+from processpi.units import Temperature
+
+water = Water(temperature=Temperature(40, "C"))
+print(water.density())
+print(water.specific_heat())
+```
+
+## Pressure-drop calculation
+
+```python
+from processpi.calculations.fluids.pressure_drop_darcy import PressureDropDarcy
+
+dp = PressureDropDarcy(
+    friction_factor=0.02,
+    length=100,
+    diameter=0.1,
+    density=1000,
+    velocity=2,
+).calculate()
+print(dp)
+```
+
+## Equipment calculation pattern
+
+1. Define unit-wrapped inputs.
+2. Build streams or equipment objects.
+3. Call `.fit()` for engine-style APIs when available.
+4. Call `.run()` or `.calculate()`.
+5. Inspect warnings and result dictionaries before using values in design decisions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,19 +29,27 @@ extra_css:
   - css/custom.css
 
 nav:
-  #- Home: index.md
+  - Home: index.md
   - Install:
       - Installation: installation.md
+      - CLI: user-guide/cli.md
   - User Guide:
       - Introduction: user-guide/introduction.md
       - Features: user-guide/features.md
-
+      - Engineering:
+          - Heat Exchangers: user-guide/engineering/heat-exchangers.md
+          - Components, Properties, and Streams: user-guide/engineering/properties-streams.md
+      - Tutorials:
+          - Getting Started: user-guide/tutorials/getting-started.md
+          - Process Engineering Examples: user-guide/tutorials/process-engineering-examples.md
+          - Advanced Workflows: user-guide/tutorials/advanced-workflows.md
       - Units: 
           - Overview: user-guide/units/overview.md
+          - Unit System: user-guide/units/units.md
+          - Variable Base Class: user-guide/units/variable.md
           - Length: user-guide/units/length.md
           - Pressure: user-guide/units/pressure.md
           - Temperature: user-guide/units/temperature.md
-          #- Time: user-guide/units/time.md
           - Mass: user-guide/units/mass.md
           - Volume: user-guide/units/volume.md
           - Flow Rate:
@@ -62,7 +70,6 @@ nav:
           - Thermal Conductivity: user-guide/units/thermal_conductivity.md
           - Thermal Resistance: user-guide/units/thermal_resistance.md
           - Velocity: user-guide/units/velocity.md
-          
       - Components:
           - Overview: user-guide/components/components.md
           - Acetic Acid: user-guide/components/acetic_acid.md
@@ -81,6 +88,7 @@ nav:
           - Carbon Tetrachloride: user-guide/components/carbon_tetrachloride.md
           - Cyclohexene: user-guide/components/cyclohexene.md
           - Chloro Methane: user-guide/components/chloromethane.md
+          - Chlorobenzene: user-guide/components/chlorobenzene.md
           - Cynogen: user-guide/components/cynogen.md
           - Ethane: user-guide/components/ethane.md
           - Ethanol: user-guide/components/ethanol.md
@@ -96,6 +104,7 @@ nav:
           - Water: user-guide/components/water.md
       - Calculations:
           - Overview: user-guide/calculations/calculations.md
+          - Coming Soon: user-guide/calculations/comming_soon.md
           - Calculation Engine: user-guide/calculations/calculation_engine.md
           - Fluid Mechanics:
               - Reynolds Number: user-guide/calculations/fluid_mechanics/reynolds_number.md
@@ -105,17 +114,28 @@ nav:
                   - Fanning Equation: user-guide/calculations/fluid_mechanics/pressure_drop/fanning.md
               - Flow Regime: user-guide/calculations/fluid_mechanics/flow_regime.md
               - Velocity: user-guide/calculations/fluid_mechanics/velocity.md
-          - Comming Soon: user-guide/calculations/comming_soon.md
-          
       - Pipe Lines:
           - Overview: user-guide/pipe_lines/engine.md
           - Pipes: user-guide/pipe_lines/pipes.md
           - Fittings: user-guide/pipe_lines/fittings.md
           - Pipe Line Networks: user-guide/pipe_lines/network.md
-
-              
+  - API Reference:
+      - Overview: api/index.md
+      - Package Init: api/__init__.md
+      - Constants: api/constants.md
+      - Calculations: api/calculations.md
+      - Components: api/components.md
+      - Equipment: api/equipment.md
+      - Integration: api/integration.md
+      - Pipelines: api/pipelines.md
+      - Streams: api/streams.md
+      - Units: api/units.md
+      - CLI: api/cli.md
+      - Legacy API Reference: api_reference.md
   - Examples:
       - Overview: examples/index.md
+      - Integration:
+          - Flowsheet Heat Exchanger Named Ports: examples/integration/flowsheet_heat_exchanger_named_ports.md
       - Pipelines:
           - Chlorine Gas Optimum Diameter: examples/pipelines/chlorine_optimum_diameter.md
           - Carbon Dioxide Gas Pipeline: examples/pipelines/co2_transfer_line.md
@@ -133,14 +153,17 @@ nav:
           - Darcy Pressure Drop (US Units): examples/calculations/pressure_drop_dracy.md
           - Long Pipeline Pressure Drop (Metric Units): examples/calculations/long_pipe_friction_factor.md
           - Hazen-Williams Pressure Drop (US Units): examples/calculations/pressure_drop_hw_us.md
-      
+  - Audit:
+      - Source Inventory: audit/source-inventory.md
+      - Documentation Audit Report: audit/documentation-audit-report.md
+      - Repository Technical Architecture Review: reviews/2026-04-09-repository-technical-architecture-review.md
   - Community:
       - Roadmap: about/roadmap.md
       - Contributing: about/contributing.md
       - License: about/license.md
       - Changelog: about/changelog.md
       - Knowledge Transfer: about/knowledge_transfer.md
-  
+
 
 extra:
   social:

--- a/processpi/__init__.py
+++ b/processpi/__init__.py
@@ -20,7 +20,7 @@ from importlib.metadata import version, PackageNotFoundError
 try:
     __version__ = version("processpi")
 except PackageNotFoundError:
-    __version__ = "0.1.0"
+    __version__ = "0.2.0.4"
 
 # -------------------------------------------------------------------
 # Submodules (explicit imports for static analyzers)

--- a/processpi/cli.py
+++ b/processpi/cli.py
@@ -1,0 +1,49 @@
+"""Command line interface for ProcessPI."""
+
+from __future__ import annotations
+
+import argparse
+from importlib.metadata import PackageNotFoundError, version
+
+
+def _package_version() -> str:
+    try:
+        return version("processpi")
+    except PackageNotFoundError:
+        from processpi import __version__
+
+        return __version__
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="processpi",
+        description="ProcessPI command line entry point for package diagnostics.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"processpi {_package_version()}",
+        help="Show the installed ProcessPI version and exit.",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.add_parser(
+        "doctor",
+        help="Check that the package imports and report the installed version.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "doctor":
+        print(f"ProcessPI {_package_version()} is importable.")
+        return 0
+    print("ProcessPI command line interface")
+    print("Use 'processpi doctor' for an import check or 'processpi --help' for options.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0"
+__version__ = "0.2.0.4"
 
 from setuptools import setup, find_packages
 from pathlib import Path


### PR DESCRIPTION
### Motivation

- Align the MkDocs site with the actual implementation by generating a source-driven API inventory and surfacing implemented packages and modules.
- Provide engineers with accurate heat-exchanger engineering guidance, examples, and limitations tied to the implemented exchanger models and heat-transfer primitives.
- Surface a small, importable CLI matching the packaged console entry point and ensure documentation navigation exposes API, tutorials, and audit artefacts.
- Record remaining documentation gaps and recommend next steps (mkdocstrings adoption, docstring enrichment, tested examples). 

### Description

- Added a generated API reference under `docs/api/` and a full source inventory and audit under `docs/audit/` produced from every `processpi/*.py` module. 
- Created engineering docs and tutorials: `docs/user-guide/engineering/heat-exchangers.md`, `properties-streams.md`, and tutorial pages under `docs/user-guide/tutorials/`; updated examples and fixed local markdown links.
- Updated MkDocs navigation in `mkdocs.yml` to expose the new API, audit, engineering guides, and tutorials; updated `docs/index.md`, changelog and roadmap to reflect documentation modernization priorities.
- Implemented a lightweight CLI module `processpi/cli.py` (matching the package entry point) and bumped package fallback versions to `0.2.0.4` in `processpi/__init__.py` and `setup.py`.

### Testing

- Ran `python -m processpi.cli --help` and `python -m processpi.cli doctor`, both succeeded and reported the package importable (`ProcessPI 0.2.0.4 is importable`).
- Ran `python -m compileall -q processpi` (byte-compile) and a local Markdown-link resolver and nav-path checker; all local Markdown links and listed nav paths resolve successfully.
- Attempted to install `mkdocs`/`mkdocs-material` but package installation was blocked by a network 403, so `mkdocs build --strict` could not be executed in this environment.
- Ran `pytest`; collection failed due to pre-existing compatibility issues in the test suite (missing/renamed exports such as `ShellAndTube` vs `ShellAndTubeHX` and a missing `processpi.units.kinetic_viscosity` import), which are outside the documentation changes and documented as remaining gaps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23c603ccdc8326b4963aca63422b79)